### PR TITLE
security: harden relay URL handling

### DIFF
--- a/packages/contract/src/controlPlaneUrl.spec.ts
+++ b/packages/contract/src/controlPlaneUrl.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { previewSocketUrl } from './preview.js';
 import { terminalSocketUrl } from './terminal.js';
+import { realtimeSocketUrl } from './realtimeStream.js';
 import { relayControlUrl } from './controlPlaneUrl.js';
 import { issueWsTicket, ticketSocketUrl } from './wsTickets.js';
 
@@ -64,5 +65,11 @@ describe('relay-derived control-plane flow', () => {
             .toBe('ws://10.0.2.2:18787/relay/terminal?role=client&machineId=machine&channel=terminal');
         expect(previewSocketUrl(websocketRelay, { machineId: 'machine', channel: 'preview', role: 'client' }))
             .toBe('ws://10.0.2.2:18787/relay/preview?role=client&machineId=machine&channel=preview');
+        expect(realtimeSocketUrl(websocketRelay, { machineId: 'machine', channel: 'voice', role: 'client' }))
+            .toBe('ws://10.0.2.2:18787/relay/stream?role=client&machineId=machine&channel=voice');
+
+        const slashHeavyRelay = `${websocketRelay}${'/'.repeat(100_000)}`;
+        expect(ticketSocketUrl(slashHeavyRelay, 'ticket', 'relay'))
+            .toBe(`${websocketRelay}?ticket=ticket`);
     });
 });

--- a/packages/contract/src/controlPlaneUrl.ts
+++ b/packages/contract/src/controlPlaneUrl.ts
@@ -1,3 +1,9 @@
+export function stripTrailingSlashes(value: string): string {
+    let end = value.length;
+    while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
+    return value.slice(0, end);
+}
+
 export function relayControlUrl(relayUrl: string, path = ''): string {
     const relay = new URL(relayUrl);
     if (relay.protocol !== 'ws:' && relay.protocol !== 'wss:') {

--- a/packages/contract/src/preview.ts
+++ b/packages/contract/src/preview.ts
@@ -1,3 +1,5 @@
+import { stripTrailingSlashes } from './controlPlaneUrl.js';
+
 /**
  * Browser preview: the wire format for tunnelling a dev server to the device.
  *
@@ -65,7 +67,7 @@ export function previewSocketUrl(
 ): string {
     // Hand-built rather than URLSearchParams: this runs on React Native too,
     // where that polyfill is partial.
-    const base = relayUrl.replace(/\/+$/, '');
+    const base = stripTrailingSlashes(relayUrl);
     const parts = [
         `role=${options.role}`,
         `machineId=${encodeURIComponent(options.machineId)}`,

--- a/packages/contract/src/realtimeStream.ts
+++ b/packages/contract/src/realtimeStream.ts
@@ -1,3 +1,5 @@
+import { stripTrailingSlashes } from './controlPlaneUrl.js';
+
 /**
  * Provider-neutral realtime voice channel.
  *
@@ -131,7 +133,7 @@ export function realtimeSocketUrl(
     relayUrl: string,
     options: { machineId: string; channel: string; role: 'machine' | 'client'; token?: string },
 ): string {
-    const base = relayUrl.replace(/\/+$/, '');
+    const base = stripTrailingSlashes(relayUrl);
     const parts = [
         `role=${options.role}`,
         `machineId=${encodeURIComponent(options.machineId)}`,

--- a/packages/contract/src/terminal.ts
+++ b/packages/contract/src/terminal.ts
@@ -1,3 +1,5 @@
+import { stripTrailingSlashes } from './controlPlaneUrl.js';
+
 /**
  * Live terminal channel: the wire format for driving a herdr pane from a client.
  *
@@ -73,7 +75,7 @@ export function terminalSocketUrl(
 ): string {
     // Hand-built rather than URLSearchParams: this runs on React Native too,
     // where that polyfill is partial.
-    const base = relayUrl.replace(/\/+$/, '');
+    const base = stripTrailingSlashes(relayUrl);
     const parts = [
         `role=${options.role}`,
         `machineId=${encodeURIComponent(options.machineId)}`,

--- a/packages/contract/src/wsTickets.ts
+++ b/packages/contract/src/wsTickets.ts
@@ -1,4 +1,4 @@
-import { relayControlUrl } from './controlPlaneUrl.js';
+import { relayControlUrl, stripTrailingSlashes } from './controlPlaneUrl.js';
 
 export type WsTransport = 'relay' | 'terminal' | 'preview' | 'stream';
 
@@ -43,5 +43,5 @@ export async function issueWsTicket(input: {
 
 export function ticketSocketUrl(relayUrl: string, ticket: string, transport: WsTransport): string {
     const path = transport === 'relay' ? '' : `/${transport}`;
-    return `${relayUrl.replace(/\/+$/, '')}${path}?ticket=${encodeURIComponent(ticket)}`;
+    return `${stripTrailingSlashes(relayUrl)}${path}?ticket=${encodeURIComponent(ticket)}`;
 }

--- a/scripts/checkPreviewTunnel.mjs
+++ b/scripts/checkPreviewTunnel.mjs
@@ -78,8 +78,8 @@ const done = (code, msg) => {
 // Stands in for `vite`/`next dev`. Bound to loopback on purpose: reaching it at
 // all is the thing a LAN address or a public tunnel could not do.
 const devServer = createServer((req, res) => {
-    res.writeHead(200, { 'content-type': 'text/html' });
-    res.end(`<html><body>${MARKER}${req.url}</body></html>`);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ marker: MARKER, path: req.url }));
 });
 await new Promise((resolve) => devServer.listen(0, '127.0.0.1', resolve));
 const devPort = devServer.address().port;


### PR DESCRIPTION
Replaces four library-input trailing-slash regexes with a linear scan, adds a 100k-slash flow regression, and JSON-encodes the local preview fixture response. Local build, focused flow, preview E2E, and full 27/27 suite pass. CodeQL SSRF findings are confined to a loopback-only E2E fixture and will be documented/dismissed separately.