### PR TITLE
Guided CLI setup, safe updates, and browser pairing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist-npm/
 
 # git worktrees for parallel sessions
 .dev/
+.firecrawl/

--- a/README.md
+++ b/README.md
@@ -60,15 +60,18 @@ Requires Linux, macOS, or WSL and Node.js 22 or newer.
 
 ```bash
 npm install -g @trymuxr/cli
-muxr setup
+muxr
 ```
 
-`muxr setup` installs or adopts Herdr with consent, syncs detected coding-agent
-integrations, starts the complete self-hosted relay and host, then displays a
-short-lived pairing QR. Voice and Run Server are optional bundled plugins using
-the same public API as every third-party plugin.
+The interactive `muxr` onboarding changes nothing until you review and apply
+its plan. You choose networking, Herdr and agent integrations, optional plugins,
+managed services, and phone/browser pairing. It then verifies the supervised
+relay and host and reports their URLs and health without printing secrets.
+Native setup displays a QR; browser setup displays a clickable HTTPS pairing
+link for an eight-hour read-only grant. Voice and Run Server are optional bundled plugins using the same public
+API as every third-party plugin.
 
-**Android:** [download the signed muxr v0.1.2 APK](https://github.com/umeranjum17/muxr/releases/download/v0.1.2/muxr-0.1.2.apk) ([SHA256SUMS](https://github.com/umeranjum17/muxr/releases/download/v0.1.2/SHA256SUMS)). A Google Play release is coming soon. **iOS is coming soon.** Prefer a browser today? `muxr self-host --web` serves the read-only web client from your machine.
+**Android:** [download the signed muxr v0.1.2 APK](https://github.com/umeranjum17/muxr/releases/download/v0.1.2/muxr-0.1.2.apk) ([SHA256SUMS](https://github.com/umeranjum17/muxr/releases/download/v0.1.2/SHA256SUMS)). A Google Play release is coming soon. **iOS is coming soon.** Prefer a browser today? Choose the read-only web client during interactive `muxr` setup.
 
 ### Let your coding agent set it up
 
@@ -76,15 +79,22 @@ Paste this prompt into Pi, Claude Code, Codex, or another local coding agent:
 
 > Set up muxr on this machine from the public release at
 > <https://github.com/umeranjum17/muxr>. Use Node.js 22+ and install the CLI with
-> `npm install -g @trymuxr/cli`, then run `muxr setup`. If Herdr is missing, ask
-> me before installing it. Run `muxr doctor` and fix any local setup problem it
-> reports. Do not use cloud EAS builds, paid APIs, or hosted services. Leave the
-> short-lived pairing QR in the terminal for me; never repeat its payload in
-> chat or logs. Finally, point me to the signed Android APK and `SHA256SUMS` on
-> the latest GitHub release.
+> `npm install -g @trymuxr/cli`, then launch `muxr` in an interactive terminal
+> for me. Do not choose connection, Herdr, integration, plugin, or service
+> options on my behalf; let me review and apply the onboarding plan. Run
+> `muxr doctor` afterward and fix any local setup problem it reports. Do not use
+> cloud EAS builds, paid APIs, or hosted services. Leave the short-lived pairing
+> QR in the terminal for me; never repeat its payload in chat or logs. Finally,
+> point me to the signed Android APK and `SHA256SUMS` on the latest GitHub
+> release.
 
-A successful setup ends with Herdr integrations current, the local relay and
-host running, and a one-use encrypted pairing QR ready for the phone.
+A successful setup ends with the selected integrations applied, the local relay
+and host running, and a one-use encrypted pairing QR ready for the phone.
+
+Run `muxr` with no arguments for the interactive setup and maintenance menu.
+Choose **Update muxr** there, or run `muxr update --yes` in automation; it updates
+the npm package, refreshes bundled plugins, and restarts the running relay and
+host.
 
 ## Development
 

--- a/apps/mobile/sources/app/(app)/index.tsx
+++ b/apps/mobile/sources/app/(app)/index.tsx
@@ -72,7 +72,9 @@ function NotAuthenticated() {
         try {
             const approved = await Modal.confirm(
                 `Pair with ${hostedPairingDisplayName(url)}?`,
-                'This phone will be able to read and type into every agent terminal on that computer, answer approvals, and start or stop agents as the user who launched muxr.\n\nOnly continue if you just ran `muxr setup` or `muxr pair` there.',
+                Platform.OS === 'web'
+                    ? 'This browser receives read-only access for eight hours. Machine keys stay end-to-end encrypted with WebCrypto in this browser.\n\nOnly continue if you just ran `muxr pair --browser` there.'
+                    : 'This phone will be able to read and type into every agent terminal on that computer, answer approvals, and start or stop agents as the user who launched muxr.\n\nOnly continue if you just ran `muxr setup` or `muxr pair` there.',
                 { confirmText: 'Pair' },
             );
             if (!approved) return;
@@ -138,8 +140,10 @@ function NotAuthenticated() {
     const promptForPairingString = async (title: string) => {
         const pasted = await Modal.prompt(
             title,
-            'Paste the pairing string shown by `muxr self-host` on that machine. It pairs this phone end-to-end encrypted.',
-            { placeholder: 'muxr://pair#…' },
+            Platform.OS === 'web'
+                ? 'Paste the string shown by `muxr pair --browser`. It grants this browser read-only access for eight hours.'
+                : 'Paste the pairing string shown by `muxr pair` on that machine. It pairs this phone end-to-end encrypted.',
+            { placeholder: 'muxr://pair?payload=…' },
         );
         if (!pasted?.trim()) return;
         await processPairLink(pasted.trim());
@@ -168,10 +172,14 @@ function NotAuthenticated() {
                                     <Text style={styles.foundMeta} numberOfLines={1}>On this network · not connected yet</Text>
                                 </View>
                             </View>
-                            <ActionButton title="Connect" icon="link-outline" action={() => pairWithDiscovered(relay)} />
+                            <ActionButton title="Pair" icon="link-outline" action={() => pairWithDiscovered(relay)} />
                         </View>
                     ))}
-                    <ActionButton title={MOBILE_ONBOARDING_CHOICES[0]} icon="qr-code-outline" action={scanHostedQr} />
+                    {Platform.OS === 'web' ? (
+                        <ActionButton title="Paste browser pairing string" icon="clipboard-outline" action={() => promptForPairingString('Pair this browser')} />
+                    ) : (
+                        <ActionButton title={MOBILE_ONBOARDING_CHOICES[0]} icon="qr-code-outline" action={scanHostedQr} />
+                    )}
                     {showOtherWays ? (
                         <View style={styles.otherWays}>
                             <ActionButton variant="secondary" title="Paste a pairing string" icon="clipboard-outline" action={() => promptForPairingString('Paste pairing string')} />

--- a/apps/mobile/sources/app/(app)/pair.tsx
+++ b/apps/mobile/sources/app/(app)/pair.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Linking from 'expo-linking';
-import { ActivityIndicator, Text, View } from 'react-native';
+import { ActivityIndicator, Platform, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StyleSheet } from 'react-native-unistyles';
@@ -10,16 +10,23 @@ import { claimHostedPairing, hostedPairingDisplayName } from '@/state/hostedE2ee
 import { getCachedConnectionSettings, saveConnectionSettings } from '@/state/connectionSettings';
 import { ActionButton } from '@/components/ActionButton';
 import { Typography } from '@/constants/Typography';
+import { Modal } from '@/modal';
 
 /**
  * What pairing actually authorises. The previous copy described only the
  * cryptography, which understated it: this is full interactive control of the
  * machine's agent sessions under the account that started muxr.
  */
-const PAIRING_GRANTS = [
+const PHONE_PAIRING_GRANTS = [
     'Read every agent terminal on that computer, including whatever is already on screen.',
     'Type into those terminals and answer approval prompts.',
     'Start, stop and restart agents — running as the user who launched muxr.',
+] as const;
+
+const BROWSER_PAIRING_GRANTS = [
+    'Read agent status and terminal output from this browser.',
+    'Keep the machine keys end-to-end encrypted in this browser.',
+    'Use this read-only grant for eight hours, then pair again.',
 ] as const;
 
 const PAIRING_STEPS = [
@@ -41,8 +48,11 @@ export default function PairScreen() {
     // Deep links arrive as route params (expo-router drops unknown query keys
     // from getInitialURL, so the raw URL is only a fallback).
     const routeParams = useLocalSearchParams();
-    const paired = React.useRef(auth.isAuthenticated);
-    React.useEffect(() => { paired.current = auth.isAuthenticated; }, [auth.isAuthenticated]);
+    const browser = Platform.OS === 'web';
+    const grants = browser ? BROWSER_PAIRING_GRANTS : PHONE_PAIRING_GRANTS;
+    const pairingSteps = browser
+        ? ['This browser claims the one-time code from the link.', ...PAIRING_STEPS.slice(1)]
+        : PAIRING_STEPS;
     const routePairUrl = React.useMemo(() => {
         const v = routeParams.v;
         if (typeof v !== 'string' || v === '') return undefined;
@@ -62,11 +72,11 @@ export default function PairScreen() {
     React.useEffect(() => {
         let cancelled = false;
         const receive = (url: string | null) => {
-            if (cancelled || !url || paired.current) return;
-            if (!url.includes('/pair?') && !url.includes('/pair#')) return;
+            if (cancelled || !url || (!url.includes('/pair?') && !url.includes('/pair#'))) return false;
             setState((current) => current?.url === url
                 ? current
                 : { phase: 'confirm', url, machineName: hostedPairingDisplayName(url) });
+            return true;
         };
         if (routePairUrl !== undefined) {
             receive(routePairUrl);
@@ -74,18 +84,18 @@ export default function PairScreen() {
         }
         void Linking.getInitialURL().then((url) => {
             if (cancelled) return;
-            if (!url) {
-                setState({ phase: 'error', message: 'Open a fresh pairing QR or App Link from `muxr pair` on the computer you want to connect.' });
-                return;
-            }
-            receive(url);
+            if (!receive(url)) {
+                setState({ phase: 'error', message: browser
+                    ? 'Paste a fresh browser pairing string from `muxr pair --browser`.'
+                    : 'Open a fresh pairing QR or link from `muxr pair` on the computer you want to connect.' });
+            };
         }).catch((cause) => {
             if (!cancelled) setState({ phase: 'error', message: cause instanceof Error ? cause.message : String(cause) });
         });
         // Warm start: the app was already open when the link arrived.
         const subscription = Linking.addEventListener('url', (event) => receive(event.url));
         return () => { cancelled = true; subscription.remove(); };
-    }, [routePairUrl]);
+    }, [routePairUrl, browser]);
 
     const pair = React.useCallback(async (url: string) => {
         const grant = await claimHostedPairing(url);
@@ -116,6 +126,21 @@ export default function PairScreen() {
         });
     }, [state, pair]);
 
+    const paste = React.useCallback(async () => {
+        const pasted = await Modal.prompt(
+            browser ? 'Paste browser pairing string' : 'Paste pairing string',
+            `Paste the one-use string shown by ${browser ? '`muxr pair --browser`' : '`muxr pair`'} on the computer.`,
+            { placeholder: 'muxr://pair?payload=…' },
+        );
+        if (!pasted?.trim()) return;
+        const url = pasted.trim();
+        if (!url.includes('/pair?') && !url.includes('/pair#')) {
+            setState({ phase: 'error', message: 'That is not a muxr pairing string.' });
+            return;
+        }
+        setState({ phase: 'confirm', url, machineName: hostedPairingDisplayName(url) });
+    }, [browser]);
+
     const cancel = React.useCallback(() => router.replace('/'), [router]);
 
     return (
@@ -130,7 +155,7 @@ export default function PairScreen() {
                         : state.machineName ?? 'Securely pair this device'}
                 </Text>
                 {state?.phase === 'confirm' && (
-                    <Text style={styles.subtitle}>wants to pair with this phone</Text>
+                    <Text style={styles.subtitle}>wants to pair with this {browser ? 'browser' : 'phone'}</Text>
                 )}
             </View>
 
@@ -141,7 +166,7 @@ export default function PairScreen() {
                             <ActivityIndicator color={styles.progressText.color} />
                             <Text style={styles.progressText}>Pairing…</Text>
                         </View>
-                        {PAIRING_STEPS.map((step, index) => (
+                        {pairingSteps.map((step, index) => (
                             <View key={step} style={styles.stepRow}>
                                 <Text style={styles.stepIndex}>{index + 1}</Text>
                                 <Text style={styles.stepText}>{step}</Text>
@@ -151,8 +176,8 @@ export default function PairScreen() {
                 ) : state.phase === 'confirm' ? (
                     <>
                         <View style={styles.stepGroup}>
-                            <Text style={styles.stepHeading}>This phone will be able to</Text>
-                            {PAIRING_GRANTS.map((grant) => (
+                            <Text style={styles.stepHeading}>{browser ? 'This browser will be able to' : 'This phone will be able to'}</Text>
+                            {grants.map((grant) => (
                                 <View key={grant} style={styles.stepRow}>
                                     <Ionicons name="ellipse" size={6} color={styles.grantDot.color} style={styles.grantBullet} />
                                     <Text style={styles.grantText}>{grant}</Text>
@@ -167,7 +192,7 @@ export default function PairScreen() {
                         </View>
                         <View style={styles.stepGroup}>
                             <Text style={styles.stepHeading}>How it is secured</Text>
-                            {PAIRING_STEPS.map((step, index) => (
+                            {pairingSteps.map((step, index) => (
                                 <View key={step} style={styles.stepRow}>
                                     <Text style={styles.stepIndex}>{index + 1}</Text>
                                     <Text style={styles.stepText}>{step}</Text>
@@ -183,6 +208,7 @@ export default function PairScreen() {
                         {state.url !== undefined && (
                             <ActionButton title="Try again" icon="refresh-outline" onPress={confirm} />
                         )}
+                        <ActionButton title="Paste pairing string" icon="clipboard-outline" onPress={() => void paste()} />
                         <ActionButton title="Back" variant="secondary" onPress={cancel} />
                     </>
                 )}

--- a/apps/mobile/sources/app/(app)/settings/connection.tsx
+++ b/apps/mobile/sources/app/(app)/settings/connection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, TextInput, View } from 'react-native';
+import { Platform, Text, TextInput, View } from 'react-native';
 import { Item } from '@/components/Item';
 import { ItemGroup } from '@/components/ItemGroup';
 import { ItemList } from '@/components/ItemList';
@@ -15,6 +15,8 @@ import {
 } from '@/state/connectionSettings';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
+import { useRouter } from 'expo-router';
+import { getCachedHostedGrant } from '@/state/hostedE2ee';
 
 const stylesheet = StyleSheet.create((theme) => ({
     label: {
@@ -58,11 +60,6 @@ const stylesheet = StyleSheet.create((theme) => ({
     dotBad: { backgroundColor: theme.colors.textDestructive },
 }));
 
-/** Host and port only: the relay URL can carry a path, and the full string is noise here. */
-function relayHost(url: string): string {
-    return /^wss?:\/\/([^/]+)/i.exec(url.trim())?.[1] ?? url.trim();
-}
-
 function Field(props: {
     label: string;
     value: string;
@@ -92,8 +89,9 @@ function Field(props: {
 
 export default function ConnectionSettingsScreen() {
     const styles = stylesheet;
+    const router = useRouter();
     const [initial, setInitial] = React.useState(() => getCachedConnectionSettings());
-    const { status } = useSocketStatus();
+    const { status, error: socketError } = useSocketStatus();
     const [showAdvanced, setShowAdvanced] = React.useState(false);
     const statusText = {
         connected: t('status.connected'),
@@ -130,21 +128,29 @@ export default function ConnectionSettingsScreen() {
 
     if (initial.mode === 'hosted') {
         const overSsh = getActiveSshForward() !== undefined;
-        const transport = overSsh ? 'Over your SSH tunnel' : 'Your own relay';
+        const transport = overSsh
+            ? 'SSH tunnel'
+            : initial.relayUrl.startsWith('wss://')
+                ? 'HTTPS/WSS transport + end-to-end encryption'
+                : 'Trusted-network WS transport + end-to-end encryption';
         const where = overSsh
             ? 'Forwarded through the SSH connection you opened in Advanced setup'
-            : relayHost(initial.relayUrl);
+            : initial.relayUrl;
+        const browserExpiresAt = Platform.OS === 'web' ? getCachedHostedGrant(initial.machineId)?.expiresAt : undefined;
         return (
             <ItemList>
                 <ItemGroup title="Status">
                     <Item
                         title={statusText}
-                        subtitle={status === 'connected' ? 'Your machine is reachable from this phone' : 'The app reconnects on its own when the machine is back'}
+                        subtitle={status === 'connected' ? 'Your machine is reachable from this device' : socketError ?? 'The app reconnects on its own when the machine is back'}
                         leftElement={<View style={[styles.dot, statusDot]} />}
                         loading={status === 'connecting'}
                     />
                     <Item title="Transport" subtitle={transport} detail={overSsh ? 'SSH' : 'Self-host'} />
                     <Item title="Relay" subtitle={where} subtitleLines={0} />
+                    {Platform.OS === 'web' && <Item title="Browser access" subtitle={browserExpiresAt === undefined
+                        ? 'Read-only · pair again every eight hours'
+                        : `Read-only · expires ${new Date(browserExpiresAt).toLocaleString()}`} />}
                 </ItemGroup>
 
                 <ItemGroup
@@ -167,8 +173,9 @@ export default function ConnectionSettingsScreen() {
                     {showAdvanced ? (
                         <>
                             <Item title="Reconnect now" subtitle="Drops the socket and dials again" onPress={() => void syncReconnect()} />
+                            <Item title="Pair another machine" subtitle="Paste a fresh string from `muxr pair`, or open its pairing link" onPress={() => router.push('/pair')} />
                             <Text style={styles.hint}>
-                                To connect a different machine, scan a fresh QR from `muxr pair` on that computer. To stop this phone reaching a machine, revoke it with the muxr CLI.
+                                To stop this device reaching a machine, revoke it from the interactive muxr menu.
                             </Text>
                         </>
                     ) : (

--- a/apps/mobile/sources/auth/accountSession.integration.spec.ts
+++ b/apps/mobile/sources/auth/accountSession.integration.spec.ts
@@ -14,6 +14,7 @@ const harness = vi.hoisted(() => ({
     clientOptions: [] as Array<{ onTicketRejected?: () => void }>,
     clientConnects: 0,
     socketStatus: 'disconnected',
+    socketError: null as string | null,
     ready: false,
 }));
 
@@ -74,6 +75,7 @@ vi.mock('../sync/storage', () => ({
             sessions: {},
             sessionsLoaded: false,
             setSocketStatus: (status: string) => { harness.socketStatus = status; },
+            setSocketError: (message: string | null) => { harness.socketError = message; },
             applyMachines: vi.fn(),
             applySessions: vi.fn(),
             applyHerdrTree: vi.fn(),

--- a/apps/mobile/sources/client/muxrClient.ts
+++ b/apps/mobile/sources/client/muxrClient.ts
@@ -43,6 +43,8 @@ export interface MuxrClientOptions {
     hostedGrant?: StoredHostedGrant;
     /** A ticket refusal triggers separate account-session validation; it is not itself a logout signal. */
     onTicketRejected?: () => void;
+    /** Permanent self-host credential failures must stop retrying and offer pairing again. */
+    onPermanentError?: (message: string) => void;
 }
 
 interface Pending {
@@ -128,9 +130,16 @@ export class MuxrClient {
                     transport: 'relay',
                 }), 'relay');
         } catch (error) {
-            this.setState('closed');
-            if (error instanceof WsTicketError && (error.status === 401 || error.status === 403)) {
-                this.options.onTicketRejected?.();
+            const rejected = error instanceof WsTicketError && (error.status === 401 || error.status === 403);
+            const expired = error instanceof Error && /grant expired/i.test(error.message);
+            const permanent = expired || rejected && this.hosted?.grant.source === 'selfhost';
+            this.setState(permanent ? 'stale' : 'closed');
+            if (rejected) this.options.onTicketRejected?.();
+            if (permanent) {
+                this.options.onPermanentError?.(expired
+                    ? 'This browser grant expired. Pair again from `muxr pair --browser`.'
+                    : 'This device was revoked. Pair it again from the muxr menu.');
+                return;
             }
             if (!this.closed) {
                 const base = this.options.reconnectDelayMs ?? 1500;

--- a/apps/mobile/sources/components/HerdView.tsx
+++ b/apps/mobile/sources/components/HerdView.tsx
@@ -581,7 +581,7 @@ export const HerdView = React.memo(({
                     </View>
                     <View style={styles.emptyAction}>
                         {Platform.OS === 'web' ? (
-                            <ActionButton title="Pair this browser" icon="link-outline" onPress={() => router.push('/pair')} />
+                            <ActionButton title="Paste browser pairing string" icon="clipboard-outline" onPress={() => router.push('/pair')} />
                         ) : setup.setupUrl ? (
                             <ActionButton title="Open setup guide" variant="quiet" icon="open-outline" onPress={() => void openExternalUrl(setup.setupUrl!)} />
                         ) : null}

--- a/apps/mobile/sources/state/hostedE2ee.ts
+++ b/apps/mobile/sources/state/hostedE2ee.ts
@@ -187,13 +187,33 @@ export async function refreshHostedGrant(machineId: string, credential = ''): Pr
 }
 
 async function json(base: string, path: string, options: RequestInit = {}): Promise<Record<string, any>> {
-    const response = await fetch(`${base}${path}`, {
-        ...options,
-        headers: { 'content-type': 'application/json', ...options.headers },
-    });
-    const body = await response.json() as Record<string, any>;
-    if (!response.ok) throw new Error(String(body.error ?? `request failed (${response.status})`));
-    return body;
+    const controller = options.signal === undefined ? new AbortController() : undefined;
+    const timeout = controller === undefined ? undefined : setTimeout(() => controller.abort(), 10_000);
+    try {
+        const response = await fetch(`${base}${path}`, {
+            ...options,
+            signal: options.signal ?? controller?.signal,
+            headers: { 'content-type': 'application/json', ...options.headers },
+        });
+        const body = await response.json() as Record<string, any>;
+        if (!response.ok) {
+            const message = String(body.error ?? `request failed (${response.status})`);
+            const friendlyErrors: Record<string, string> = {
+                invalid_claim: 'This pairing string is invalid. Create a fresh one on the machine.',
+                already_claimed: 'This pairing string was already used. Create a fresh one on the machine.',
+                expired: 'This pairing string expired. Create a fresh one on the machine.',
+                wrong_device_kind: 'This pairing link is for a different client type. Generate a fresh link from the muxr menu.',
+            };
+            const friendly = friendlyErrors[message];
+            throw new Error(friendly ?? message);
+        }
+        return body;
+    } catch (cause) {
+        if (cause instanceof Error && cause.name === 'AbortError') throw new Error('The relay did not respond. Check the network, then run `muxr doctor` on the machine.');
+        throw cause;
+    } finally {
+        if (timeout !== undefined) clearTimeout(timeout);
+    }
 }
 
 export function hostedPairingDisplayName(url: string): string {

--- a/apps/mobile/sources/sync/storage.ts
+++ b/apps/mobile/sources/sync/storage.ts
@@ -178,6 +178,7 @@ interface StorageState {
     // that simply has not loaded yet.
     sessionsLoaded: boolean;
     socketStatus: 'disconnected' | 'connecting' | 'connected' | 'error';
+    socketError: string | null;
     socketLastConnectedAt: number | null;
     socketLastDisconnectedAt: number | null;
     nativeUpdateStatus: { available: boolean; updateUrl?: string } | null;
@@ -193,6 +194,7 @@ interface StorageState {
     setSessionMessages: (sessionId: string, messages: Message[], loaded?: boolean, hasMoreOlder?: boolean) => void;
     updateSession: (sessionId: string, patch: Partial<Session>) => void;
     setSocketStatus: (status: StorageState['socketStatus']) => void;
+    setSocketError: (message: string | null) => void;
     applyLocalSettings: (patch: Partial<LocalSettings>) => void;
     applySettingsLocal: (patch: Partial<Settings>) => void;
     updateSessionDraft: (sessionId: string, draft: string | null) => void;
@@ -257,6 +259,7 @@ export const storage = create<StorageState>()((set, get) => ({
     isDataReady: false,
     sessionsLoaded: false,
     socketStatus: 'disconnected',
+    socketError: null,
     socketLastConnectedAt: null,
     socketLastDisconnectedAt: null,
     nativeUpdateStatus: null,
@@ -348,6 +351,7 @@ export const storage = create<StorageState>()((set, get) => ({
         return { sessions, sessionListViewData: buildSessionListViewData(sessions) };
     }),
     setSocketStatus: (socketStatus) => set({ socketStatus }),
+    setSocketError: (socketError) => set({ socketError }),
     // Settings are device-local in muxr -- there is no settings sync request --
     // so writing the store was the whole change and every toggle reset on reload.
     applyLocalSettings: (patch) => set((state) => {
@@ -579,7 +583,7 @@ export function useSocketStatus() {
     // so useShallow never matched and the component re-rendered forever. The
     // timestamps were read by nobody, and a clock sampled during selection would
     // not record the transition anyway.
-    return storage(useShallow((state) => ({ status: state.socketStatus })));
+    return storage(useShallow((state) => ({ status: state.socketStatus, error: state.socketError })));
 }
 
 export function useSideChatSessions(_parentSessionId: string | null): Session[] {

--- a/apps/mobile/sources/sync/sync.ts
+++ b/apps/mobile/sources/sync/sync.ts
@@ -208,6 +208,7 @@ class MuxrSync {
             ...(hostedGrant === undefined ? {} : { hostedGrant }),
             ...(settings.mode === 'hosted' ? {
                 onTicketRejected: () => { void this.refreshAccountSession().catch(() => undefined); },
+                onPermanentError: (message: string) => storage.getState().setSocketError(message),
             } : {}),
         });
         client.onPluginsInvalidated?.((frame) => reconcilePluginCaches(frame));
@@ -217,6 +218,7 @@ class MuxrSync {
             // Re-open from the host snapshot instead of leaving a stale transcript
             // that only a manual app reload could fix.
             if (state === 'open') {
+                storage.getState().setSocketError(null);
                 // Machine frames are edge-triggered; reconnect/mount paths also
                 // reconcile caches so a lost wakeup cannot leave stale UI.
                 reconcilePluginCaches({ type: 'plugins.invalidated', reason: 'changed', pluginIds: [] });

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -375,10 +375,20 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                             : <ActivityIndicator size="small" color={theme.colors.textSecondary} />}
                     </Pressable>
                 )}
-                <Pressable onPress={stopSession} hitSlop={10} disabled={stopping} accessibilityRole="button" accessibilityLabel="Stop agent" accessibilityState={{ disabled: stopping }} style={{ padding: 4 }}>
-                    <Ionicons name="stop-circle-outline" size={19} color={theme.colors.textSecondary} />
-                </Pressable>
+                {Platform.OS !== 'web' && (
+                    <Pressable onPress={stopSession} hitSlop={10} disabled={stopping} accessibilityRole="button" accessibilityLabel="Stop agent" accessibilityState={{ disabled: stopping }} style={{ padding: 4 }}>
+                        <Ionicons name="stop-circle-outline" size={19} color={theme.colors.textSecondary} />
+                    </Pressable>
+                )}
             </View>
+
+            {Platform.OS === 'web' && (
+                <View style={{ paddingHorizontal: 12, paddingVertical: 7, backgroundColor: theme.colors.surfaceHigh, borderBottomWidth: 1, borderBottomColor: theme.colors.divider }}>
+                    <Text style={{ color: theme.colors.textSecondary, fontSize: 12, textAlign: 'center' }}>
+                        Read-only browser · terminal input and agent controls are disabled · access expires eight hours after pairing
+                    </Text>
+                </View>
+            )}
 
             <View
                 ref={paneGestures.ref}
@@ -483,6 +493,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                 )}
             </View>
 
+            {Platform.OS !== 'web' && <>
             <ScrollView
                 horizontal
                 showsHorizontalScrollIndicator={false}
@@ -567,6 +578,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     <Ionicons name="arrow-up-circle" size={30} color={theme.colors.text} />
                 </Pressable>
             </View>
+            </>}
 
             <PluginSlot
                 slot="session.overlay"

--- a/apps/relay/src/main.ts
+++ b/apps/relay/src/main.ts
@@ -1,6 +1,7 @@
 import { loadRelayConfig } from './config.js';
 import { startRelay } from './relay.js';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 
 const config = loadRelayConfig();
@@ -13,7 +14,9 @@ if (existsSync(lockFile)) {
     if (Number.isSafeInteger(pid) && pid > 0) {
         let aliveRelay = false;
         try {
-            aliveRelay = readFileSync(`/proc/${pid}/cmdline`, 'utf8').includes('apps/relay');
+            process.kill(pid, 0);
+            const command = spawnSync(process.env.MUXR_PS_BIN?.trim() || 'ps', ['-ww', '-p', String(pid), '-o', 'command='], { encoding: 'utf8' });
+            aliveRelay = command.status === 0 && /(?:\/relay\.js|apps\/relay\/.+\/main\.js)(?:\s|$)/.test(command.stdout);
         } catch {
             // dead pid: stale lock
         }

--- a/apps/relay/src/relay.ts
+++ b/apps/relay/src/relay.ts
@@ -425,11 +425,12 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                     const body = (await readJsonBody(req).catch(() => undefined)) as Record<string, unknown> | undefined;
                     const claim = typeof body?.claim === 'string' ? body.claim : '';
                     const machineSlug = typeof body?.machineSlug === 'string' ? body.machineSlug.trim() : '';
-                    if (claim.length < 43 || !/^[a-z0-9][a-z0-9-]{0,62}$/.test(machineSlug)) {
-                        writeJsonError(res, 400, 'claim and machineSlug are required');
+                    const deviceKind = body?.deviceKind === 'browser' ? 'browser' : body?.deviceKind === 'native' ? 'native' : undefined;
+                    if (claim.length < 43 || !/^[a-z0-9][a-z0-9-]{0,62}$/.test(machineSlug) || deviceKind === undefined) {
+                        writeJsonError(res, 400, 'claim, machineSlug and deviceKind are required');
                         return;
                     }
-                    const session = await localPairing.createSession({ claim, machineSlug });
+                    const session = await localPairing.createSession({ claim, machineSlug, deviceKind });
                     writeJson(res, 201, { pair_id: session.pairId, expires_in: session.expiresIn });
                     return;
                 }
@@ -443,19 +444,20 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                     const devicePublicKey = typeof body?.device_public_key === 'string' ? body.device_public_key : '';
                     const deviceName = typeof body?.device_name === 'string' ? body.device_name.slice(0, 120) : '';
                     const mailbox = typeof body?.mailbox === 'string' ? body.mailbox : '';
-                    const browserExpiresAt = body?.device_kind === 'browser' ? Date.now() + 8 * 60 * 60_000 : undefined;
+                    const deviceKind = body?.device_kind === 'browser' ? 'browser' : 'native';
+                    const browserExpiresAt = deviceKind === 'browser' ? Date.now() + 8 * 60 * 60_000 : undefined;
                     if (claim === '' || devicePublicKey === '' || deviceName === '' || mailbox === '' || mailbox.length > 16 * 1024) {
                         writeJsonError(res, 400, 'claim, device_public_key, device_name and mailbox are required');
                         return;
                     }
                     const result = await localPairing.claim(claimMatch[1], {
-                        claim, devicePublicKey, deviceName, mailbox,
+                        claim, devicePublicKey, deviceName, deviceKind, mailbox,
                         ...(browserExpiresAt === undefined ? {} : { expiresAt: browserExpiresAt }),
                     });
                     if (result.state === 'issued') {
                         writeJson(res, 201, { device_id: result.deviceId, device_credential: result.credential });
                     } else {
-                        writeJsonError(res, result.state === 'invalid_claim' ? 403 : result.state === 'expired' ? 400 : 409, result.state);
+                        writeJsonError(res, result.state === 'invalid_claim' || result.state === 'wrong_device_kind' ? 403 : result.state === 'expired' ? 400 : 409, result.state);
                     }
                     return;
                 }

--- a/apps/relay/src/selfhostPairing.ts
+++ b/apps/relay/src/selfhostPairing.ts
@@ -15,6 +15,7 @@ export interface SelfhostPairSession {
     pairId: string;
     claimHash: string;
     machineSlug: string;
+    deviceKind: 'native' | 'browser';
     createdAt: number;
     expiresAt: number;
     usedAt?: number;
@@ -90,7 +91,7 @@ export class SelfhostPairing {
     }
 
     /** CLI side (mint-secret authed at the route): open a 5-minute pairing window. */
-    createSession(input: { claim: string; machineSlug: string }, now = Date.now()): Promise<{ pairId: string; expiresIn: number }> {
+    createSession(input: { claim: string; machineSlug: string; deviceKind: 'native' | 'browser' }, now = Date.now()): Promise<{ pairId: string; expiresIn: number }> {
         return this.serialized(async () => {
             await this.load();
             this.state.sessions = this.state.sessions
@@ -101,6 +102,7 @@ export class SelfhostPairing {
                 pairId,
                 claimHash: hash(input.claim),
                 machineSlug: input.machineSlug,
+                deviceKind: input.deviceKind,
                 createdAt: now,
                 expiresAt: now + PAIR_TTL_MS,
             });
@@ -112,14 +114,15 @@ export class SelfhostPairing {
     /** Phone side: single-use claim. Returns the device credential on success. */
     claim(
         pairId: string,
-        input: { claim: string; devicePublicKey: string; deviceName: string; mailbox: string; expiresAt?: number },
+        input: { claim: string; devicePublicKey: string; deviceName: string; deviceKind: 'native' | 'browser'; mailbox: string; expiresAt?: number },
         now = Date.now(),
-    ): Promise<{ state: 'issued'; deviceId: string; credential: string } | { state: 'already_claimed' | 'expired' | 'invalid_claim' }> {
+    ): Promise<{ state: 'issued'; deviceId: string; credential: string } | { state: 'already_claimed' | 'expired' | 'invalid_claim' | 'wrong_device_kind' }> {
         return this.serialized(async () => {
             await this.load();
             const session = this.state.sessions.find((s) => s.pairId === pairId);
             if (session === undefined || session.claimHash !== hash(input.claim)) return { state: 'invalid_claim' };
             if (session.expiresAt <= now) return { state: 'expired' };
+            if ((session.deviceKind ?? 'native') !== input.deviceKind) return { state: 'wrong_device_kind' };
             if (session.usedAt !== undefined) return { state: 'already_claimed' };
             session.usedAt = now;
             session.devicePublicKey = input.devicePublicKey;

--- a/docs/FLIP-CHECKLIST.md
+++ b/docs/FLIP-CHECKLIST.md
@@ -11,7 +11,7 @@ tree; they do not make the repo public or publish npm.
 - [x] `**/android/build/` gitignored; Gradle intermediates untracked
 - [x] Stray root artifacts removed (`demo-change.ts`, `commands.json`, `herdr-api.schema.json`)
 - [x] GitHub repository renamed to `muxr` (clone `umeranjum17/muxr`). npm publishes under `@trymuxr/cli`; the installed command remains `muxr`.
-- [x] Public quickstart is npm-first: `npm install -g @trymuxr/cli`, then `muxr setup`; source-clone setup is for contributors
+- [x] Public quickstart is npm-first: `npm install -g @trymuxr/cli`, then interactive `muxr`; source-clone setup is for contributors
 - [x] OFL-1.1 text + NOTICE for Inter / JetBrains Mono / Bricolage Grotesque; Whisper + xterm in NOTICE
 - [x] Issue/PR templates, Dependabot, docs index, plugin READMEs, capabilities docs
 - [x] Contract plugin-bridge types match `plugin.*`; CI checks RequestMap + bundled `plugin check`

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Start here, then follow one path.
 
 ## Use it
 
-- [README](../README.md) — `npm install -g @trymuxr/cli`, then `muxr setup`
+- [README](../README.md) — `npm install -g @trymuxr/cli`, then interactive `muxr`
 - [Self-hosting](SELF-HOSTING.md) — own relay, pairing, Tailscale/tunnels, Docker
 - [Native Android build](NATIVE-BUILD.md) — local EAS APK; Expo Go will not work
 - [Voice setup](VOICE-SETUP.md) — provider-neutral realtime voice, xAI adapter, dictation, platform bounds

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -9,34 +9,45 @@ On the machine that runs your agents (Linux, macOS, WSL):
 
 ```bash
 npm install -g @trymuxr/cli
-muxr setup
+muxr
 ```
 
-Setup adopts or installs Herdr with consent, syncs detected agent integrations,
-starts your relay and host, then:
+The interactive onboarding inspects the machine without changing it. You choose
+the connection method, local port or external URL, whether to host the read-only
+web client, agent integrations, optional plugins, and managed services. After a
+final **Apply setup** confirmation, muxr starts the selected relay and host, then:
 
 1. Stores strict E2EE relay state under `~/.muxr/relay`.
-2. Prints a **pairing QR code and a raw pairing string**.
-3. Waits for your phone, then completes the end-to-end key exchange.
+2. Runs the selected phone, browser, or sequential pairing flow.
+3. Reports the connection mode, relay URL, web URL when enabled, service health,
+   pairing result, integrations, and plugins. Credentials and internal IDs are
+   never included in this final summary.
 
-In the app: **Scan QR code** (or paste the pairing string). Done — your machine
-shows up and every agent on it is in your pocket.
+The registered user service supervises the relay and host together, so both
+return after login or reboot and `muxr update` restarts them as one managed unit.
+Unchanged setup choices keep existing devices paired; changing the endpoint
+requires and displays a fresh pairing step.
 
-For manual service control use `muxr daemon status|logs|start|stop`. Advanced
+In the native app: **Scan QR code** (or paste the pairing string). For the
+read-only browser, setup prints a clickable HTTPS pairing link; the browser
+grant expires after eight hours and the UI then asks you to pair again.
+
+For automation use `muxr daemon status|logs|start|stop|restart`. Advanced
 split deployments can use `muxr self-host --relay-only` and
 `muxr self-host --host-only`.
 
 ## Reaching the relay from your phone
 
-`muxr self-host` picks an advertise address in this order:
+Interactive onboarding presents these choices. The equivalent automation flags
+are:
 
 | Flag | What happens |
 |---|---|
 | `--advertise <url>` | Explicit relay URL wins. Use your own domain/reverse proxy. |
 | `--tunnel` | Spawns `cloudflared` for a public `trycloudflare.com` URL. The URL is ephemeral; use a named tunnel for permanence. |
-| *(Tailscale detected)* | Uses private HTTPS through `tailscale serve`; the relay stays on loopback. |
+| *(choose Tailscale Serve)* | Uses private HTTPS through `tailscale serve`; the relay stays on loopback. |
 | `--tailscale-direct` | Rollback path using the tailnet IP directly. |
-| *(fallback)* | LAN address. Phone must be on the same network. |
+| *(choose Local network)* | LAN address. Phone must be on the same network. |
 
 muxr never enables Funnel. Restrict the Serve endpoint with a tailnet grant/ACL to intended devices even though muxr pairing and E2EE remain authoritative. `--web` requires a secure `wss://` route; insecure LAN HTTP is refused.
 
@@ -95,6 +106,7 @@ relay, its own keys, its own device list.
 
 ## Updating
 
-Update the packaged CLI with `npm update -g @trymuxr/cli`; then run `muxr setup`
-to reconcile the local services. Source checkouts can instead pull, run
+Run `muxr` and choose **Update muxr**, or use `muxr update --yes` in automation.
+The updater installs the latest npm release, refreshes bundled plugins, and
+restarts a running local relay and host. Source checkouts can instead pull, run
 `yarn install --frozen-lockfile && yarn build`, and restart the relay and host.

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -8,12 +8,16 @@ Requires Node 22+ and [Herdr](https://herdr.dev). If Herdr is missing, setup ask
 
 ```bash
 npm install -g @trymuxr/cli
-muxr setup
+muxr
 ```
 
-`muxr setup` inspects the machine, adopts the existing Herdr configuration, installs muxr's bundled plugins, syncs detected coding-agent integrations, starts the relay and host, and displays a short-lived pairing QR plus pasteable pairing string.
+The interactive onboarding inspects the machine, then asks you to choose the connection method, Herdr and coding-agent integrations, optional plugins, managed services, browser hosting, and phone/browser pairing. Nothing changes until you review and apply the plan. It then verifies the supervised relay and host and reports the selected relay URL, web URL when enabled, and service health without printing credentials. Native setup displays a QR; browser setup displays a clickable HTTPS pairing link for an eight-hour read-only grant.
+
+Run `muxr` with no arguments for the interactive setup and maintenance menu.
 
 ```bash
+muxr update                    # check, confirm, update, and restart
+muxr update --check            # check without changing anything
 muxr doctor                    # redacted setup diagnostics
 muxr pair                      # pair another phone
 muxr pair --browser            # pair an 8-hour read-only browser

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "doctor": "node scripts/doctor.mjs",
         "worktrees:clean": "node scripts/cleanWorktrees.mjs",
         "web:deploy": "bash scripts/deployWebExport.sh",
-        "web:export": "cd apps/mobile && env -u EXPO_PUBLIC_MUXR_TOKEN -u EXPO_PUBLIC_MUXR_E2EE_KEY -u EXPO_PUBLIC_MUXR_MACHINE_ID -u EXPO_PUBLIC_MUXR_MODE npx expo export --platform web",
+        "web:export": "cd apps/mobile && APP_ENV=production MUXR_PUBLIC_BASE_URL=https://trymuxr.com env -u EXPO_PUBLIC_MUXR_TOKEN -u EXPO_PUBLIC_MUXR_E2EE_KEY -u EXPO_PUBLIC_MUXR_MACHINE_ID -u EXPO_PUBLIC_MUXR_MODE npx expo export --platform web",
         "pack": "yarn build && yarn web:export && node scripts/pack.mjs",
         "pack:smoke": "yarn build && yarn web:export && node scripts/checkPackageSmoke.mjs && node scripts/packageLifecycleSmoke.mjs"
     },

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -89,6 +89,7 @@ function cliEnv(targetHome = home, extra = {}) {
         ...inherited,
         HOME: targetHome,
         PATH: `${binDir}:${dirname(process.execPath)}`,
+        MUXR_PS_BIN: '/usr/bin/ps',
         HERDR_BIN: join(binDir, 'herdr'),
         FAKE_HERDR_STATE: fakeState,
         FAKE_HERDR_LOG: fakeLog,
@@ -224,6 +225,7 @@ try {
     assert.ok(listing.includes('package/THIRD_PARTY_LICENSES.json'));
     assert.ok(!listing.includes('package/esbuild-metafile.json'));
     assert.ok(listing.includes('package/relay.js'), 'self-host relay bundle missing from npm artifact');
+    assert.ok(listing.includes('package/update.mjs'), 'interactive CLI updater missing from npm artifact');
     assert.ok(listing.includes('package/plugins/control/run.mjs'), 'control plugin missing from npm artifact');
     assert.ok(listing.includes('package/plugins/run-server/start.mjs'), 'Run Server plugin missing from npm artifact');
     assert.ok(listing.includes('package/plugins/voice/rpc.mjs'), 'Voice plugin missing from npm artifact');
@@ -251,6 +253,25 @@ try {
         env: { ...process.env, npm_config_cache: join(scratch, 'npm-cache') },
     });
     const cli = join(installDir, 'node_modules', '.bin', 'muxr');
+    const installedUpdate = await import(new URL(`file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'update.mjs')}`).href);
+    assert.ok(installedUpdate.compareVersions('1.0.0-beta.10', '1.0.0-beta.9') > 0);
+    assert.ok(installedUpdate.compareVersions('1.0.0-beta.9', '1.0.0-beta.10') < 0);
+    assert.ok(installedUpdate.compareVersions('1.0.0', '1.0.0-rc.1') > 0);
+    const promptSmokePath = join(scratch, 'prompt-smoke.mjs');
+    const setupUiUrl = new URL(`file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'setup-ui.mjs')}`).href;
+    writeFileSync(promptSmokePath, `import { prompt } from ${JSON.stringify(setupUiUrl)};\nconst answer = await prompt('Cancel prompt');\nif (answer !== undefined) process.exitCode = 1;\n`);
+    const promptSmoke = await runTty(`${process.execPath} ${promptSmokePath}`, cliEnv(), '\u0003', 20_000, undefined, 'never', 'Cancel prompt');
+    assert.equal(promptSmoke.code, 0, promptSmoke.output);
+    assert.doesNotMatch(promptSmoke.output, /unsettled top-level await|SyntaxError/);
+    const menuCancel = await runTty(cli, cliEnv(), '\u0003', 20_000, undefined, 'never', 'What would you like to do?');
+    assert.equal(menuCancel.code, 0, menuCancel.output);
+    assert.doesNotMatch(menuCancel.output, /Get started\s+ muxr setup/, 'cancelling the menu printed command help');
+    const inspectHome = join(scratch, 'inspect-home');
+    mkdirSync(inspectHome, { recursive: true });
+    const inspectBefore = filesSnapshot(inspectHome);
+    const inspected = run(cli, ['setup', '--inspect'], { cwd: installDir, env: cliEnv(inspectHome) });
+    assert.match(inspected.stdout, /Inspection complete\. Nothing changed\./);
+    assert.equal(filesSnapshot(inspectHome), inspectBefore, '`setup --inspect` mutated a non-TTY HOME');
 
     const refusalHome = join(scratch, 'refusal-home');
     mkdirSync(refusalHome, { recursive: true });
@@ -304,7 +325,8 @@ try {
     const setupArgs = ['--relay-only', '--port', String(setupPort), '--advertise', `ws://127.0.0.1:${setupPort}`];
     assert.equal(run(cli, ['version'], { cwd: installDir, env }).stdout.trim(), packageJson.version);
     const beforeHelp = filesSnapshot(home);
-    assert.match(run(cli, ['setup', '--help'], { cwd: installDir, env }).stdout, /Guided setup adopts or installs Herdr/);
+    assert.match(run(cli, ['setup', '--help'], { cwd: installDir, env }).stdout, /Interactive setup lets you choose networking/);
+    assert.match(run(cli, ['update', '--help'], { cwd: installDir, env }).stdout, /Check npm for a newer/);
     assert.equal(filesSnapshot(home), beforeHelp, 'subcommand help changed the home directory');
 
     const beforeDryRun = filesSnapshot(home);
@@ -317,6 +339,20 @@ try {
     run(cli, ['setup', ...setupArgs], { cwd: installDir, env });
     assert.equal(readFileSync(join(home, '.muxr', 'setup-manifest.json'), 'utf8'), manifestAfterFirst);
     run(cli, ['daemon', 'install', '--mode', 'selfhost'], { cwd: installDir, env });
+    run(cli, ['daemon', 'restart'], { cwd: installDir, env });
+    const updateNpm = join(scratch, 'update-npm');
+    const updateLog = join(scratch, 'update.log');
+    writeFileSync(updateNpm, '#!/bin/sh\nif [ "$1" = view ]; then printf \'"%s"\\n\' "${MUXR_UPDATE_LATEST:-9.9.9}"; exit 0; fi\nif [ "$1" = install ]; then printf "%s\\n" "$*" >> "$MUXR_UPDATE_LOG"; exit 0; fi\nexit 1\n', { mode: 0o755 });
+    const updateEnv = { ...env, MUXR_NPM_BIN: updateNpm, MUXR_UPDATE_LOG: updateLog };
+    const cancelledUpdate = await runTty(`${cli} update`, updateEnv, '\r', 20_000, undefined, 'never', 'Apply this update?');
+    assert.equal(cancelledUpdate.code, 0, cancelledUpdate.output);
+    assert.ok(!existsSync(updateLog), 'pressing Enter applied the update');
+    assert.match(run(cli, ['update', '--yes'], { cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '0.0.1' } }).stdout, /newer than npm latest/);
+    assert.ok(!existsSync(updateLog), 'updater installed a registry downgrade');
+    assert.match(run(cli, ['update', '--check'], { cwd: installDir, env: updateEnv }).stdout, /9\.9\.9 is available/);
+    run(cli, ['update', '--yes'], { cwd: installDir, env: updateEnv });
+    assert.match(readFileSync(updateLog, 'utf8'), /install -g @trymuxr\/cli@9\.9\.9/);
+    assert.match(readFileSync(join(home, '.config', 'systemd', 'user', 'muxr.service'), 'utf8'), /MUXR_MODE=.*selfhost/, 'update removed the daemon mode');
     assert.equal(readFileSync(join(home, '.config', 'herdr', 'config.toml'), 'utf8'), configBefore);
     const instructions = readFileSync(instructionPath, 'utf8');
     assert.equal(instructions.match(/muxr:herdr-skill:start/g)?.length, 1);
@@ -335,14 +371,14 @@ try {
     assert.match(readFileSync(instructionPath, 'utf8'), /Keep this line\./);
     run(cli, ['doctor'], { cwd: installDir, env });
 
-    const host = spawn(cli, ['up', '--fake'], { cwd: installDir, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    const host = spawn(cli, ['up', '--fake'], { cwd: installDir, env: { ...env, MUXR_MODE: 'selfhost' }, stdio: ['ignore', 'pipe', 'pipe'] });
     let hostOutput = '';
     host.stdout.on('data', (chunk) => { hostOutput += chunk; });
     host.stderr.on('data', (chunk) => { hostOutput += chunk; });
     await new Promise((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error(`packaged host did not start\n${hostOutput}`)), 10_000);
         const poll = setInterval(() => {
-            if (hostOutput.includes('(fake)')) {
+            if (hostOutput.includes('(fake)') && existsSync(join(home, '.muxr', 'relay', 'relay.pid'))) {
                 clearTimeout(timer);
                 clearInterval(poll);
                 resolve();
@@ -351,12 +387,29 @@ try {
     });
     host.kill('SIGTERM');
     await new Promise((resolve) => host.once('exit', resolve));
+    await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('managed relay survived its host service')), 5_000);
+        const poll = setInterval(async () => {
+            const alive = await fetch(`http://127.0.0.1:${setupPort}/health`).then((response) => response.ok).catch(() => false);
+            if (!alive) {
+                clearTimeout(timer);
+                clearInterval(poll);
+                resolve();
+            }
+        }, 100);
+    });
 
     const macHome = join(scratch, 'mac-home');
+    const launchctlLog = join(scratch, 'launchctl.log');
+    const launchctlState = join(scratch, 'launchctl.state');
+    writeFileSync(join(binDir, 'launchctl'), `#!/bin/sh\necho "$*" >> "${launchctlLog}"\ncase "$1" in\n  print) [ -f "${launchctlState}" ] && cat "${launchctlState}" || exit 1 ;;\n  bootstrap) echo 'state = waiting' > "${launchctlState}" ;;\n  kickstart) echo 'state = running' > "${launchctlState}" ;;\n  bootout) rm -f "${launchctlState}" ;;\nesac\n`, { mode: 0o755 });
     mkdirSync(macHome, { recursive: true });
-    const macEnv = cliEnv(macHome, { MUXR_PLATFORM: 'darwin' });
+    const macEnv = cliEnv(macHome, { MUXR_PLATFORM: 'darwin', MUXR_NO_SERVICE_COMMANDS: '' });
     run(cli, ['daemon', 'install'], { cwd: installDir, env: macEnv });
     assert.match(readFileSync(join(macHome, 'Library', 'LaunchAgents', 'com.muxr.host.plist'), 'utf8'), /com\.muxr\.host/);
+    run(cli, ['daemon', 'start'], { cwd: installDir, env: macEnv });
+    assert.match(readFileSync(launchctlLog, 'utf8'), /bootstrap[\s\S]*kickstart/, 'first macOS start did not kickstart after bootstrap');
+    run(cli, ['daemon', 'status'], { cwd: installDir, env: macEnv });
     run(cli, ['daemon', 'uninstall'], { cwd: installDir, env: macEnv });
 
     writeFileSync(join(home, '.muxr', 'xai.key'), 'xai-user-owned\n', { mode: 0o600 });

--- a/scripts/checkSelfhostRevocation.mjs
+++ b/scripts/checkSelfhostRevocation.mjs
@@ -40,13 +40,13 @@ async function pair(name) {
     const keys = generateKeyPair();
     const claim = randomBytes(32).toString('base64url');
     const opened = await json('/v1/selfhost/pair-sessions', {
-        method: 'POST', headers: bearer(mintSecret), body: JSON.stringify({ claim, machineSlug: machine }),
+        method: 'POST', headers: bearer(mintSecret), body: JSON.stringify({ claim, machineSlug: machine, deviceKind: 'native' }),
     });
     if (!opened.response.ok) throw new Error(`open pair failed: ${JSON.stringify(opened.body)}`);
     const pairId = opened.body.pair_id;
     const claimed = await json(`/v1/selfhost/pair-sessions/${pairId}/claim`, {
         method: 'POST',
-        body: JSON.stringify({ claim, device_public_key: keys.publicKey, device_name: name, mailbox: 'opaque-mailbox' }),
+        body: JSON.stringify({ claim, device_public_key: keys.publicKey, device_name: name, device_kind: 'native', mailbox: 'opaque-mailbox' }),
     });
     if (!claimed.response.ok) throw new Error(`claim failed: ${JSON.stringify(claimed.body)}`);
     const device = { id: claimed.body.device_id, credential: claimed.body.device_credential, keys, name };
@@ -119,6 +119,19 @@ let socketB;
 try {
     await startRelay();
     mintSecret = JSON.parse(readFileSync(join(dataDir, 'mint-secret'), 'utf8'));
+
+    const authorityClaim = randomBytes(32).toString('base64url');
+    const authoritySession = await json('/v1/selfhost/pair-sessions', {
+        method: 'POST', headers: bearer(mintSecret),
+        body: JSON.stringify({ claim: authorityClaim, machineSlug: machine, deviceKind: 'native' }),
+    });
+    const rejectedBrowser = await json(`/v1/selfhost/pair-sessions/${authoritySession.body.pair_id}/claim`, {
+        method: 'POST',
+        body: JSON.stringify({ claim: authorityClaim, device_public_key: generateKeyPair().publicKey, device_name: 'Browser', device_kind: 'browser', mailbox: 'opaque-mailbox' }),
+    });
+    if (rejectedBrowser.response.status !== 403 || rejectedBrowser.body.error !== 'wrong_device_kind') {
+        throw new Error('browser claim accepted a native/full-control invitation');
+    }
 
     const a = await pair('phone A');
     const b = await pair('phone B');

--- a/scripts/checkTailscaleIngress.mjs
+++ b/scripts/checkTailscaleIngress.mjs
@@ -8,7 +8,7 @@ const scratch = mkdtempSync(join(tmpdir(), 'muxr-tailscale-'));
 const fake = join(scratch, 'tailscale');
 const originalPath = process.env.PATH;
 const configure = (status, serveStatus = '{}') => {
-    writeFileSync(fake, `#!/bin/sh\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}' ;;\n  "serve --bg --https=443 http://127.0.0.1:8792") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
+    writeFileSync(fake, `#!/bin/sh\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}' ;;\n  "serve --yes --bg --https=443 http://127.0.0.1:8792") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
     chmodSync(fake, 0o755);
 };
 process.env.PATH = `${scratch}:${originalPath}`;
@@ -17,11 +17,16 @@ try {
     const ingress = tailscaleIngress([]);
     assert.deepEqual(ingress, { dnsName: 'dev.tailnet.ts.net' });
     assert.deepEqual(await resolveAdvertise([], 8792, ingress), {
-        url: 'wss://dev.tailnet.ts.net', note: 'Tailscale Serve (private tailnet HTTPS)',
+        url: 'wss://dev.tailnet.ts.net',
+        note: 'Tailscale Serve (private tailnet HTTPS)',
+        ingress: { kind: 'tailscale-serve', port: 8792, dnsName: 'dev.tailnet.ts.net' },
     });
 
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.' } }, JSON.stringify({ TCP: { '443': { HTTPS: true } }, Web: { 'dev.tailnet.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:9999' } } } } }));
     await assert.rejects(resolveAdvertise([], 8792, tailscaleIngress([])), /already owned/);
+
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.' } }, JSON.stringify({ Web: { 'other.tailnet.ts.net:8443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:8792' } } } } }));
+    assert.equal((await resolveAdvertise([], 8792, tailscaleIngress([]))).url, 'wss://dev.tailnet.ts.net');
 
     configure({ Self: { TailscaleIPs: ['100.64.0.1'] } });
     assert.throws(() => tailscaleIngress([]), /MagicDNS/);
@@ -30,6 +35,8 @@ try {
     assert.equal(tailscaleIngress(['--tailscale-direct']), undefined);
     const direct = await resolveAdvertise(['--tailscale-direct'], 8792, undefined);
     assert.equal(direct.url, 'ws://100.64.0.1:8792');
+    await assert.rejects(resolveAdvertise(['--advertise', 'wss://user:pass@example.com'], 8792), /without credentials/);
+    await assert.rejects(resolveAdvertise(['--advertise', 'wss://example.com/muxr'], 8792), /without credentials/);
     process.stdout.write('tailscale ingress ownership passed\n');
 } finally {
     process.env.PATH = originalPath;

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -4,8 +4,12 @@ import { runDaemon, runDevices, runDoctor, runIntegrations, runPair, runSelfHost
 import { runSetup } from './setup-wizard.mjs';
 import { runPlugin } from './plugin.mjs';
 import { runPackage } from './package.mjs';
+import { runUpdate } from './update.mjs';
+import { select } from './setup-ui.mjs';
 
 const HELP = `muxr — every coding agent on your phone
+
+Run muxr with no arguments for the interactive menu.
 
 Get started
   muxr setup                     install, connect, and pair this machine
@@ -13,8 +17,9 @@ Get started
   muxr pair [--browser]          pair another phone or read-only browser
 
 Run and maintain
+  muxr update [--check|--yes]    check for or install the latest npm release
   muxr self-host [options]       run the relay, host, and pairing flow
-  muxr daemon <command>          install, start, stop, inspect, or remove the host
+  muxr daemon <command>          install, start, stop, restart, or inspect muxr services
   muxr devices list|revoke       list or revoke paired devices
   muxr integrations sync|uninstall
 
@@ -25,14 +30,15 @@ Use “muxr help <command>” for command options.
 `;
 
 const COMMAND_HELP = {
-    setup: `muxr setup [--inspect] [--dry-run] [--no-agent-config]\n           [--install-herdr|--no-install-herdr] [--port <n>]\n\nGuided setup adopts or installs Herdr, syncs integrations, starts the self-hosted relay and host, then shows a short-lived pairing QR.\n`,
+    setup: `muxr setup [--inspect] [--dry-run] [--no-agent-config]\n           [--install-herdr|--no-install-herdr] [--port <n>]\n\nInteractive setup lets you choose networking, integrations, plugins, and services, shows a final plan, then applies it and displays a short-lived pairing QR.\n`,
     'self-host': `muxr self-host [--advertise <ws-url>] [--tunnel] [--tailscale-direct]\n               [--port <n>] [--relay-only|--host-only] [--web] [--yes]\n`,
-    daemon: `muxr daemon install|uninstall|start|stop|status|logs\n`,
+    daemon: `muxr daemon install|uninstall|start|stop|restart|status|logs\n`,
     devices: `muxr devices list\nmuxr devices revoke <number|name>\n`,
     integrations: `muxr integrations sync [--all] [--dry-run]\nmuxr integrations uninstall [--dry-run]\n`,
     plugin: `muxr plugin create <name>\nmuxr plugin check|dev <path> [--web]\nmuxr plugin call <path> <contribution-id> [--input '<json>'] [--context '<json>']\nmuxr plugin list\nmuxr plugin install|update <local-path|owner/repo[/subdir][@ref]|npm:<name>@<exact-version>> [--yes]\nmuxr plugin remove <plugin-id> [--yes]\n`,
     pair: `muxr pair [--browser]\n\nCreate a short-lived pairing QR for another native device or an 8-hour read-only browser.\n`,
     doctor: `muxr doctor\n\nCheck Node, Herdr, integrations, managed files, and the self-host relay without printing secrets.\n`,
+    update: `muxr update [--check|--yes]\n\nCheck npm for a newer @trymuxr/cli release. Interactive terminals ask before installing; --yes updates without prompting.\n`,
 };
 
 function printHelp(command) {
@@ -40,8 +46,29 @@ function printHelp(command) {
 }
 
 const input = process.argv.slice(2);
-const command = input[0] ?? 'help';
-const args = input.slice(1);
+let command = input[0];
+let args = input.slice(1);
+if (command === undefined && process.stdin.isTTY && process.stdout.isTTY) {
+    const selected = await select('What would you like to do?', [
+        { value: 'setup', title: 'Set up or change connection', description: 'review networking, Herdr, integrations, plugins, and services' },
+        { value: 'update', title: 'Update muxr', description: 'check npm and install the latest release' },
+        { value: 'pair', title: 'Pair another phone', description: 'show a short-lived encrypted pairing QR' },
+        { value: 'pair-browser', title: 'Pair a browser', description: 'create an eight-hour read-only browser grant' },
+        { value: 'doctor', title: 'Check this setup', description: 'run safe diagnostics without printing secrets' },
+        { value: 'restart', title: 'Restart muxr', description: 'restart the supervised relay and host' },
+        { value: 'help', title: 'Show commands', description: 'print the non-interactive command reference' },
+    ]);
+    if (selected === undefined) process.exit(0);
+    command = selected;
+    if (command === 'restart') {
+        command = 'daemon';
+        args = ['restart'];
+    } else if (command === 'pair-browser') {
+        command = 'pair';
+        args = ['--browser'];
+    }
+}
+command ??= 'help';
 let code = 0;
 
 if (command === 'help' || command === '--help' || command === '-h') {
@@ -59,6 +86,8 @@ if (command === 'help' || command === '--help' || command === '-h') {
     code = await runDevices(deviceCommand, deviceArgs);
 } else if (command === 'doctor') {
     code = await runDoctor();
+} else if (command === 'update') {
+    code = await runUpdate(args);
 } else if (command === 'daemon') {
     code = await runDaemon(args);
 } else if (command === 'integrations') {

--- a/scripts/host-up.mjs
+++ b/scripts/host-up.mjs
@@ -1,14 +1,75 @@
-/** Run the distributed host bridge in the foreground. The relay is hosted separately. */
+/** Run the user-operated host bridge. In self-host mode this process also owns the relay child. */
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const packagedHost = fileURLToPath(new URL('./host.js', import.meta.url));
 const hostEntry = existsSync(packagedHost)
     ? packagedHost
     : fileURLToPath(new URL('../apps/host/dist/main.js', import.meta.url));
-const child = spawn(process.execPath, [hostEntry, ...process.argv.slice(3)], { stdio: 'inherit' });
-for (const signal of ['SIGINT', 'SIGTERM']) {
-    process.on(signal, () => child.kill(signal));
+const packagedRelay = fileURLToPath(new URL('./relay.js', import.meta.url));
+const relayEntry = existsSync(packagedRelay)
+    ? packagedRelay
+    : fileURLToPath(new URL('../apps/relay/dist/main.js', import.meta.url));
+const children = [];
+let stopping = false;
+
+function start(entry, env = process.env, args = []) {
+    const child = spawn(process.execPath, [entry, ...args], { stdio: 'inherit', env });
+    children.push(child);
+    child.on('exit', (code, signal) => {
+        if (stopping) return;
+        stopping = true;
+        for (const sibling of children) if (sibling !== child && sibling.exitCode === null) sibling.kill('SIGTERM');
+        process.stderr.write(`muxr ${entry === hostEntry ? 'host' : 'relay'} exited (${signal ?? code ?? 1})\n`);
+        process.exitCode = code ?? 1;
+    });
+    return child;
 }
-child.on('exit', (code) => process.exit(code ?? 1));
+
+async function waitForRelay(port) {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+        const ready = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.ok).catch(() => false);
+        if (ready) return;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw new Error(`muxr relay did not become ready on :${port}`);
+}
+
+if (process.env.MUXR_MODE === 'selfhost') {
+    const root = process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr');
+    const state = JSON.parse(readFileSync(join(root, 'selfhost.json'), 'utf8'));
+    const port = Number(state.relayPort);
+    if (!Number.isInteger(port)) throw new Error('self-host relay state has no valid port');
+    const relay = start(relayEntry, {
+        ...process.env,
+        MUXR_RELAY_LOCAL_AUTHORITY: '1',
+        MUXR_RELAY_MDNS: '1',
+        MUXR_RELAY_PORT: String(port),
+        MUXR_RELAY_HOST: state.bindHost || '0.0.0.0',
+        MUXR_RELAY_DATA_DIR: join(root, 'relay'),
+        ...(state.webRoot ? { MUXR_WEB_ROOT: state.webRoot } : {}),
+        ...(state.webOrigin ? { MUXR_ALLOWED_ORIGINS: state.webOrigin } : {}),
+    });
+    try { await waitForRelay(port); }
+    catch (cause) {
+        stopping = true;
+        relay.kill('SIGTERM');
+        throw cause;
+    }
+}
+
+start(hostEntry, process.env, process.argv.slice(3));
+
+function stop(signal) {
+    if (stopping) return;
+    stopping = true;
+    for (const child of children) if (child.exitCode === null) child.kill(signal);
+    setTimeout(() => {
+        for (const child of children) if (child.exitCode === null) child.kill('SIGKILL');
+        process.exit(0);
+    }, 2000).unref();
+}
+for (const signal of ['SIGINT', 'SIGTERM']) process.on(signal, () => stop(signal));

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -408,6 +408,10 @@ export async function runLocalPrerequisites(args = []) {
     try {
         const binary = await bootstrapHerdr(args);
         if (!binary) return args.includes('--dry-run') ? 0 : 1;
+        if (args.includes('--no-integrations')) {
+            print('  coding-agent integrations left unchanged');
+            return 0;
+        }
         const integrationArgs = ['sync', ...(args.includes('--dry-run') ? ['--dry-run'] : []), ...(args.includes('--force') ? ['--force'] : [])];
         if (args.includes('--all')) integrationArgs.push('--all');
         if (args.includes('--no-agent-config')) integrationArgs.push('--no-agent-config');
@@ -566,10 +570,15 @@ function serviceCommand(action) {
         if (action === 'reload') return { ok: true, stdout: '', stderr: '' };
         if (action === 'start' || action === 'restart') {
             const loaded = run('launchctl', ['print', service]);
-            return loaded.ok ? run('launchctl', ['kickstart', '-k', service]) : run('launchctl', ['bootstrap', domain, plist]);
+            if (loaded.ok) return run('launchctl', ['kickstart', '-k', service]);
+            const bootstrapped = run('launchctl', ['bootstrap', domain, plist]);
+            return bootstrapped.ok ? run('launchctl', ['kickstart', '-k', service]) : bootstrapped;
         }
         if (action === 'stop' || action === 'unload') return run('launchctl', ['bootout', service]);
-        if (action === 'status') return run('launchctl', ['print', service]);
+        if (action === 'status') {
+            const printed = run('launchctl', ['print', service]);
+            return { ...printed, ok: printed.ok && /\bstate = running\b/.test(printed.stdout) };
+        }
     }
     if (action === 'reload') return run('systemctl', ['--user', 'daemon-reload']);
     if (action === 'start') return run('systemctl', ['--user', 'enable', '--now', 'muxr.service']);
@@ -578,6 +587,41 @@ function serviceCommand(action) {
     if (action === 'status') return run('systemctl', ['--user', 'status', 'muxr.service', '--no-pager']);
     if (action === 'unload') return run('systemctl', ['--user', 'disable', '--now', 'muxr.service']);
     return { ok: false, stdout: '', stderr: `unknown service action ${action}` };
+}
+
+export function daemonIsRunning() {
+    return serviceCommand('status').ok;
+}
+
+export function daemonMode() {
+    try {
+        const content = readFileSync(daemonDefinition().path, 'utf8');
+        return /MUXR_MODE[\s\S]{0,80}selfhost/.test(content) ? 'selfhost' : /MUXR_MODE[\s\S]{0,80}hosted/.test(content) ? 'hosted' : undefined;
+    } catch { return undefined; }
+}
+
+function publicRelayUrl(value) {
+    if (typeof value !== 'string') return undefined;
+    try {
+        const parsed = new URL(value);
+        return ['ws:', 'wss:'].includes(parsed.protocol) ? parsed.origin : undefined;
+    } catch { return undefined; }
+}
+
+export async function selfhostPublicSummary() {
+    const state = readSelfhostState();
+    if (state === undefined) return undefined;
+    const relayHealthy = await fetch(`http://127.0.0.1:${state.relayPort}/health`).then((response) => response.ok).catch(() => false);
+    return {
+        connectionMode: typeof state.connectionMode === 'string' ? state.connectionMode : undefined,
+        relayPort: Number.isInteger(state.relayPort) ? state.relayPort : undefined,
+        relayUrl: publicRelayUrl(state.relayUrl),
+        webEnabled: state.webEnabled === true,
+        ingressHealthy: state.connectionMode !== 'cloudflare' || cloudflaredAlive(state.ingress),
+        webUrl: state.webEnabled === true ? publicRelayUrl(state.relayUrl)?.replace(/^ws/, 'http') : undefined,
+        relayHealthy,
+        hostRunning: daemonIsRunning(),
+    };
 }
 
 export async function runDaemon(args = []) {
@@ -606,9 +650,11 @@ export async function runDaemon(args = []) {
             saveManifest(manifest, dryRun);
             if (!dryRun) {
                 serviceCommand('unload');
+                await stopOwnedSelfhostRelay();
+                cleanupManagedIngress(readSelfhostState());
                 serviceCommand('reload');
             }
-            print('Daemon registration removed; muxr data and unrelated services were left intact.');
+            print('Daemon registration and muxr-owned ingress removed; muxr data and unrelated services were left intact.');
             return 0;
         }
         if (action === 'logs') {
@@ -621,7 +667,7 @@ export async function runDaemon(args = []) {
             print(result.stdout || result.stderr || 'No daemon log yet.');
             return result.ok ? 0 : 1;
         }
-        if (!['start', 'stop', 'status'].includes(action)) throw new Error('usage: muxr daemon install|uninstall|start|stop|status|logs');
+        if (!['start', 'stop', 'restart', 'status'].includes(action)) throw new Error('usage: muxr daemon install|uninstall|start|stop|restart|status|logs');
         const result = serviceCommand(action);
         print(result.stdout || result.stderr || `daemon ${action}: ok`);
         return result.ok || action === 'status' ? 0 : 1;
@@ -834,22 +880,57 @@ export function tailscaleIngress(args) {
     }
 }
 
-function tailscaleRootProxy(value) {
-    if (value === null || typeof value !== 'object') return undefined;
-    if (typeof value.Proxy === 'string') return value.Proxy;
-    if (value.Handlers?.['/'] !== undefined) return tailscaleRootProxy(value.Handlers['/']);
-    for (const child of Object.values(value)) {
-        const found = tailscaleRootProxy(child);
-        if (found !== undefined) return found;
+function tailscaleRootProxy(value, dnsName) {
+    const web = value?.Web;
+    if (web === null || typeof web !== 'object') return undefined;
+    const exact = dnsName ? web[`${dnsName}:443`]?.Handlers?.['/']?.Proxy : undefined;
+    if (typeof exact === 'string') return exact;
+    if (dnsName) return undefined;
+    const roots = Object.entries(web)
+        .filter(([address]) => address.endsWith(':443'))
+        .map(([, config]) => config?.Handlers?.['/']?.Proxy)
+        .filter((proxy) => typeof proxy === 'string');
+    return roots.length === 1 ? roots[0] : undefined;
+}
+
+function cloudflaredAlive(ingress) {
+    if (ingress?.kind !== 'cloudflare-quick') return false;
+    const pid = Number(ingress.pid);
+    const command = Number.isSafeInteger(pid) && pid > 1 ? run(env('MUXR_PS_BIN') || 'ps', ['-ww', '-p', String(pid), '-o', 'command=']) : { ok: false };
+    return command.ok && command.stdout.includes(`cloudflared tunnel --url http://127.0.0.1:${ingress.port}`);
+}
+
+function cleanupManagedIngress(state) {
+    const ingress = state?.ingress;
+    if (ingress?.kind === 'cloudflare-quick') {
+        if (cloudflaredAlive(ingress)) process.kill(Number(ingress.pid), 'SIGTERM');
+        return;
     }
-    return undefined;
+    if (ingress?.kind !== 'tailscale-serve') return;
+    const current = spawnSync('tailscale', ['serve', 'status', '--json'], { encoding: 'utf8' });
+    if (current.error?.code === 'ENOENT') return;
+    if (current.status !== 0) throw new Error('cannot inspect the previous muxr Tailscale Serve route; leaving it unchanged');
+    let parsed;
+    try { parsed = JSON.parse(current.stdout || '{}'); }
+    catch { throw new Error('Tailscale Serve returned invalid status JSON; leaving it unchanged'); }
+    const expected = `http://127.0.0.1:${ingress.port}`;
+    const rootProxy = tailscaleRootProxy(parsed, ingress.dnsName);
+    if (rootProxy === undefined) return;
+    if (rootProxy !== expected) throw new Error('the previous Tailscale Serve route changed outside muxr; leaving it unchanged');
+    const disabled = spawnSync('tailscale', ['serve', '--https=443', 'off'], { encoding: 'utf8' });
+    if (disabled.status !== 0) throw new Error(`could not remove the previous muxr Tailscale Serve route: ${disabled.stderr.trim() || disabled.stdout.trim()}`);
 }
 
 export async function resolveAdvertise(args, port, tailscale) {
     const explicit = flagValue(args, '--advertise')?.trim();
     if (explicit) {
-        if (!/^wss?:\/\/[^/]+/.test(explicit)) throw new Error('--advertise must be a ws:// or wss:// URL');
-        return { url: explicit.replace(/\/$/,''), note: 'explicit --advertise' };
+        let parsed;
+        try { parsed = new URL(explicit); }
+        catch { throw new Error('--advertise must be a valid ws:// or wss:// URL'); }
+        if (!['ws:', 'wss:'].includes(parsed.protocol) || !parsed.hostname || parsed.username || parsed.password || parsed.pathname !== '/' || parsed.search || parsed.hash) {
+            throw new Error('--advertise must be a root ws:// or wss:// URL without credentials, paths, query, or fragment');
+        }
+        return { url: parsed.toString().replace(/\/$/, ''), note: 'explicit --advertise' };
     }
     if (args.includes('--tunnel')) {
         const check = spawnSync('cloudflared', ['--version'], { encoding: 'utf8' });
@@ -866,22 +947,33 @@ export async function resolveAdvertise(args, port, tailscale) {
             const match = readFileSync(logPath, 'utf8').match(/https:\/\/[a-z0-9-]+\.trycloudflare\.com/);
             if (match) tunnelUrl = match[0];
         }
-        if (tunnelUrl === undefined) throw new Error(`cloudflared did not print a tunnel URL; see ${logPath}`);
-        return { url: tunnelUrl.replace(/^https/, 'wss'), note: 'cloudflare quick tunnel (ephemeral URL; use a named tunnel for permanence)' };
+        if (tunnelUrl === undefined) {
+            proc.kill('SIGTERM');
+            throw new Error(`cloudflared did not print a tunnel URL; see ${logPath}`);
+        }
+        return {
+            url: tunnelUrl.replace(/^https/, 'wss'),
+            note: 'cloudflare quick tunnel (ephemeral URL; use a named tunnel for permanence)',
+            ingress: { kind: 'cloudflare-quick', pid: proc.pid, port },
+        };
     }
     if (tailscale) {
         const current = spawnSync('tailscale', ['serve', 'status', '--json'], { encoding: 'utf8' });
         if (current.status !== 0) throw new Error(`cannot inspect Tailscale Serve ownership: ${current.stderr.trim() || 'status failed'}`);
         let rootProxy;
-        try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}')); }
+        try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), tailscale.dnsName); }
         catch { throw new Error('Tailscale Serve returned invalid status JSON'); }
         const expected = `http://127.0.0.1:${port}`;
         if (rootProxy !== undefined && rootProxy !== expected) throw new Error('Tailscale Serve root is already owned by another service; use --tailscale-direct or remove it yourself');
         const serve = rootProxy === expected
             ? { status: 0, stdout: '', stderr: '' }
-            : spawnSync('tailscale', ['serve', '--bg', '--https=443', expected], { encoding: 'utf8' });
+            : spawnSync('tailscale', ['serve', '--yes', '--bg', '--https=443', expected], { encoding: 'utf8' });
         if (serve.status !== 0) throw new Error(`tailscale serve failed: ${serve.stderr.trim() || serve.stdout.trim() || 'check operator permissions'}; use --tailscale-direct for direct tailnet mode`);
-        return { url: `wss://${tailscale.dnsName}`, note: 'Tailscale Serve (private tailnet HTTPS)' };
+        return {
+            url: `wss://${tailscale.dnsName}`,
+            note: 'Tailscale Serve (private tailnet HTTPS)',
+            ingress: { kind: 'tailscale-serve', port, dnsName: tailscale.dnsName },
+        };
     }
     const status = spawnSync('tailscale', ['status', '--json'], { encoding: 'utf8' });
     if (status.status === 0) {
@@ -937,6 +1029,54 @@ async function ensureSelfhostRelay(port, webRoot, host = '0.0.0.0', webOrigin) {
     throw new Error(`self-host relay did not come up on :${port}; see ${logPath}`);
 }
 
+async function stopOwnedSelfhostRelay() {
+    const state = readSelfhostState();
+    if (state === undefined) return undefined;
+    const port = Number(state.relayPort);
+    const health = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.ok ? response.json() : undefined).catch(() => undefined);
+    if (health?.ok !== true) return undefined;
+    const pidPath = join(stateDir(), 'relay', 'relay.pid');
+    const pid = Number(existsSync(pidPath) ? readFileSync(pidPath, 'utf8').trim() : '');
+    if (!Number.isSafeInteger(pid) || pid <= 1) throw new Error('running relay has no valid pid file; leaving it untouched');
+    const command = run(env('MUXR_PS_BIN') || 'ps', ['-ww', '-p', String(pid), '-o', 'command=']);
+    const relayCommand = command.ok ? command.stdout.trim() : '';
+    if (!/(?:^|\s)\S*\/relay\.js(?:\s|$)/.test(relayCommand) && !relayCommand.includes(relayEntry())) {
+        throw new Error('relay pid does not belong to a muxr relay process; leaving it untouched');
+    }
+    try { process.kill(pid, 'SIGTERM'); }
+    catch (cause) { if (cause?.code === 'ESRCH') return { state, health, port }; else throw cause; }
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+        const stopped = await fetch(`http://127.0.0.1:${port}/health`).then(() => false).catch(() => true);
+        if (stopped) return { state, health, port };
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error('relay did not stop; leaving the existing process in place');
+}
+
+function persistRelayRuntimeState({ state, health }) {
+    state.bindHost = health.bindHost === '127.0.0.1' ? '127.0.0.1' : '0.0.0.0';
+    state.webEnabled = health.webEnabled === true;
+    state.webRoot = state.webEnabled ? join(dirname(realpathSync(process.argv[1])), 'web') : undefined;
+    state.webOrigin = state.webEnabled && typeof state.relayUrl === 'string' ? state.relayUrl.replace(/^wss/, 'https') : undefined;
+    writeSelfhostState(state);
+}
+
+export async function stopSelfhostRelayIfRunning() {
+    const previous = await stopOwnedSelfhostRelay();
+    if (previous === undefined) return false;
+    persistRelayRuntimeState(previous);
+    return true;
+}
+
+export async function restartSelfhostRelayIfRunning() {
+    const previous = await stopOwnedSelfhostRelay();
+    if (previous === undefined) return false;
+    persistRelayRuntimeState(previous);
+    const { state, port } = previous;
+    await ensureSelfhostRelay(port, state.webRoot, state.bindHost, state.webOrigin);
+    return true;
+}
+
 function flagValue(args, name) {
     const inline = args.find((a) => a.startsWith(`${name}=`));
     if (inline !== undefined) return inline.slice(name.length + 1);
@@ -944,19 +1084,30 @@ function flagValue(args, name) {
     return index >= 0 ? args[index + 1] : undefined;
 }
 
-async function startMuxrDaemon(mode, args = []) {
+async function startMuxrDaemon(mode, args = [], restartRunning = true) {
     const dryRun = args.includes('--dry-run');
     const common = [...(dryRun ? ['--dry-run'] : []), ...(args.includes('--force') ? ['--force'] : [])];
     if ((await runDaemon(['install', '--mode', mode, ...common])) !== 0) throw new Error('daemon registration failed');
     if (dryRun) {
-        print(`  would start the muxr host in ${mode} mode`);
+        print(`  would start muxr services in ${mode} mode`);
         return;
     }
-    if ((await runDaemon(['start'])) !== 0) throw new Error('muxr host did not start');
-    for (let attempt = 0; attempt < 20; attempt += 1) {
+    const running = daemonIsRunning();
+    if (!running || restartRunning) {
+        const action = running ? 'restart' : 'start';
+        if ((await runDaemon([action])) !== 0) throw new Error(`muxr host did not ${action}`);
+    }
+    for (let attempt = 0; attempt < 40; attempt += 1) {
         if (serviceCommand('status').ok) {
-            print(`  ✓ muxr host running in ${mode} mode`);
-            return;
+            const relayReady = mode !== 'selfhost' || await (async () => {
+                const state = readSelfhostState();
+                return state?.relayPort !== undefined
+                    && fetch(`http://127.0.0.1:${state.relayPort}/health`).then((response) => response.ok).catch(() => false);
+            })();
+            if (relayReady) {
+                print(`  ✓ muxr services running in ${mode} mode`);
+                return;
+            }
         }
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
@@ -964,11 +1115,16 @@ async function startMuxrDaemon(mode, args = []) {
 }
 
 export async function runSelfHost(args = []) {
+    let pendingIngress;
     const port = Number(flagValue(args, '--port') ?? 8792);
     const relayOnly = args.includes('--relay-only');
     const hostOnly = args.includes('--host-only');
     const dryRun = args.includes('--dry-run');
     const web = args.includes('--web');
+    const pairKind = args.includes('--pair-browser') ? 'browser' : 'native';
+    const noPair = args.includes('--no-pair');
+    const connectionMode = flagValue(args, '--connection-mode');
+    const reconfigure = args.includes('--reconfigure');
     if (web && !process.stdout.isTTY && !args.includes('--yes')) {
         error('--web requires an interactive trust confirmation or explicit --yes');
         return 1;
@@ -996,12 +1152,27 @@ export async function runSelfHost(args = []) {
         if (state === undefined) {
             state = { version: 1, machine: machineIdentity(undefined), relayPort: port };
         }
+        const hostWasRunning = daemonIsRunning();
+        const explicitAdvertise = flagValue(args, '--advertise')?.replace(/\/$/, '');
+        const sameConfiguration = state.relayPort === port
+            && state.connectionMode === connectionMode
+            && state.webEnabled === web
+            && (connectionMode !== 'external' && connectionMode !== 'lan' || state.relayUrl === explicitAdvertise);
+        if (!sameConfiguration && reconfigure) {
+            cleanupManagedIngress(state);
+            if (hostWasRunning && (await runDaemon(['stop'])) !== 0) throw new Error('could not stop the managed muxr service before reconfiguration');
+            await stopOwnedSelfhostRelay();
+            delete state.ingress;
+        }
         state.relayPort = port;
         if (web && !existsSync(join(webRoot, 'index.html'))) throw new Error(`web client missing at ${webRoot}; install a package with the web client or pass --web-root`);
         const tailscale = tailscaleIngress(args);
-        const advertise = await resolveAdvertise(args, port, tailscale);
+        const advertise = sameConfiguration && connectionMode === 'cloudflare' && typeof state.relayUrl === 'string' && cloudflaredAlive(state.ingress)
+            ? { url: state.relayUrl, note: 'existing Cloudflare quick tunnel', ingress: state.ingress }
+            : await resolveAdvertise(args, port, tailscale);
+        pendingIngress = advertise.ingress?.kind === 'cloudflare-quick' ? advertise.ingress : undefined;
         if (web && !advertise.url.startsWith('wss://')) throw new Error('--web requires HTTPS (Tailscale Serve, a named HTTPS tunnel, or --advertise wss://...)');
-        const bindHost = tailscale || web ? '127.0.0.1' : '0.0.0.0';
+        const bindHost = tailscale || args.includes('--tunnel') || web || explicitAdvertise?.startsWith('wss://') ? '127.0.0.1' : '0.0.0.0';
         const webOrigin = web ? advertise.url.replace(/^wss/, 'https') : undefined;
         await ensureSelfhostRelay(port, web ? webRoot : undefined, bindHost, webOrigin);
         const mintPath = join(stateDir(), 'relay', 'mint-secret');
@@ -1012,7 +1183,14 @@ export async function runSelfHost(args = []) {
         const secretRaw = JSON.parse(readFileSync(mintPath, 'utf8'));
         state.mintSecret = secretRaw;
         state.relayUrl = advertise.url;
+        state.connectionMode = connectionMode;
+        state.webEnabled = web;
+        state.webRoot = web ? webRoot : undefined;
+        state.webOrigin = webOrigin;
+        state.bindHost = bindHost;
+        state.ingress = advertise.ingress;
         writeSelfhostState(state);
+        pendingIngress = undefined;
         print(`  ✓ self-host relay on :${port} (${advertise.note})`);
         print(`  ✓ advertise ${advertise.url}`);
         if (web) print(`  ✓ web client ${advertise.url.replace(/^ws/, 'http')}`);
@@ -1020,9 +1198,15 @@ export async function runSelfHost(args = []) {
             print('Relay ready. Run `muxr self-host --host-only` on the machine holding this state.');
             return 0;
         }
-        await startMuxrDaemon('selfhost', args);
-        return await withSelfhostRotationLock(() => runSelfhostPair(state, web ? 'browser' : 'native'));
+        if (env('MUXR_NO_SERVICE_COMMANDS') !== '1' && (!sameConfiguration || !hostWasRunning)) await stopOwnedSelfhostRelay();
+        await startMuxrDaemon('selfhost', args, !sameConfiguration || !hostWasRunning);
+        if (noPair) {
+            print('Ready — existing paired devices will reconnect automatically.');
+            return 0;
+        }
+        return await withSelfhostRotationLock(() => runSelfhostPair(state, pairKind));
     } catch (cause) {
+        if (pendingIngress && cloudflaredAlive(pendingIngress)) process.kill(Number(pendingIngress.pid), 'SIGTERM');
         error(cause instanceof Error ? cause.message : String(cause));
         return 1;
     }
@@ -1211,7 +1395,7 @@ async function runSelfhostPair(state, requestedKind = 'native') {
         const created = await api(base, '/v1/selfhost/pair-sessions', {
             method: 'POST',
             headers: authHeaders,
-            body: JSON.stringify({ claim, machineSlug: state.machine.id }),
+            body: JSON.stringify({ claim, machineSlug: state.machine.id, deviceKind: requestedKind }),
         });
         if (!created.response.ok) throw new Error(created.body.error || `pair session failed (${created.response.status})`);
         const payload = Buffer.from(JSON.stringify({
@@ -1250,8 +1434,17 @@ async function runSelfhostPair(state, requestedKind = 'native') {
     }
 
     print('');
-    if (process.stdout.isTTY) print(await QRCode.toString(pending.pairUrl, { type: 'terminal', small: true }));
-    print('Pairing string (paste in the app if the QR is awkward):');
+    const browser = pending.deviceKind === 'browser';
+    const payload = new URL(pending.pairUrl).searchParams.get('payload');
+    const browserOrigin = publicRelayUrl(state.relayUrl)?.replace(/^wss/, 'https');
+    if (browser && browserOrigin && payload) {
+        print('Open this secure browser pairing link within five minutes:');
+        print(`${browserOrigin}/pair#payload=${payload}`);
+        print('The resulting browser access is read-only and expires after eight hours.');
+    } else if (process.stdout.isTTY) {
+        print(await QRCode.toString(pending.pairUrl, { type: 'terminal', small: true }));
+    }
+    print(browser ? 'Browser pairing string (paste into the hosted web client):' : 'Pairing string (paste in the app if the QR is awkward):');
     print(pending.pairUrl);
     const pairFile = join(stateDir(), 'pairing-link.txt');
     writeFileSync(pairFile, `${pending.pairUrl}\n`, { mode: 0o600 });
@@ -1327,9 +1520,17 @@ export async function runPair(args = []) {
         if (state?.machine?.crypto === undefined || typeof state.mintSecret !== 'string') {
             throw new Error('muxr is not set up yet; run `muxr setup` first');
         }
-        const healthy = await fetch(`http://127.0.0.1:${state.relayPort}/health`).then((response) => response.ok).catch(() => false);
-        if (!healthy) throw new Error('self-host relay is not running; run `muxr self-host --relay-only` first');
-        return await withSelfhostRotationLock(() => runSelfhostPair(state, args.includes('--browser') ? 'browser' : 'native'));
+        const browser = args.includes('--browser');
+        if (browser && (!state.webEnabled || !publicRelayUrl(state.relayUrl)?.startsWith('wss://'))) throw new Error('the browser client is off; run `muxr` and enable secure browser hosting first');
+        let healthy = await fetch(`http://127.0.0.1:${state.relayPort}/health`).then((response) => response.ok).catch(() => false);
+        if (!healthy) {
+            const definition = daemonDefinition('selfhost');
+            if (existsSync(definition.path)) await runDaemon(['restart']);
+            else await ensureSelfhostRelay(state.relayPort, state.webRoot, state.bindHost, state.webOrigin);
+            healthy = await fetch(`http://127.0.0.1:${state.relayPort}/health`).then((response) => response.ok).catch(() => false);
+        }
+        if (!healthy) throw new Error('the relay could not restart; run `muxr doctor` for the exact failing check');
+        return await withSelfhostRotationLock(() => runSelfhostPair(state, browser ? 'browser' : 'native'));
     } catch (cause) {
         error(cause instanceof Error ? cause.message : String(cause));
         return 1;
@@ -1559,6 +1760,17 @@ export async function runDoctor() {
     add(selfhost === undefined ? 'warn' : relayReady ? 'ok' : 'warn', 'self-host relay', selfhost === undefined
         ? 'not configured — run muxr setup'
         : relayReady ? `running on :${selfhost.relayPort}` : `configured on :${selfhost.relayPort}, not running`);
+    if (selfhost !== undefined) {
+        const ingressReady = selfhost.connectionMode !== 'cloudflare' || cloudflaredAlive(selfhost.ingress);
+        add(ingressReady ? 'ok' : 'warn', 'connection', ingressReady
+            ? `${selfhost.connectionMode ?? 'self-host'} · ${publicRelayUrl(selfhost.relayUrl) ?? `local port ${selfhost.relayPort}`}`
+            : 'Cloudflare tunnel is not running; run `muxr` to restore it and pair the new endpoint');
+        const hostRunning = daemonIsRunning();
+        add(hostRunning ? 'ok' : 'warn', 'host service', hostRunning ? 'running' : 'not running');
+        if (selfhost.webEnabled === true) add(ingressReady ? 'ok' : 'warn', 'web client', ingressReady
+            ? `${publicRelayUrl(selfhost.relayUrl)?.replace(/^ws/, 'http') ?? 'configured'} · read-only browser grants expire after eight hours`
+            : 'configured but unreachable until the tunnel is restored');
+    }
     const width = Math.max(...checks.map((check) => check.name.length));
     print();
     for (const check of checks) print(`  ${{ ok: 'ok  ', warn: 'warn', fail: 'FAIL' }[check.level]}  ${check.name.padEnd(width)}  ${check.detail}`);

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -109,7 +109,7 @@ await build({
     legalComments: 'none',
     logLevel: 'warning',
 });
-for (const file of ['cli.mjs', 'doctor.mjs', 'local-setup.mjs', 'setup-ui.mjs', 'setup-wizard.mjs', 'host-up.mjs', 'package.mjs']) {
+for (const file of ['cli.mjs', 'doctor.mjs', 'local-setup.mjs', 'setup-ui.mjs', 'setup-wizard.mjs', 'update.mjs', 'host-up.mjs', 'package.mjs']) {
     copyFileSync(join(root, 'scripts', file), join(out, file));
 }
 const extensionSource = readFileSync(join(root, 'scripts', 'plugin.mjs'), 'utf8');

--- a/scripts/setup-ui.mjs
+++ b/scripts/setup-ui.mjs
@@ -1,4 +1,4 @@
-import { emitKeypressEvents } from 'node:readline';
+import { createInterface, emitKeypressEvents } from 'node:readline';
 
 const interactive = () => Boolean(process.stdin.isTTY && process.stdout.isTTY);
 const ansi = (code, text) => interactive() && process.env.NO_COLOR === undefined ? `\x1b[${code}m${text}\x1b[0m` : text;
@@ -81,6 +81,24 @@ export async function select(message, choices, initial = 0) {
         };
         process.stdin.on('keypress', onKey);
     });
+}
+
+export async function prompt(message, initial = '') {
+    if (!interactive()) return initial;
+    const suffix = initial ? ` ${dim(`(${initial})`)}` : '';
+    const reader = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise((resolve) => {
+        let settled = false;
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            resolve(value);
+        };
+        reader.once('SIGINT', () => finish(undefined));
+        reader.question(`${bold(`◆ ${message}`)}${suffix}\n  › `, finish);
+    });
+    reader.close();
+    return typeof answer === 'string' ? answer.trim() || initial : undefined;
 }
 
 export async function withSpinner(label, task) {

--- a/scripts/setup-wizard.mjs
+++ b/scripts/setup-wizard.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { networkInterfaces } from 'node:os';
-import { intro, heading, status, note, outro, select, withSpinner } from './setup-ui.mjs';
-import { runBootstrap, runLocalPrerequisites, runSelfHost } from './local-setup.mjs';
+import { intro, heading, status, note, outro, prompt, select, withSpinner } from './setup-ui.mjs';
+import { runDoctor, runLocalPrerequisites, runPair, runSelfHost, selfhostPublicSummary } from './local-setup.mjs';
 
 function command(name, args = []) {
     const result = spawnSync(name, args, { encoding: 'utf8', timeout: 120_000 });
@@ -46,11 +46,15 @@ export function inspectSetup() {
     const integration = herdrVersion.ok ? command('herdr', ['integration', 'status']) : { ok: false, output: '' };
     const agents = integrationSummary(integration.output);
     const tailscale = command('tailscale', ['ip', '-4']);
+    const tailscaleStatus = tailscale.ok ? command('tailscale', ['status', '--json']) : { ok: false, output: '' };
+    let tailscaleDns;
+    try { tailscaleDns = JSON.parse(tailscaleStatus.output).Self?.DNSName?.replace(/\.$/, ''); }
+    catch { tailscaleDns = undefined; }
     const cloudflared = command('cloudflared', ['--version']);
     return {
         herdr: { installed: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrStatus.ok },
         agents,
-        tailscale: { installed: !tailscale.missing, connected: tailscale.ok && tailscale.output !== '', ip: tailscale.output.split('\n')[0] },
+        tailscale: { installed: !tailscale.missing, connected: tailscale.ok && tailscale.output !== '', ip: tailscale.output.split('\n')[0], dnsName: tailscaleDns },
         cloudflared: { installed: cloudflared.ok },
         lan: lanAddress(),
     };
@@ -121,24 +125,42 @@ async function choosePlugins() {
 }
 
 async function installPlugins(plugins) {
+    const installed = [];
+    const failed = [];
     for (const plugin of plugins) {
         heading(`Review ${plugin.repo}`);
         const result = interactiveCommand(herdr(), ['plugin', 'install', plugin.repo, '--ref', plugin.ref]);
-        if (!result.ok) status(plugin.title, `skipped — ${result.output || 'install failed'}`, 'warn');
-        else status(plugin.title, 'installed', 'ok');
+        if (!result.ok) {
+            failed.push(plugin);
+            status(plugin.title, `skipped — ${result.output || 'install failed'}`, 'warn');
+        } else {
+            installed.push(plugin);
+            status(plugin.title, 'installed', 'ok');
+        }
     }
+    return { installed, failed };
 }
 
 function choices(found) {
     const options = [];
     if (found.tailscale.connected) {
-        options.push({ value: 'tailscale', title: 'Self-host with Tailscale', description: 'recommended · private from anywhere' });
+        options.push({ value: 'tailscale', title: 'Tailscale Serve', description: 'recommended · private tailnet HTTPS/WSS' });
+        options.push({ value: 'tailscale-direct', title: 'Direct Tailscale IP', description: 'advanced · connect to the tailnet address and port' });
     }
-    options.push({ value: 'lan', title: 'Self-host on this network', description: 'phone stays on the same LAN' });
+    if (found.lan) options.push({ value: 'lan', title: 'Local network', description: 'phone stays on the same trusted LAN' });
+    options.push({ value: 'external', title: 'External URL for this relay', description: 'reverse proxy or domain pointing back to this machine' });
     if (found.cloudflared.installed) {
-        options.push({ value: 'cloudflare', title: 'Self-host with Cloudflare Tunnel', description: 'advanced · temporary public tunnel' });
+        options.push({ value: 'cloudflare', title: 'Cloudflare quick tunnel', description: 'temporary public HTTPS/WSS endpoint' });
     }
     return options;
+}
+
+function connectionLabel(mode, endpoint, port) {
+    if (mode === 'tailscale') return `Tailscale Serve on local port ${port}`;
+    if (mode === 'tailscale-direct') return `Direct Tailscale on port ${port}`;
+    if (mode === 'lan') return `Trusted LAN on port ${port}`;
+    if (mode === 'cloudflare') return `Cloudflare quick tunnel to local port ${port}`;
+    return `External ${endpoint}`;
 }
 
 export async function runSetup(args = []) {
@@ -152,6 +174,13 @@ export async function runSetup(args = []) {
         return 1;
     }
     const scripted = !fromPlugin && (!process.stdin.isTTY || !process.stdout.isTTY || automationFlags.some((flag) => args.includes(flag)));
+    if (args.includes('--inspect')) {
+        intro();
+        const found = await withSpinner('Inspecting Herdr, agents, and networking', async () => inspectSetup());
+        renderInspection(found);
+        outro('Inspection complete. Nothing changed.');
+        return 0;
+    }
     if (scripted) {
         const prerequisites = await runLocalPrerequisites(args);
         if (prerequisites !== 0) return prerequisites;
@@ -159,49 +188,170 @@ export async function runSetup(args = []) {
     }
 
     intro();
-    if (!fromPlugin && !args.includes('--inspect')) {
-        const bootstrapped = await runBootstrap(args);
-        if (bootstrapped !== 0) return bootstrapped;
-        outro('muxr is installed in Herdr. Open the muxr setup plugin to continue.');
-        return 0;
-    }
-
     const found = await withSpinner('Inspecting Herdr, agents, and networking', async () => inspectSetup());
     renderInspection(found);
-    if (args.includes('--inspect')) {
-        outro('Inspection complete. Nothing changed.');
-        return 0;
-    }
+    const current = await selfhostPublicSummary();
 
     let mode = requestedMode;
-    if (mode === 'selfhost') mode = found.tailscale.connected ? 'tailscale' : 'lan';
-    if (!mode) mode = await select('How should this machine connect?', choices(found));
-    if (!mode) return 1;
-
-    heading('Optional Herdr add-ons');
-    const plugins = await choosePlugins();
-    if (plugins === undefined) return 1;
-
-    if (!['tailscale', 'lan', 'cloudflare'].includes(mode)) {
+    if (mode === 'selfhost') mode = undefined;
+    if (!mode) {
+        const connectionChoices = choices(found).map((choice) => choice.value === current?.connectionMode
+            ? { ...choice, title: `${choice.title} · current` }
+            : choice);
+        const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
+        mode = await select('How should this machine connect?', connectionChoices, initial);
+    }
+    if (!mode) return 0;
+    if (!['tailscale', 'tailscale-direct', 'lan', 'external', 'cloudflare'].includes(mode)) {
         process.stderr.write(`unknown setup mode: ${mode}\n`);
         return 1;
     }
+    if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected) {
+        process.stderr.write('Tailscale is not connected; choose Local network or External URL for this relay\n');
+        return 1;
+    }
+    if (mode === 'lan' && !found.lan) {
+        process.stderr.write('no local network address was found; choose another connection method\n');
+        return 1;
+    }
+    if (mode === 'cloudflare' && !found.cloudflared.installed) {
+        process.stderr.write('cloudflared is not installed; choose another connection method\n');
+        return 1;
+    }
 
-    note(mode === 'tailscale'
-        ? ['Tailscale was detected. No ports will be opened to the public internet.', 'muxr will start Herdr, your agent integrations, the relay, and the host.']
-        : mode === 'cloudflare'
-            ? ['Cloudflare creates a public relay URL. Payloads remain end-to-end encrypted.', 'Use a named tunnel for a permanent deployment.']
-            : ['The relay will be reachable only from this local network.', 'Pair only on a network you trust; agent payloads remain end-to-end encrypted.']);
+    let port;
+    while (port === undefined) {
+        const portText = await prompt('Local relay port', value(args, '--port') ?? String(current?.relayPort ?? 8792));
+        if (portText === undefined) return 0;
+        const parsed = Number(portText);
+        if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
+        else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
+    }
+    let endpoint;
+    if (mode === 'external') {
+        while (endpoint === undefined) {
+            const entered = await prompt('External relay URL (wss://...)', current?.connectionMode === 'external' ? current.relayUrl : '');
+            if (entered === undefined) return 0;
+            try {
+                const parsed = new URL(entered);
+                if (parsed.protocol === 'wss:' && parsed.hostname && !parsed.username && !parsed.password && parsed.pathname === '/' && !parsed.search && !parsed.hash) endpoint = parsed.toString().replace(/\/$/, '');
+                else status('External relay URL', 'use a root wss://host URL without credentials, query, or fragment', 'warn');
+            } catch {
+                status('External relay URL', 'use a valid wss:// URL', 'warn');
+            }
+        }
+    }
 
-    const prerequisites = await runLocalPrerequisites(args);
+    const secureWebMode = ['tailscale', 'external', 'cloudflare'].includes(mode);
+    const web = secureWebMode
+        ? await select('Host the read-only browser client too?', [
+            { value: false, title: 'Native app only', description: 'do not expose the browser client' },
+            { value: true, title: 'Host the browser client', description: 'serve it over the selected HTTPS/WSS connection' },
+        ], current?.webEnabled ? 1 : 0)
+        : false;
+    if (web === undefined) return 0;
+    if (!secureWebMode) status('Browser client', 'requires Tailscale Serve, External WSS, or Cloudflare; native app only', 'off');
+    const desiredUrl = mode === 'lan' ? `ws://${found.lan}:${port}`
+        : mode === 'external' ? endpoint
+            : mode === 'tailscale-direct' ? `ws://${found.tailscale.ip}:${port}`
+                : mode === 'tailscale' && found.tailscale.dnsName ? `wss://${found.tailscale.dnsName}`
+                    : mode === 'cloudflare'
+                        && current?.connectionMode === 'cloudflare'
+                        && current.relayPort === port
+                        && current.webEnabled === web
+                        && current.ingressHealthy === true
+                        ? current.relayUrl
+                        : undefined;
+    const connectionChanged = current === undefined || desiredUrl === undefined || current.relayUrl !== desiredUrl;
+    const pairingChoices = [
+        ...(!connectionChanged ? [{ value: 'none', title: 'Keep paired devices', description: 'no new QR; existing devices keep working' }] : []),
+        { value: 'phone', title: 'Phone', description: 'pair the native app first' },
+        ...(web ? [
+            { value: 'browser', title: 'Browser', description: 'pair one read-only browser for eight hours' },
+            { value: 'both', title: 'Phone, then browser', description: 'complete both pairing steps' },
+        ] : []),
+    ];
+    const pairing = await select(connectionChanged ? 'The endpoint changed. Which client should pair again?' : 'Pair another client?', pairingChoices);
+    if (pairing === undefined) return 0;
+
+    const installHerdr = found.herdr.installed ? false : await select('Herdr is required. Install it during setup?', [
+        { value: false, title: 'Cancel setup', description: 'leave this machine unchanged' },
+        { value: true, title: 'Install Herdr', description: 'download the public installer, then verify the installation' },
+    ]);
+    if (!found.herdr.installed && installHerdr !== true) return 0;
+
+    const syncIntegrations = await select('Sync the detected coding-agent integrations?', [
+        { value: true, title: 'Sync detected integrations', description: `${found.agents.available.length} available · keeps lifecycle status current` },
+        { value: false, title: 'Leave integrations unchanged', description: 'do not install or alter coding-agent hooks' },
+    ]);
+    if (syncIntegrations === undefined) return 0;
+
+    heading('Optional Herdr add-ons');
+    const plugins = await choosePlugins();
+    if (plugins === undefined) return 0;
+
+    heading('Review setup');
+    note([
+        `Connection: ${connectionLabel(mode, endpoint, port)}`,
+        `Herdr: ${found.herdr.installed ? 'adopt existing installation and ensure its server is running' : 'download, install, and start after your explicit selection'}`,
+        'Bundled plugins: link the public muxr plugins into Herdr',
+        `Agent integrations: ${syncIntegrations ? 'sync detected providers and managed instruction blocks' : 'leave hooks and instruction files unchanged'}`,
+        `Optional add-ons: ${plugins.length ? plugins.map((plugin) => plugin.title).join(', ') : 'none'}`,
+        `Browser client: ${web ? 'host read-only web app; browser keys stay WebCrypto-wrapped on this device' : 'off'}`,
+        `Pairing: ${pairing === 'none' ? 'keep existing devices; no new pairing' : pairing === 'both' ? 'phone, then browser' : pairing}${pairing === 'browser' || pairing === 'both' ? ' · browser access is read-only for eight hours' : ''}`,
+        `Ingress: ${mode === 'tailscale' ? 'persist a muxr-owned Tailscale Serve route' : mode === 'cloudflare' ? 'start a tracked temporary Cloudflare tunnel' : mode === 'external' ? 'bind loopback for your external reverse proxy' : 'no proxy or public tunnel changes'}`,
+        'Services: register or restart the relay and host with systemd/launchd',
+        `Existing connections: ${connectionChanged ? 'the public endpoint changes, so every previously paired device needs a fresh pairing link' : 'keep working; restart only if a reviewed runtime setting changed'}`,
+        'No change is made until you choose Apply setup.',
+    ]);
+    const apply = await select('Apply this setup?', [
+        { value: false, title: 'Cancel', description: 'leave this machine unchanged' },
+        { value: true, title: 'Apply setup', description: 'make the reviewed changes, verify health, then show the pairing QR' },
+    ]);
+    if (apply !== true) {
+        outro('Cancelled. Nothing changed.');
+        return 0;
+    }
+
+    const prerequisiteArgs = [
+        ...args.filter((arg) => arg !== '--from-plugin'),
+        ...(found.herdr.installed ? [] : ['--install-herdr']),
+        ...(syncIntegrations ? [] : ['--no-integrations']),
+    ];
+    const prerequisites = await runLocalPrerequisites(prerequisiteArgs);
     if (prerequisites !== 0) return prerequisites;
-    await installPlugins(plugins);
-    const modeIndex = args.indexOf('--mode');
-    const dropped = new Set(modeIndex >= 0 ? [modeIndex, modeIndex + 1] : []);
-    const selfhostArgs = args.filter((arg, index) => !arg.startsWith('--mode=') && !dropped.has(index) && arg !== '--from-plugin');
-    if (mode === 'lan' && found.lan) selfhostArgs.push('--advertise', `ws://${found.lan}:${value(args, '--port') ?? 8792}`);
+    const pluginResult = await installPlugins(plugins);
+    const selfhostArgs = ['--port', String(port), '--connection-mode', mode, '--reconfigure'];
+    if (mode === 'lan') selfhostArgs.push('--advertise', `ws://${found.lan}:${port}`);
+    if (mode === 'external') selfhostArgs.push('--advertise', endpoint);
     if (mode === 'cloudflare') selfhostArgs.push('--tunnel');
+    if (mode === 'tailscale-direct') selfhostArgs.push('--tailscale-direct');
+    if (web) selfhostArgs.push('--web', '--yes');
+    if (pairing === 'browser') selfhostArgs.push('--pair-browser');
+    if (pairing === 'none') selfhostArgs.push('--no-pair');
     const result = await runSelfHost(selfhostArgs);
-    if (result === 0) outro('Paired. Your agents are ready in muxr.');
-    return result;
+    if (result !== 0) return result;
+    const browserPairFailed = pairing === 'both' && (await runPair(['--browser'])) !== 0;
+    const doctor = await runDoctor();
+    if (doctor !== 0) return doctor;
+    const summary = await selfhostPublicSummary();
+    heading('Setup complete');
+    note([
+        `Connection: ${connectionLabel(mode, endpoint, port)}`,
+        'Relay location: this machine',
+        `Relay URL: ${summary?.relayUrl ?? 'unavailable'}`,
+        `Web URL: ${summary?.webUrl ?? 'off'}`,
+        `Relay service: ${summary?.relayHealthy ? 'running' : 'check required'}`,
+        `Host service: ${summary?.hostRunning ? 'running' : 'check required'}`,
+        `Herdr: ${found.herdr.running ? 'running' : 'started during setup'}`,
+        `Integrations: ${syncIntegrations ? 'selected providers synced' : 'unchanged'}`,
+        `Pairing: ${pairing === 'none' ? 'existing devices kept' : browserPairFailed ? 'phone paired; browser pairing failed' : pairing === 'both' ? 'phone and browser paired' : `${pairing} paired`}${!browserPairFailed && (pairing === 'browser' || pairing === 'both') ? ' · browser expires in eight hours' : ''}`,
+        `Plugins: bundled${pluginResult.installed.length ? ` + ${pluginResult.installed.map((plugin) => plugin.title).join(', ')}` : ''}`,
+        ...(pluginResult.failed.length ? [`Plugin install failed: ${pluginResult.failed.map((plugin) => plugin.title).join(', ')}`] : []),
+        'Configuration: ~/.muxr (owner-only)',
+    ]);
+    outro(pairing === 'none'
+        ? 'Setup updated. Existing devices will reconnect automatically.'
+        : 'Paired. Open muxr on your phone, or run `muxr` anytime to change these choices.');
+    return browserPairFailed ? 1 : 0;
 }

--- a/scripts/update.mjs
+++ b/scripts/update.mjs
@@ -1,0 +1,126 @@
+import { createRequire } from 'node:module';
+import { spawnSync } from 'node:child_process';
+import { daemonIsRunning, daemonMode, restartSelfhostRelayIfRunning, runBootstrap, runDaemon, stopSelfhostRelayIfRunning } from './local-setup.mjs';
+import { select } from './setup-ui.mjs';
+
+const PACKAGE = '@trymuxr/cli';
+
+function currentVersion() {
+    const require = createRequire(import.meta.url);
+    try { return require('./package.json').version; }
+    catch { return require('../package.json').version; }
+}
+
+function npm(args, stdio = 'pipe') {
+    return spawnSync(process.env.MUXR_NPM_BIN?.trim() || 'npm', args, {
+        encoding: stdio === 'pipe' ? 'utf8' : undefined,
+        stdio,
+    });
+}
+
+export function compareVersions(left, right) {
+    const parse = (value) => {
+        const match = value.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+        return match && { numbers: match.slice(1, 4).map(Number), prerelease: match[4]?.split('.') };
+    };
+    const a = parse(left);
+    const b = parse(right);
+    if (!a || !b) return undefined;
+    for (let index = 0; index < 3; index += 1) {
+        if (a.numbers[index] !== b.numbers[index]) return a.numbers[index] - b.numbers[index];
+    }
+    if (a.prerelease === undefined && b.prerelease === undefined) return 0;
+    if (a.prerelease === undefined) return 1;
+    if (b.prerelease === undefined) return -1;
+    const length = Math.max(a.prerelease.length, b.prerelease.length);
+    for (let index = 0; index < length; index += 1) {
+        const leftIdentifier = a.prerelease[index];
+        const rightIdentifier = b.prerelease[index];
+        if (leftIdentifier === rightIdentifier) continue;
+        if (leftIdentifier === undefined) return -1;
+        if (rightIdentifier === undefined) return 1;
+        const leftNumeric = /^\d+$/.test(leftIdentifier);
+        const rightNumeric = /^\d+$/.test(rightIdentifier);
+        if (leftNumeric && rightNumeric) return Number(leftIdentifier) - Number(rightIdentifier);
+        if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+        return leftIdentifier < rightIdentifier ? -1 : 1;
+    }
+    return 0;
+}
+
+export async function runUpdate(args = []) {
+    const current = currentVersion();
+    const lookup = npm(['view', PACKAGE, 'dist-tags.latest', '--json']);
+    if (lookup.status !== 0) {
+        process.stderr.write(`Could not check npm: ${(lookup.stderr || lookup.stdout || 'npm failed').trim()}\n`);
+        return 1;
+    }
+
+    let latest;
+    try { latest = JSON.parse(lookup.stdout.trim()); }
+    catch { latest = lookup.stdout.trim(); }
+    if (typeof latest !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(latest)) {
+        process.stderr.write('npm returned an invalid muxr version\n');
+        return 1;
+    }
+    const comparison = compareVersions(latest, current);
+    if (comparison === undefined) {
+        process.stderr.write('installed muxr version is invalid\n');
+        return 1;
+    }
+    if (comparison <= 0) {
+        process.stdout.write(comparison === 0
+            ? `muxr ${current} is current.\n`
+            : `muxr ${current} is newer than npm latest (${latest}); nothing changed.\n`);
+        return 0;
+    }
+
+    process.stdout.write(`muxr ${latest} is available (installed: ${current}).\n`);
+    if (args.includes('--check')) return 0;
+
+    let approved = args.includes('--yes');
+    if (!approved && process.stdin.isTTY && process.stdout.isTTY) {
+        process.stdout.write([
+            'Update plan:',
+            `  • install ${PACKAGE}@${latest}`,
+            '  • ensure the Herdr server is running and relink bundled plugins',
+            '  • restart the muxr relay and host if they are running',
+            '',
+        ].join('\n'));
+        approved = await select('Apply this update?', [
+            { value: false, title: 'Not now', description: 'leave this installation unchanged' },
+            { value: true, title: 'Update muxr', description: `install ${PACKAGE}@${latest} and apply the plan above` },
+        ]) === true;
+    }
+    if (!approved) {
+        process.stdout.write(`Nothing changed. Run \`muxr update --yes\` when ready.\n`);
+        return 0;
+    }
+
+    const restart = daemonIsRunning();
+    const restartMode = daemonMode();
+    const install = npm(['install', '-g', `${PACKAGE}@${latest}`], 'inherit');
+    if (install.status !== 0) return install.status ?? 1;
+
+    if ((await runBootstrap(['--no-install-herdr'])) !== 0) {
+        process.stderr.write('The package updated, but plugin refresh failed. Run `muxr doctor`.\n');
+        return 1;
+    }
+    let relayRestarted = false;
+    try {
+        if (restart) {
+            if ((await runDaemon(['stop'])) !== 0) throw new Error('host service did not stop');
+            if (restartMode === 'selfhost') relayRestarted = await stopSelfhostRelayIfRunning();
+            if ((await runDaemon(['start'])) !== 0) throw new Error('host service did not start');
+            relayRestarted = restartMode === 'selfhost';
+        } else {
+            relayRestarted = await restartSelfhostRelayIfRunning();
+        }
+    } catch (cause) {
+        process.stderr.write(`The package updated, but the managed services did not restart: ${cause instanceof Error ? cause.message : String(cause)}\n`);
+        return 1;
+    }
+    const restarted = [relayRestarted ? 'relay' : '', restart ? 'host' : ''].filter(Boolean).join(' and ');
+    process.stdout.write(`Updated muxr to ${latest}${restarted ? ` and restarted the ${restarted}` : ''}.\n`);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- make no-argument `muxr` the guided setup and maintenance entry point with read-only inspection, persisted defaults, a Cancel-first Apply gate, explicit networking/web/plugin choices, and a non-secret completion summary
- add downgrade-safe `muxr update`, supervised relay+host lifecycle, macOS/Linux service hardening, exact Tailscale/Cloudflare ownership cleanup, and truthful doctor output
- make native and browser pairing explicit and recoverable: server-bound client authority, authenticated re-pairing, clickable HTTPS browser links, read-only/8-hour browser UX, endpoint visibility, and permanent credential error handling

## Verification
- `node scripts/runSuite.mjs` — all gates pass; one live Herdr event run timed out once under an 83-pane workspace and passed immediately on isolated rerun
- `yarn pack:smoke`
- `yarn workspace @muxr/mobile typecheck`
- `node scripts/checkSelfhostRevocation.mjs`
- `node scripts/checkTailscaleIngress.mjs`
- independent final reviews from Claude, Codex, and Kimi: SHIP, no blocker/high findings

## Notes
- shared remote-relay enrollment is intentionally not included; it requires a separate machine-scoped authority protocol rather than exporting the relay mint secret
