### PR TITLE
Discover agent catalog and CLI usage at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ Drive every coding agent on your machine — Pi, Claude Code, Codex, Cursor, and
 - **Attention inbox:** surface blocked agents and answer approvals from your phone.
 - **Changes and attachments:** inspect per-run git changes and receive screenshots,
   APKs, exports, and other artifacts from the pane that produced them.
-- **Start agents and squads:** choose an agent, directory, optional worktree, or
-  start several agents together.
+- **Start agents and squads:** choose from the bounded agent catalog reported by
+  the connected Herdr host, select a directory and optional worktree, or start
+  several agents together. A safe fallback remains available offline.
+- **Usage at a glance:** aggregate available coding-CLI limits. Codex uses its
+  local app-server contract directly; CLIs without a guaranteed non-model usage
+  API are reported as available with an honest in-CLI `/usage` action.
 - **Voice:** start an explicit provider-neutral realtime conversation through a
   backend plugin, or dictate editable text locally with bundled Whisper Base
   English. Provider credentials stay on the host; dictation audio never leaves

--- a/apps/host/src/fakeSessionSource.ts
+++ b/apps/host/src/fakeSessionSource.ts
@@ -95,6 +95,10 @@ export function createFakeSessionSource(): SessionSource {
             return [];
         },
 
+        async agentKinds() {
+            return ['pi', 'claude', 'codex'];
+        },
+
         async pluginList() {
             return [];
         },

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -1288,6 +1288,14 @@ export async function createHerdrSessionSource(
             };
         },
 
+        async agentKinds(): Promise<string[]> {
+            const result = await client.call<{ manifests?: Array<{ agent?: string }> }>('server.agent_manifests', {});
+            return [...new Set((result.manifests ?? [])
+                .map((manifest) => manifest.agent?.trim())
+                .filter((agent): agent is string => agent !== undefined && /^[a-z][a-z0-9_-]{0,31}$/.test(agent)))]
+                .slice(0, 64);
+        },
+
         async herdrTree(): Promise<HerdrTreeWorkspace[]> {
             // Cached maps are event-fresh; a snapshot call here would work too but
             // the Spaces screen polls, so keep this free.

--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -54,6 +54,7 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
         },
         'session.open': (params) => source.open(params),
         'herdr.tree': async () => ({ workspaces: await source.herdrTree() }),
+        'herdr.agentKinds': async () => ({ kinds: await source.agentKinds() }),
         'plugin.list': () => { throw new Error('authenticated device context required'); },
         'plugin.manifest': (params) => source.pluginManifest(params),
         'plugin.approve': () => { throw new Error('authenticated device context required'); },
@@ -178,7 +179,7 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
             const readOnly = options.canMutateDevice?.(deviceId) === false;
             const readOnlyRequests = new Set<RequestType>([
                 'session.list', 'session.open', 'session.status',
-                'herdr.tree', 'herdr.layout', 'pane.read', 'plugin.list', 'plugin.manifest',
+                'herdr.tree', 'herdr.agentKinds', 'herdr.layout', 'pane.read', 'plugin.list', 'plugin.manifest',
                 'attachment.fetch', 'attachment.read', 'unread.catalog',
                 'attention.catalog', 'machines.list', 'terminal.attach',
             ]);

--- a/apps/host/src/sessionSource.ts
+++ b/apps/host/src/sessionSource.ts
@@ -85,6 +85,8 @@ export interface SessionSource {
     refreshPlugins?(): Promise<void>;
     /** The whole herd: workspaces -> tabs -> panes with live agent state. */
     herdrTree(): Promise<HerdrTreeWorkspace[]>;
+    /** Agent kinds supported by the connected Herdr host. */
+    agentKinds(): Promise<string[]>;
     /** Immutable native UI plugin catalog and snapshots. */
     pluginList(deviceId: string): Promise<PluginSummary[]>;
     pluginManifest(options: { pluginId: string; manifestHash: string }): Promise<PluginManifestV1>;

--- a/apps/mobile/sources/app/(app)/new-agent.tsx
+++ b/apps/mobile/sources/app/(app)/new-agent.tsx
@@ -33,7 +33,7 @@ import {
     saveConnectionSettings,
 } from '@/state/connectionSettings';
 
-import { AGENT_KINDS as KINDS } from '@/sync/agentKinds';
+import { FALLBACK_AGENT_KINDS } from '@/sync/agentKinds';
 
 const MAX_SQUAD = 4;
 const MAX_RECENT_CHIPS = 6;
@@ -207,6 +207,8 @@ export default function NewAgentScreen() {
     const insets = useSafeAreaInsets();
     const settings = getCachedConnectionSettings();
 
+    const [catalog, setCatalog] = React.useState<readonly string[]>(FALLBACK_AGENT_KINDS);
+    const [catalogSource, setCatalogSource] = React.useState<'loading' | 'host' | 'fallback'>('loading');
     const [selected, setSelected] = React.useState<ReadonlySet<string>>(new Set(['pi']));
     const [cwd, setCwd] = React.useState(settings.lastSessionCwd ?? '');
     const [worktree, setWorktree] = React.useState(false);
@@ -222,6 +224,21 @@ export default function NewAgentScreen() {
                 if (live) setWorkspaces(tree.workspaces ?? []);
             })
             .catch(() => {});
+        void sync
+            .request('herdr.agentKinds', {})
+            .then((result) => {
+                if (!live) return;
+                const kinds = [...new Set((result.kinds ?? []).filter((kind) => /^[a-z][a-z0-9_-]{0,31}$/.test(kind)))].slice(0, 64);
+                if (kinds.length === 0) { setCatalogSource('fallback'); return; }
+                setCatalog(kinds);
+                setCatalogSource('host');
+                setSelected((previous) => {
+                    const supported = new Set([...previous].filter((kind) => kinds.includes(kind)));
+                    if (supported.size === 0) supported.add(kinds[0]!);
+                    return supported;
+                });
+            })
+            .catch(() => { if (live) setCatalogSource('fallback'); });
         return () => {
             live = false;
         };
@@ -310,15 +327,20 @@ export default function NewAgentScreen() {
                 <View>
                     <View style={styles.sectionLabelRow}>
                         <Text style={styles.sectionLabel}>AGENT</Text>
-                        {squad && (
-                            <View style={styles.squadBadge}>
-                                <Ionicons name="grid" size={11} color={theme.colors.accent} />
-                                <Text style={styles.squadBadgeText}>SQUAD {kinds.length}</Text>
-                            </View>
-                        )}
+                        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                            <Text style={styles.squadBadgeText}>
+                                {catalogSource === 'host' ? 'FROM HERDR' : catalogSource === 'loading' ? 'CHECKING HOST' : 'OFFLINE FALLBACK'}
+                            </Text>
+                            {squad && (
+                                <View style={styles.squadBadge}>
+                                    <Ionicons name="grid" size={11} color={theme.colors.accent} />
+                                    <Text style={styles.squadBadgeText}>SQUAD {kinds.length}</Text>
+                                </View>
+                            )}
+                        </View>
                     </View>
                     <View style={styles.grid}>
-                        {KINDS.map((option) => {
+                        {catalog.map((option) => {
                             const isSelected = selected.has(option);
                             return (
                                 <Pressable

--- a/apps/mobile/sources/sync/agentKinds.ts
+++ b/apps/mobile/sources/sync/agentKinds.ts
@@ -1,11 +1,9 @@
-/**
- * `herdr agent start --kind` values. One list, so the new-agent screen and the
- * split-with-agent picker cannot drift apart. Mirrors `herdr agent start --help`;
- * kinds the installed herdr doesn't know fail gracefully at start time.
- */
-export const AGENT_KINDS = [
+/** Safe offline fallback. Connected screens replace this with the bounded
+ * catalog reported by the current Herdr host. Persistence keeps the superset so
+ * an existing session remains readable while the host is offline. */
+export const FALLBACK_AGENT_KINDS = [
     'pi', 'claude', 'codex', 'gemini', 'cursor', 'devin', 'agy', 'cline', 'omp',
     'mastracode', 'opencode', 'copilot', 'kimi', 'kiro', 'droid', 'amp', 'grok',
     'hermes', 'kilo', 'qodercli', 'maki',
 ] as const;
-export const COMMON_AGENT_KINDS = AGENT_KINDS;
+export const AGENT_KINDS = FALLBACK_AGENT_KINDS;

--- a/packages/contract/src/requests.ts
+++ b/packages/contract/src/requests.ts
@@ -71,6 +71,7 @@ export interface RequestMap {
     };
     /** The whole herd: workspaces -> tabs -> panes with live agent state. */
     'herdr.tree': { params: Record<string, never>; result: { workspaces: HerdrTreeWorkspace[] } };
+    'herdr.agentKinds': { params: Record<string, never>; result: { kinds: string[] } };
     /** Immutable native UI plugin catalog. Safe to enumerate from read-only clients. */
     'plugin.list': {
         params: Record<string, never>;

--- a/plugins/usage-status/rpc.mjs
+++ b/plugins/usage-status/rpc.mjs
@@ -1,10 +1,85 @@
 #!/usr/bin/env node
-import { execFile } from 'node:child_process';
-const child = execFile('pi', ['--print', '--mode', 'json', '--no-session', '--no-tools', '--no-skills', '-np', '--no-context-files', '/quota'], { timeout: 30000, maxBuffer: 1024 * 1024 }, (error, stdout) => {
-  if (error) process.exit(1);
-  for (const line of stdout.split('\n').reverse()) {
-    try { const event = JSON.parse(line); if (event.message?.customType === 'subscription-usage') { process.stdout.write(JSON.stringify(event.message.content)); return; } } catch {}
+import { spawn } from 'node:child_process';
+import { constants, accessSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+function available(command) {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    try { accessSync(join(directory, command), constants.X_OK); return true; } catch {}
   }
-  process.stdout.write(JSON.stringify('Usage unavailable'));
-});
-child.stdin?.end();
+  return false;
+}
+
+function codexUsage() {
+  if (!available('codex')) return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    const child = spawn('codex', ['app-server'], { stdio: ['pipe', 'pipe', 'ignore'] });
+    let buffer = '';
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill('SIGTERM');
+      setTimeout(() => { if (child.exitCode === null) child.kill('SIGKILL'); }, 1_000).unref();
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(undefined), 8_000);
+    child.once('error', () => finish(undefined));
+    child.stdin.on('error', () => finish(undefined));
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      buffer += chunk;
+      if (buffer.length > 64 * 1024) { finish(undefined); return; }
+      for (;;) {
+        const newline = buffer.indexOf('\n');
+        if (newline < 0) break;
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        try {
+          const message = JSON.parse(line);
+          if (message.id === 1) child.stdin.write(`${JSON.stringify({ id: 2, method: 'account/rateLimits/read', params: {} })}\n`);
+          if (message.id === 2) finish(message.result);
+        } catch {}
+      }
+    });
+    child.stdin.write(`${JSON.stringify({ id: 1, method: 'initialize', params: { clientInfo: { name: 'muxr', version: '1' } } })}\n`);
+  });
+}
+
+function relativeReset(seconds) {
+  if (!Number.isFinite(seconds) || seconds * 1000 < Date.now() - 86_400_000 || seconds * 1000 > Date.now() + 366 * 86_400_000) return '';
+  let minutes = Math.max(0, Math.ceil((seconds * 1000 - Date.now()) / 60_000));
+  const days = Math.floor(minutes / 1440); minutes -= days * 1440;
+  const hours = Math.floor(minutes / 60); minutes = Math.floor(minutes - hours * 60);
+  return [days && `${days}d`, hours && `${hours}h`, !days && minutes && `${minutes}m`].filter(Boolean).join(' ');
+}
+
+function codexText(result) {
+  const limits = Object.values(result?.rateLimitsByLimitId ?? {});
+  if (!limits.length && result?.rateLimits) limits.push(result.rateLimits);
+  if (!limits.length) return undefined;
+  return ['OpenAI Codex', ...limits.slice(0, 16).map((limit) => {
+    const window = limit.primary;
+    const name = String(limit.limitName ?? limit.limitId ?? 'Codex').replace(/[^\x20-\x7e]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80) || 'Codex';
+    const left = Number.isFinite(window?.usedPercent) ? `${Math.max(0, Math.min(100, 100 - window.usedPercent))}% left` : 'usage available';
+    const reset = relativeReset(window?.resetsAt);
+    return `  ${name}  ${left}${reset ? ` · resets in ${reset}` : ''}`;
+  })].join('\n');
+}
+
+const sections = [];
+const codexAvailable = available('codex');
+const codex = codexText(await codexUsage());
+if (codex) sections.push(codex);
+else if (codexAvailable) sections.push('OpenAI Codex\n  CLI available · open /usage in that CLI for current limits');
+const visible = [
+  ['pi', 'Pi'],
+  ['claude', 'Anthropic Claude'],
+  ['kimi', 'Kimi Code'],
+  ['cursor', 'Cursor'],
+  ['grok', 'xAI Grok'],
+  ['gemini', 'Gemini CLI'],
+].filter(([command]) => available(command)).map(([, name]) => `${name}\n  CLI available · open /usage in that CLI for current limits`);
+sections.push(...visible);
+process.stdout.write(JSON.stringify(sections.join('\n') || 'Usage unavailable'));

--- a/scripts/checkHerdrE2E.mjs
+++ b/scripts/checkHerdrE2E.mjs
@@ -147,6 +147,10 @@ async function run() {
     send(socket, { type: 'client.hello', clientId: 'herdr-e2e' });
     const discovered = await request(socket, 'session.list', {});
     console.log(`ok: session.list returned ${discovered.length} herdr session(s)`);
+    const catalog = await request(socket, 'herdr.agentKinds', {});
+    if (!Array.isArray(catalog?.kinds) || catalog.kinds.length === 0 || catalog.kinds.length > 64
+        || !catalog.kinds.every((kind) => /^[a-z][a-z0-9_-]{0,31}$/.test(kind))) fail('herdr.agentKinds returned an invalid catalog');
+    console.log(`ok: herdr.agentKinds returned ${catalog.kinds.length} host-supported kind(s)`);
 
     // 2. session.start (async agent.start: the answer must beat the 20s client timeout)
     const started = await request(socket, 'session.start', { cwd: workdir, kind: 'pi', label: 'e2e' });

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const scratch = mkdtempSync(join(tmpdir(), 'muxr-usage-'));
+const piMarker = join(scratch, 'pi-ran');
+try {
+    writeFileSync(join(scratch, 'pi'), `#!/bin/sh\ntouch "${piMarker}"\nexit 99\n`, { mode: 0o755 });
+    writeFileSync(join(scratch, 'codex'), `#!/usr/bin/env node\nlet b='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>{b+=d;for(;;){const i=b.indexOf('\\n');if(i<0)break;const line=b.slice(0,i);b=b.slice(i+1);const m=JSON.parse(line);if(m.id===1)console.log(JSON.stringify({id:1,result:{}}));if(m.id===2)console.log(JSON.stringify({id:2,result:{rateLimitsByLimitId:{codex:{limitId:'codex',primary:{usedPercent:25,resetsAt:Math.floor(Date.now()/1000)+3600}}}}}));}});\n`, { mode: 0o755 });
+    for (const command of ['claude', 'kimi', 'grok']) writeFileSync(join(scratch, command), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const result = spawnSync(process.execPath, ['plugins/usage-status/rpc.mjs'], {
+        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}` }, timeout: 15_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const text = JSON.parse(result.stdout);
+    assert.match(text, /OpenAI Codex[\s\S]*75% left/);
+    assert.match(text, /Anthropic Claude[\s\S]*open \/usage in that CLI/);
+    assert.match(text, /Kimi Code[\s\S]*open \/usage in that CLI/);
+    assert.ok(!existsSync(piMarker), 'Usage plugin invoked Pi and could enter a paid model path');
+
+    rmSync(join(scratch, 'codex'));
+    const fallback = spawnSync(process.execPath, ['plugins/usage-status/rpc.mjs'], {
+        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: scratch }, timeout: 15_000,
+    });
+    assert.equal(fallback.status, 0, fallback.stderr);
+    const fallbackText = JSON.parse(fallback.stdout);
+    assert.doesNotMatch(fallbackText, /OpenAI Codex/);
+    assert.match(fallbackText, /Anthropic Claude[\s\S]*open \/usage in that CLI/);
+    assert.ok(!existsSync(piMarker), 'Fallback Usage invoked Pi');
+    process.stdout.write('PASS e2e: safe multi-provider usage aggregation\n');
+} finally {
+    rmSync(scratch, { recursive: true, force: true });
+}

--- a/scripts/runSuite.mjs
+++ b/scripts/runSuite.mjs
@@ -30,6 +30,7 @@ const checks = [
     ['e2e: device pairing through relay', 'node', ['scripts/checkPairing.mjs']],
     ['e2e: durable self-host device revocation', 'node', ['scripts/checkSelfhostRevocation.mjs']],
     ['e2e: shared remote relay isolation', 'node', ['scripts/checkRemoteRelay.mjs']],
+    ['e2e: multi-provider usage aggregation', 'node', ['scripts/checkUsageStatus.mjs']],
     ['e2e: tailscale ingress ownership', 'node', ['scripts/checkTailscaleIngress.mjs']],
     ['e2e: voice plugin secret lifecycle', 'node', ['scripts/checkVoicePlugin.mjs']],
     ['e2e: strict auth (local fixture exposure)', 'node', ['scripts/checkStrictAuth.mjs']],


### PR DESCRIPTION
## Summary
- populate the new-agent/squad picker from the connected Herdr host's bounded `server.agent_manifests` catalog through a public read-only request contract
- keep the compiled superset only as an explicit offline fallback and show `CHECKING HOST`, `FROM HERDR`, or `OFFLINE FALLBACK` in the picker
- replace Pi-only Usage with a zero-model-call aggregator: Codex reads local `account/rateLimits/read`; other installed CLIs get honest `/usage` guidance without execution
- bound Codex subprocess time, output, rendering, and termination; never render tokens, costs, credentials, or arbitrary provider text

## Verification
- `node scripts/runSuite.mjs` — 29/29
- `node scripts/checkUsageStatus.mjs`
- live `node scripts/checkHerdrE2E.mjs` — 19 host-supported kinds returned
- `yarn build`
- `yarn workspace @muxr/mobile typecheck`
- Claude, Codex, and Kimi: SHIP, no blocker/high findings; Usage 9/10, picker 9/10
