### PR TITLE
docs: polish launch screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Drive every coding agent on your machine — Pi, Claude Code, Codex, Cursor, and
 > fixture may run cleartext; normal relays do not.
 
 <p align="center">
-  <img src="docs/screenshots/voice.png" alt="muxr Realtime voice conversation" width="31%" />
-  <img src="docs/screenshots/live-update.png" alt="muxr Android Live Update controls" width="31%" />
-  <img src="docs/screenshots/voice-settings.png" alt="muxr plugin-owned realtime provider settings" width="31%" />
+  <img src="docs/play/store-assets/01-herd.png" alt="muxr Herd overview on Android" width="31%" />
+  <img src="docs/play/store-assets/02-terminal.png" alt="muxr real terminal controls on Android" width="31%" />
+  <img src="docs/play/store-assets/03-plugins.png" alt="muxr public plugin catalog on Android" width="31%" />
 </p>
 
 ## What it does

--- a/docs/FLIP-CHECKLIST.md
+++ b/docs/FLIP-CHECKLIST.md
@@ -45,12 +45,12 @@ The repository and fresh public history are now live. npm publication and publis
 ## Publish
 
 - [x] Repo public; description, homepage, and topics set
-- [ ] Publish the prepared `v0.1.0` GitHub Release (signed APK, AAB, CLI tarball, source archive, demo, and `SHA256SUMS` are attached to the draft)
+- [x] Published `v0.1.0` with the signed APK, AAB, `@trymuxr/cli` tarball, frozen source archive, demo, and verified `SHA256SUMS`
 - [x] Published and anonymously verified `@trymuxr/cli@0.1.0` on npm (`muxr version`, help, and setup help all passed)
 - [x] Support policy posted in `README.md`: issues accepted, best-effort, no SLA
 
 ## After
 
 - [ ] Watch first-week issues; free-tier support load starts now
-- [ ] Complete [the clean-room new-user smoke](NEW-USER-SMOKE.md) from the public tag and release artifacts
+- [x] Completed [the clean-room new-user smoke](NEW-USER-SMOKE.md) from public tag `v0.1.0` (fresh clone/build and 27/27 suite passed)
 - [ ] Announce only after that full self-host flow passes


### PR DESCRIPTION
Replaces stale voice/account captures in the README with the polished Herd, terminal, and plugin-platform launch assets. Also records the completed public release and clean-room v0.1.0 verification.