### PR TITLE
fix: close final v0.1.2 audit residuals

### DIFF
--- a/apps/host/src/herdr/attachmentWatcher.test.ts
+++ b/apps/host/src/herdr/attachmentWatcher.test.ts
@@ -82,9 +82,14 @@ describe('scanPane', () => {
         await expect(watcher.fetch('p1', oversize.id)).resolves.toBeNull();
     });
 
-    it('returns [] for a missing pane dir without throwing', async () => {
+    it('returns [] for missing or out-of-root pane dirs without throwing', async () => {
         const root = paneRoot();
+        const outside = `${root}-outside`;
+        mkdirSync(outside, { recursive: true });
+        roots.push(outside);
+        writeFileSync(join(outside, 'private.txt'), 'nope');
         expect(await scanPane(root, 'nope')).toEqual([]);
+        expect(await scanPane(root, `../${outside.split('/').pop()}`)).toEqual([]);
     });
 });
 

--- a/apps/host/src/herdr/attachmentWatcher.ts
+++ b/apps/host/src/herdr/attachmentWatcher.ts
@@ -7,7 +7,7 @@
 import { createHash } from 'node:crypto';
 import { createReadStream, mkdirSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import { open as openAsync, readdir, readFile, stat } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import type { SessionAttachment } from '@muxr/contract';
 
 export const MAX_ATTACHMENTS = 50;
@@ -125,7 +125,9 @@ export interface AttachmentScan {
 }
 
 export async function scanPaneWithAttribution(rootDir: string, paneId: string, cache?: Map<string, CachedAttachment>): Promise<AttachmentScan> {
-    const dir = join(rootDir, paneId);
+    const root = resolve(rootDir);
+    const dir = resolve(root, paneId);
+    if (!dir.startsWith(`${root}${sep}`)) return { attachments: [], total: 0, truncated: false };
     let entries: import('node:fs').Dirent[];
     try {
         entries = await readdir(dir, { withFileTypes: true });

--- a/apps/mobile/android/app/src/main/res/xml/secure_store_backup_rules.xml
+++ b/apps/mobile/android/app/src/main/res/xml/secure_store_backup_rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
   <include domain="sharedpref" path="."/>
-  <exclude domain="sharedpref" path="SecureStore"/>
+  <exclude domain="sharedpref" path="SecureStore.xml"/>
 </full-backup-content>

--- a/apps/mobile/android/app/src/main/res/xml/secure_store_data_extraction_rules.xml
+++ b/apps/mobile/android/app/src/main/res/xml/secure_store_data_extraction_rules.xml
@@ -2,10 +2,10 @@
 <data-extraction-rules>
   <cloud-backup>
     <include domain="sharedpref" path="."/>
-    <exclude domain="sharedpref" path="SecureStore"/>
+    <exclude domain="sharedpref" path="SecureStore.xml"/>
   </cloud-backup>
   <device-transfer>
     <include domain="sharedpref" path="."/>
-    <exclude domain="sharedpref" path="SecureStore"/>
+    <exclude domain="sharedpref" path="SecureStore.xml"/>
   </device-transfer>
 </data-extraction-rules>

--- a/docs/NATIVE-BUILD.md
+++ b/docs/NATIVE-BUILD.md
@@ -12,10 +12,11 @@ APK or `expo run:android` after a prebuild.
 Kotlin. An iOS build will lack the voice overlay microphone foreground service
 and in-app SSH forwarding.
 
-`apps/mobile/android/` is a committed prebuild pinned to
-`app.muxr.local.preview`. Changing `MUXR_APP_ID_BASE` requires
-`npx expo prebuild --platform android --clean` from `apps/mobile` or the
-committed directory silently wins.
+`apps/mobile/android/` is the committed production prebuild for
+`com.trymuxr.app`. Do not change that permanent store identity. Regenerate the
+prebuild only with `APP_ENV=production`, `MUXR_APP_ID_BASE=com.trymuxr.app`, and
+`MUXR_PUBLIC_BASE_URL=https://trymuxr.com`; otherwise local app-config defaults
+can silently replace the committed identity.
 
 The first `eas build --local` creates a keystore through your Expo account
 (`eas credentials` in `apps/mobile`). `credentials.json` is gitignored; do not
@@ -91,18 +92,11 @@ has no default and must be the HTTPS origin that will host activation plus iOS
 Universal Link and Android App Link association files.
 
 Set `MUXR_EAS_PROJECT_ID` only after creating or transferring the owner’s muxr
-project. The former product’s EAS project id is deliberately not inherited.
-Without that env var, `eas build --local` refuses to start. The committed
-prebuild can still produce a preview APK signed with `android/app/debug.keystore`:
-
-```bash
-export EXPO_PUBLIC_MUXR_MODE=hosted
-export EXPO_PUBLIC_MUXR_RELAY_URL='ws://<relay-host>:<port>'
-cd apps/mobile/android
-./gradlew assembleRelease
-```
-Changing the production app identifier creates a separate store identity unless
-the owner arranges a transfer/update under the final identifier.
+project. Without that env var, `eas build --local` refuses to start. Signed
+release APKs and AABs must use the local EAS profiles below; do not distribute a
+direct Gradle build, which has no owner release credential. Changing the
+production app identifier creates a separate store identity unless the owner
+arranges a transfer/update under the final identifier.
 
 ## Fast bundle check
 

--- a/docs/PLAY-STORE-PLAN.md
+++ b/docs/PLAY-STORE-PLAN.md
@@ -31,7 +31,7 @@ APP_ENV=production \
 MUXR_DISTRIBUTION=store \
 MUXR_PUBLIC_BASE_URL=https://trymuxr.com \
 eas build --platform android --profile production --local --non-interactive \
-  --output ./muxr-0.1.1.aab
+  --output ./muxr-0.1.2.aab
 ```
 
 Before submission:


### PR DESCRIPTION
## Summary
- block attachment pane paths from escaping the watched root
- make Android SecureStore backup exclusions match the actual shared-preference filename
- correct contributor-facing native build and v0.1.2 Play artifact guidance

## Verification
- `node scripts/runSuite.mjs` — 27/27 passed
- focused attachment watcher flow — 11/11 passed
- mobile build policy passed
- `git diff --check` passed
- independent security audit: PASS, no blockers/highs
- independent launch-consistency audit: PASS after these contributor-doc corrections