### PR TITLE
Use pinned ccusage for local agent activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Drive every coding agent on your machine — Pi, Claude Code, Codex, Cursor, and
 - **Start agents and squads:** choose from the bounded agent catalog reported by
   the connected Herdr host, select a directory and optional worktree, or start
   several agents together. A safe fallback remains available offline.
-- **Usage at a glance:** aggregate available coding-CLI limits. Codex uses its
-  local app-server contract directly; CLIs without a guaranteed non-model usage
-  API are reported as available with an honest in-CLI `/usage` action.
+- **Usage at a glance:** pinned [ccusage](https://github.com/ccusage/ccusage) reads local coding-agent logs offline
+  for today's per-agent activity, while Codex's local app-server reports current
+  rate limits. Costs, prompts, models, and session details stay out of the card;
+  other installed CLIs get an honest in-CLI `/usage` action.
 - **Voice:** start an explicit provider-neutral realtime conversation through a
   backend plugin, or dictate editable text locally with bundled Whisper Base
   English. Provider credentials stay on the host; dictation audio never leaves

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -15,6 +15,8 @@ The interactive onboarding inspects the machine, then asks you to choose the con
 
 Run `muxr` with no arguments for the interactive setup and maintenance menu. The same menu can host a supervised shared relay on a VPS, create one-use machine enrollments, or connect a local Herdr host using only a machine-scoped credential.
 
+The bundled Usage card runs the exact pinned [ccusage](https://github.com/ccusage/ccusage) backend offline against local coding-agent logs and shows today's allowlisted per-agent token totals without costs, prompts, models, or session details. npm installs one platform-specific ccusage binary (about 4 MB) for Linux or macOS. Current Codex percentages come from its local app-server; other coding CLIs are never invoked.
+
 ```bash
 muxr update                    # check, confirm, update, and restart
 muxr update --check            # check without changing anything

--- a/docs/specs/plugin-primitives.html
+++ b/docs/specs/plugin-primitives.html
@@ -31,7 +31,7 @@
     <li>Hard-kill stuck RPCs, isolate concurrency, and stop repeated full catalog reparsing.</li>
     <li>Publish schemas and prove bundled plus adversarial third-party plugins on Android.</li>
   </ol></div>
-  <div class="card"><h2>Latest revision</h2><p>UI version 11 adds a bounded declarative <code>code</code> node. One app-owned Prism tokenizer now renders plugin previews, native/web file views, Markdown code fences, and native diff lines with shared theme colors, line numbers, selection, and safe plain-text fallback. File previews read at most 24 KiB / 240 lines and report truncation; plugins still ship no HTML or native code.</p></div>
+  <div class="card"><h2>Latest revision</h2><p>Usage now delegates local multi-agent activity to an exact pinned ccusage native backend in offline/no-cost mode, then allowlists only agent names and rounded total-token counts; only the final bounded card text is cached for one minute. Codex current limits still use its bounded local API; other CLIs are never executed. UI version 11 also adds one app-owned Prism tokenizer for plugin previews, native/web files, Markdown fences, and native diff lines.</p></div>
   <div class="card"><h2>Verification</h2><ul class="check">
     <li>Automation passes 29/29; all 17 bundled plugins and adversarial combinations validate correctly.</li>
     <li>The v11 manifest/tokenization flow, mobile typecheck, web export, and Android production JS bundle pass.</li>

--- a/docs/specs/plugin-primitives.md
+++ b/docs/specs/plugin-primitives.md
@@ -46,6 +46,8 @@ RPC contributions may explicitly request `sessions` and/or `workspace-tree`. Imm
 
 Run Server now owns Linux/macOS listener discovery, project-cwd filtering, HTTP probes, labels, refresh cadence, and whether its generic `item-list` control exists. UI version 5 removes `url-chip`; active-only bounded item-list polling stops when unfocused and force-refreshes on open. The plugin returns only a validated `{ target: "preview", port }` kernel action. The compiled preview route/transport owns `preview.list` fallback and `preview.attach`; no primitive calls either request or accepts an arbitrary HTTP/file URL.
 
+The Usage plugin now uses the exact pinned ccusage native package as its backend aggregator. It runs one bounded `daily --last 1 --by-agent --json --no-cost --offline` read over local agent logs, allowlists names and total-token counts, caches only the final bounded card text for one minute, and never exposes costs, prompts, models, or session details. Codex current limits still come from its local app-server; other CLIs are detected but never executed.
+
 UI version 11 adds a bounded declarative `code` node with app-owned Prism tokenization, line numbers, selection, shared theme tokens, and plain-text fallback. The same tokenizer now powers native/web file views, Markdown code fences, and native diff lines, replacing the duplicate hand-rolled regex highlighter. File previews read at most 24 KiB / 240 lines and report truncation; ordinary text remains capped at 4 KiB while a sanitized RPC result string may use the existing 64 KiB total transport budget. UI version 7 adds plugin-owned navigation badge read sources and singleton tree-sheet cardinality. UI version 6 makes user-visible manifest strings bounded localized values with exact-locale, base-locale, then default fallback on the phone. The same public `shortcuts` contribution drives build-time localized Assistant resources and the live Android launcher projection. Runtime-installed plugins cannot add Assistant capability bindings because Android only accepts those from packaged XML; a third-party plugin included in a custom build receives the identical build-time behavior.
 
 ## Files
@@ -82,6 +84,7 @@ UI version 11 adds a bounded declarative `code` node with app-owned Prism tokeni
 
 ## Revisions
 
+- 2026-08-17 — Usage now delegates local multi-agent activity to an exact pinned ccusage backend in offline/no-cost mode while retaining the bounded local Codex limit API and never invoking other coding CLIs.
 - 2026-08-17 — Unified file, Markdown, plugin code, and native diff highlighting on the existing Prism dependency so third-party plugins receive the same bounded renderer without HTML or native modules.
 - 2026-08-15 — Replace feature-named native renderers with primitives; attachments/changes become pull RPCs.
 - 2026-08-15 — Primitives are slot-agnostic and may repeat in one slot. Initial Voice token transport contract added (superseded by the provider-neutral backend stream on 2026-08-16). Herd tree no longer refreshes on every status tick.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
+        "ccusage": "20.0.20",
         "ws": "^8.18.0"
     },
     "engines": {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -10,7 +10,7 @@ These packages install into Herdr during muxr setup. Each can have an optional H
 | `inbox` | public session context RPC | Inbox tab using the source-driven `collection` primitive |
 | `changes` | `git status` list RPC | session pill using `item-list` |
 | `attachments` | dump-dir list RPC | session pill using `item-list` |
-| `usage-status` | bounded quota RPC | declarative data card |
+| `usage-status` | pinned offline ccusage + bounded Codex limits | declarative data card |
 | `terminal-keys` | none | declarative terminal key row |
 | `dictation` | none | home composer using `dictate` |
 | `workspace-hierarchy` | public workspace-tree context RPC | session overlay using source-driven `tree-sheet` |

--- a/plugins/usage-status/README.md
+++ b/plugins/usage-status/README.md
@@ -1,3 +1,10 @@
 # Usage status
 
-Bundled native usage card. It invokes the installed Pi quota command through the existing authenticated machine shell boundary and stores no credentials.
+Read-only coding-agent usage card.
+
+- **Local activity:** runs the exact pinned [ccusage](https://github.com/ccusage/ccusage) native binary with `daily --last 1 --by-agent --json --no-cost --offline`. It reads local coding-agent logs, makes no model or pricing request, and returns only allowlisted agent names plus rounded total-token counts.
+- **Current Codex limits:** queries the installed Codex local app-server API and renders only bounded percentages and reset times.
+- **Other CLIs:** PATH-only detection with guidance to open that CLI's own `/usage`; muxr never invokes those CLIs.
+- **Bounds:** ccusage gets 15 seconds in parallel with Codex's 8-second call, each subprocess output is capped at 64 KiB, and timeout/error falls back without breaking the card.
+- **State/secrets:** keeps only a one-minute owner-only cache of the final bounded card text and receives the plugin runner's restricted `HOME`, `PATH`, and `MUXR_*` environment. Cost fields and model/session details are never cached or rendered.
+- **Offline:** local activity uses ccusage's offline mode; missing binaries or logs degrade to live limits and availability rows.

--- a/plugins/usage-status/rpc.mjs
+++ b/plugins/usage-status/rpc.mjs
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { constants, accessSync } from 'node:fs';
+import { constants, accessSync, chmodSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { delimiter, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+let ccusageFailure;
+const AGENTS = {
+  claude: 'Anthropic Claude', codex: 'OpenAI Codex', opencode: 'OpenCode', amp: 'Amp', droid: 'Droid', codebuff: 'Codebuff',
+  hermes: 'Hermes Agent', pi: 'Pi', goose: 'Goose', openclaw: 'OpenClaw', kilo: 'Kilo Code', kimi: 'Kimi Code', qwen: 'Qwen',
+  copilot: 'GitHub Copilot CLI', cursor: 'Cursor', gemini: 'Gemini CLI', grok: 'xAI Grok',
+};
 
 function available(command) {
   for (const directory of (process.env.PATH ?? '').split(delimiter)) {
@@ -10,22 +19,128 @@ function available(command) {
   return false;
 }
 
+function ccusageBinary() {
+  if (process.env.MUXR_CCUSAGE_BIN?.trim()) return process.env.MUXR_CCUSAGE_BIN.trim();
+  const target = {
+    'darwin-arm64': '@ccusage/ccusage-darwin-arm64', 'darwin-x64': '@ccusage/ccusage-darwin-x64',
+    'linux-arm64': '@ccusage/ccusage-linux-arm64', 'linux-x64': '@ccusage/ccusage-linux-x64',
+  }[`${process.platform}-${process.arch}`];
+  if (!target) return undefined;
+  try {
+    const binary = require.resolve(`${target}/bin/ccusage`);
+    try { accessSync(binary, constants.X_OK); }
+    catch {
+      try { chmodSync(binary, 0o755); }
+      catch { ccusageFailure = 'ccusage backend is not executable · reinstall muxr without sudo'; return undefined; }
+    }
+    return binary;
+  } catch { ccusageFailure = 'ccusage backend is missing · reinstall muxr'; return undefined; }
+}
+
+function runJson(command, args, timeout = 8_000) {
+  if (!command) return Promise.resolve(undefined);
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'ignore'] });
+    let buffer = '';
+    let settled = false;
+    let escalation;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (child.exitCode === null) {
+        child.kill('SIGTERM');
+        escalation = setTimeout(() => { if (child.exitCode === null) child.kill('SIGKILL'); }, 1_000);
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(undefined), timeout);
+    child.once('error', () => finish(undefined));
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      buffer += chunk;
+      if (buffer.length > 64 * 1024) finish(undefined);
+    });
+    child.once('close', (code) => {
+      if (escalation) clearTimeout(escalation);
+      if (code !== 0) { finish(undefined); return; }
+      try { finish(JSON.parse(buffer)); } catch { finish(undefined); }
+    });
+  });
+}
+
+async function ccusageDaily() {
+  const binary = ccusageBinary();
+  if (!binary) return undefined;
+  const result = await runJson(binary, ['daily', '--last', '1', '--by-agent', '--json', '--no-cost', '--offline'], 15_000);
+  if (result === undefined && ccusageFailure === undefined) ccusageFailure = 'ccusage activity unavailable · reopen Usage in a minute';
+  return result;
+}
+
+function tokens(value) {
+  if (!Number.isSafeInteger(value) || value < 0) return undefined;
+  if (value >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(Math.round(value));
+}
+
+function ccusageText(result) {
+  const totals = new Map();
+  for (const day of Array.isArray(result?.daily) ? result.daily.slice(0, 1) : []) {
+    for (const row of Array.isArray(day?.agents) ? day.agents.slice(0, 32) : []) {
+      if (!Object.hasOwn(AGENTS, row?.agent) || !Number.isSafeInteger(row.totalTokens) || row.totalTokens < 0) continue;
+      totals.set(row.agent, (totals.get(row.agent) ?? 0) + row.totalTokens);
+    }
+  }
+  const lines = [...totals].sort((a, b) => b[1] - a[1]).slice(0, 16).flatMap(([agent, total]) => {
+    const value = tokens(total);
+    return value === undefined ? [] : [`  ${AGENTS[agent]}  ${value} tokens`];
+  });
+  return lines.length ? { text: ['Local activity today · ccusage', ...lines].join('\n'), agents: new Set(totals.keys()) } : undefined;
+}
+
+function cachedOutput() {
+  const state = process.env.MUXR_PLUGIN_STATE_DIR?.trim();
+  if (!state) return undefined;
+  try {
+    const saved = JSON.parse(readFileSync(join(state, 'usage.json'), 'utf8'));
+    if (Date.now() - saved.at < 60_000 && typeof saved.text === 'string' && saved.text.length <= 8192) return saved.text;
+  } catch {}
+  return undefined;
+}
+
+function saveOutput(text) {
+  const state = process.env.MUXR_PLUGIN_STATE_DIR?.trim();
+  if (!state) return;
+  const cache = join(state, 'usage.json');
+  const temporary = `${cache}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify({ at: Date.now(), text }), { mode: 0o600 });
+    renameSync(temporary, cache);
+  } catch {}
+}
+
 function codexUsage() {
   if (!available('codex')) return Promise.resolve(undefined);
   return new Promise((resolve) => {
     const child = spawn('codex', ['app-server'], { stdio: ['pipe', 'pipe', 'ignore'] });
     let buffer = '';
     let settled = false;
+    let escalation;
     const finish = (value) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      child.kill('SIGTERM');
-      setTimeout(() => { if (child.exitCode === null) child.kill('SIGKILL'); }, 1_000).unref();
+      if (child.exitCode === null) {
+        child.kill('SIGTERM');
+        escalation = setTimeout(() => { if (child.exitCode === null) child.kill('SIGKILL'); }, 1_000);
+      }
       resolve(value);
     };
     const timer = setTimeout(() => finish(undefined), 8_000);
     child.once('error', () => finish(undefined));
+    child.once('close', () => { if (escalation) clearTimeout(escalation); finish(undefined); });
     child.stdin.on('error', () => finish(undefined));
     child.stdout.setEncoding('utf8');
     child.stdout.on('data', (chunk) => {
@@ -59,27 +174,35 @@ function codexText(result) {
   const limits = Object.values(result?.rateLimitsByLimitId ?? {});
   if (!limits.length && result?.rateLimits) limits.push(result.rateLimits);
   if (!limits.length) return undefined;
-  return ['OpenAI Codex', ...limits.slice(0, 16).map((limit) => {
+  return ['OpenAI Codex limits', ...limits.slice(0, 16).map((limit) => {
     const window = limit.primary;
     const name = String(limit.limitName ?? limit.limitId ?? 'Codex').replace(/[^\x20-\x7e]+/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80) || 'Codex';
-    const left = Number.isFinite(window?.usedPercent) ? `${Math.max(0, Math.min(100, 100 - window.usedPercent))}% left` : 'usage available';
+    const left = Number.isFinite(window?.usedPercent) ? `${Math.round(Math.max(0, Math.min(100, 100 - window.usedPercent)))}% left` : 'usage available';
     const reset = relativeReset(window?.resetsAt);
     return `  ${name}  ${left}${reset ? ` · resets in ${reset}` : ''}`;
   })].join('\n');
 }
 
-const sections = [];
-const codexAvailable = available('codex');
-const codex = codexText(await codexUsage());
-if (codex) sections.push(codex);
-else if (codexAvailable) sections.push('OpenAI Codex\n  CLI available · open /usage in that CLI for current limits');
-const visible = [
-  ['pi', 'Pi'],
-  ['claude', 'Anthropic Claude'],
-  ['kimi', 'Kimi Code'],
-  ['cursor', 'Cursor'],
-  ['grok', 'xAI Grok'],
-  ['gemini', 'Gemini CLI'],
-].filter(([command]) => available(command)).map(([, name]) => `${name}\n  CLI available · open /usage in that CLI for current limits`);
-sections.push(...visible);
-process.stdout.write(JSON.stringify(sections.join('\n') || 'Usage unavailable'));
+const cached = cachedOutput();
+if (cached !== undefined) {
+  process.stdout.write(JSON.stringify(cached));
+} else {
+  const sections = [];
+  const codexAvailable = available('codex');
+  const [activity, codex] = await Promise.all([
+    ccusageDaily().then(ccusageText),
+    codexUsage().then(codexText),
+  ]);
+  if (activity) sections.push(activity.text);
+  else if (ccusageFailure) sections.push(`Local activity\n  ${ccusageFailure}`);
+  if (codex) sections.push(codex);
+  else if (codexAvailable) sections.push('OpenAI Codex limits\n  CLI available · open /usage in that CLI for current limits');
+  const active = activity?.agents ?? new Set();
+  const visible = [
+    ['pi', 'pi'], ['claude', 'claude'], ['kimi', 'kimi'], ['cursor', 'cursor'], ['grok', 'grok'], ['gemini', 'gemini'],
+  ].filter(([command, agent]) => available(command) && !active.has(agent)).map(([, agent]) => `${AGENTS[agent] ?? agent}\n  CLI available · open /usage in that CLI for current limits`);
+  sections.push(...visible);
+  const output = sections.join('\n') || 'Usage unavailable';
+  saveOutput(output);
+  process.stdout.write(JSON.stringify(output));
+}

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -240,12 +240,22 @@ try {
     assert.equal(licenseInventory.bundledInputs, undefined);
     assert.ok(!JSON.stringify(licenseInventory).includes(`${root}/`), 'license inventory leaked a repository path');
     for (const dependency of licenseInventory.dependencies) {
-        assert.equal(dependency.declaredRange, dependency.bundled ? null : packageJson.dependencies[dependency.name]);
+        if (dependency.transitiveOf !== undefined) {
+            assert.equal(dependency.declaredRange, null);
+            assert.equal(dependency.transitiveOf, 'ccusage');
+            assert.equal(dependency.auditedVersion, packageJson.dependencies.ccusage);
+        } else {
+            assert.equal(dependency.declaredRange, dependency.bundled ? null : packageJson.dependencies[dependency.name]);
+        }
         assert.match(dependency.auditedVersion, /^\d+\.\d+\.\d+/);
         assert.equal(dependency.version, undefined, 'ambiguous dependency version field returned');
     }
     assert.equal(packageJson.name, '@trymuxr/cli');
     assert.deepEqual(packageJson.bin, { muxr: './cli.mjs' });
+    assert.equal(packageJson.dependencies.ccusage, '20.0.20', 'packed CLI did not pin the reviewed ccusage backend');
+    for (const target of ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64']) {
+        assert.ok(licenseInventory.dependencies.some((dependency) => dependency.name === `@ccusage/ccusage-${target}` && dependency.transitiveOf === 'ccusage'), `${target} ccusage binary missing from license audit`);
+    }
 
     writeFileSync(join(installDir, 'package.json'), '{"private":true}\n');
     run('npm', ['install', '--ignore-scripts', '--no-audit', '--no-fund', tarball], {
@@ -253,6 +263,42 @@ try {
         env: { ...process.env, npm_config_cache: join(scratch, 'npm-cache') },
     });
     const cli = join(installDir, 'node_modules', '.bin', 'muxr');
+    assert.ok(existsSync(join(installDir, 'node_modules', 'ccusage', 'src', 'cli.js')), 'ccusage wrapper missing from installed package');
+    const ccusageTarget = ['linux', 'darwin'].includes(process.platform) && ['x64', 'arm64'].includes(process.arch)
+        ? join(installDir, 'node_modules', '@ccusage', `ccusage-${process.platform}-${process.arch}`, 'bin', 'ccusage')
+        : undefined;
+    if (ccusageTarget !== undefined) {
+        assert.ok(existsSync(ccusageTarget), `ccusage native backend missing for ${process.platform}-${process.arch}`);
+        const usageHome = join(scratch, 'usage-home');
+        const claudeLogs = join(usageHome, '.claude', 'projects', 'smoke', 'session');
+        mkdirSync(claudeLogs, { recursive: true });
+        writeFileSync(join(claudeLogs, 'chat.jsonl'), `${JSON.stringify({
+            costUSD: 0,
+            message: { id: 'smoke', model: 'claude-sonnet-4-20250514', role: 'assistant', usage: { cache_creation_input_tokens: 0, cache_read_input_tokens: 0, input_tokens: 1, output_tokens: 1 } },
+            requestId: 'smoke-request', sessionId: 'smoke-session', timestamp: new Date().toISOString(), version: '2.0.0',
+        })}\n`);
+        const usagePlugin = join(installDir, 'node_modules', '@trymuxr', 'cli', 'plugins', 'usage-status', 'rpc.mjs');
+        run(process.execPath, [usagePlugin], { cwd: installDir, env: { ...process.env, HOME: usageHome, PATH: binDir } });
+        assert.notEqual(statSync(ccusageTarget).mode & 0o111, 0, 'packaged ccusage backend stayed non-executable');
+        const resolveScript = `const {createRequire}=require('node:module');process.stdout.write(createRequire(${JSON.stringify(usagePlugin)}).resolve('@ccusage/ccusage-${process.platform}-${process.arch}/bin/ccusage'))`;
+        const resolvedCcusage = run(process.execPath, ['-e', resolveScript], { cwd: installDir }).stdout;
+        assert.equal(resolvedCcusage, ccusageTarget, 'Usage plugin did not resolve its installed native ccusage package');
+        const probe = run(resolvedCcusage, ['daily', '--last', '1', '--by-agent', '--json', '--no-cost', '--offline'], {
+            cwd: installDir,
+            env: { ...process.env, HOME: usageHome, HTTPS_PROXY: 'http://127.0.0.1:1', HTTP_PROXY: 'http://127.0.0.1:1' },
+        });
+        const parsedProbe = JSON.parse(probe.stdout);
+        assert.ok(Array.isArray(parsedProbe.daily), 'pinned ccusage changed its --by-agent JSON shape');
+        assert.ok(parsedProbe.daily.length > 0, 'ccusage fixture produced no daily row; shape assertions would be vacuous');
+        for (const day of parsedProbe.daily) {
+            assert.ok(Array.isArray(day.agents), 'pinned ccusage omitted daily[].agents');
+            for (const agent of day.agents) {
+                assert.equal(typeof agent.agent, 'string');
+                assert.equal(typeof agent.totalTokens, 'number');
+            }
+        }
+        assert.ok(parsedProbe.daily.some((day) => day.agents.some((agent) => agent.agent === 'claude')), 'ccusage agent ids no longer match the Usage allowlist');
+    }
     const installedUpdate = await import(new URL(`file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'update.mjs')}`).href);
     assert.ok(installedUpdate.compareVersions('1.0.0-beta.10', '1.0.0-beta.9') > 0);
     assert.ok(installedUpdate.compareVersions('1.0.0-beta.9', '1.0.0-beta.10') < 0);

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -1,35 +1,57 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const scratch = mkdtempSync(join(tmpdir(), 'muxr-usage-'));
 const piMarker = join(scratch, 'pi-ran');
+const ccusageMarker = join(scratch, 'ccusage-ran');
+const codexMarker = join(scratch, 'codex-ran');
+const ccusage = join(scratch, 'ccusage');
 try {
     writeFileSync(join(scratch, 'pi'), `#!/bin/sh\ntouch "${piMarker}"\nexit 99\n`, { mode: 0o755 });
-    writeFileSync(join(scratch, 'codex'), `#!/usr/bin/env node\nlet b='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>{b+=d;for(;;){const i=b.indexOf('\\n');if(i<0)break;const line=b.slice(0,i);b=b.slice(i+1);const m=JSON.parse(line);if(m.id===1)console.log(JSON.stringify({id:1,result:{}}));if(m.id===2)console.log(JSON.stringify({id:2,result:{rateLimitsByLimitId:{codex:{limitId:'codex',primary:{usedPercent:25,resetsAt:Math.floor(Date.now()/1000)+3600}}}}}));}});\n`, { mode: 0o755 });
+    writeFileSync(ccusage, `#!/bin/sh\n[ "$*" = "daily --last 1 --by-agent --json --no-cost --offline" ] || exit 77\nprintf x >> "${ccusageMarker}"\nprintf '%s' '${JSON.stringify({
+        daily: [{ date: '2026-08-17', agents: [
+            { agent: 'claude', totalTokens: 1_250_000, inputTokens: 42, totalCost: 123.45 },
+            { agent: 'kimi', totalTokens: 2500 },
+            { agent: 'pi', totalTokens: 800 },
+            { agent: 'hostile\\nname', totalTokens: 999999 },
+        ] }],
+        totals: { totalTokens: 1_253_300, totalCost: 123.45 },
+    })}'\n`, { mode: 0o755 });
+    writeFileSync(join(scratch, 'codex'), `#!/usr/bin/env node\nrequire('fs').appendFileSync(${JSON.stringify(codexMarker)}, 'x');let b='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>{b+=d;for(;;){const i=b.indexOf('\\n');if(i<0)break;const line=b.slice(0,i);b=b.slice(i+1);const m=JSON.parse(line);if(m.id===1)console.log(JSON.stringify({id:1,result:{}}));if(m.id===2)console.log(JSON.stringify({id:2,result:{rateLimitsByLimitId:{codex:{limitId:'codex',primary:{usedPercent:25,resetsAt:Math.floor(Date.now()/1000)+3600}}}}}));}});\n`, { mode: 0o755 });
     for (const command of ['claude', 'kimi', 'grok']) writeFileSync(join(scratch, command), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
     const result = spawnSync(process.execPath, ['plugins/usage-status/rpc.mjs'], {
-        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}` }, timeout: 15_000,
+        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch }, timeout: 20_000,
     });
     assert.equal(result.status, 0, result.stderr);
     const text = JSON.parse(result.stdout);
-    assert.match(text, /OpenAI Codex[\s\S]*75% left/);
-    assert.match(text, /Anthropic Claude[\s\S]*open \/usage in that CLI/);
-    assert.match(text, /Kimi Code[\s\S]*open \/usage in that CLI/);
+    assert.match(text, /Local activity today · ccusage[\s\S]*Anthropic Claude  1\.3M tokens[\s\S]*Kimi Code  2\.5K tokens[\s\S]*Pi  800 tokens/);
+    assert.match(text, /OpenAI Codex limits[\s\S]*75% left/);
+    assert.doesNotMatch(text, /123\.45|totalCost|inputTokens|hostile/);
+    assert.doesNotMatch(text, /Anthropic Claude\n  CLI available/);
+    assert.ok(existsSync(ccusageMarker), 'Usage plugin did not invoke its pinned ccusage backend');
     assert.ok(!existsSync(piMarker), 'Usage plugin invoked Pi and could enter a paid model path');
+    const cached = spawnSync(process.execPath, ['plugins/usage-status/rpc.mjs'], {
+        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch }, timeout: 20_000,
+    });
+    assert.equal(cached.status, 0, cached.stderr);
+    assert.match(JSON.parse(cached.stdout), /Local activity today · ccusage/);
+    assert.equal(readFileSync(ccusageMarker, 'utf8'), 'x', 'one-minute cache did not prevent a duplicate ccusage scan');
+    assert.equal(readFileSync(codexMarker, 'utf8'), 'x', 'one-minute cache did not prevent a duplicate Codex app-server');
 
+    rmSync(join(scratch, 'usage.json'));
     rmSync(join(scratch, 'codex'));
     const fallback = spawnSync(process.execPath, ['plugins/usage-status/rpc.mjs'], {
-        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: scratch }, timeout: 15_000,
+        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: scratch, MUXR_CCUSAGE_BIN: join(scratch, 'missing') }, timeout: 20_000,
     });
     assert.equal(fallback.status, 0, fallback.stderr);
     const fallbackText = JSON.parse(fallback.stdout);
-    assert.doesNotMatch(fallbackText, /OpenAI Codex/);
+    assert.doesNotMatch(fallbackText, /OpenAI Codex|Local activity today/);
     assert.match(fallbackText, /Anthropic Claude[\s\S]*open \/usage in that CLI/);
     assert.ok(!existsSync(piMarker), 'Fallback Usage invoked Pi');
-    process.stdout.write('PASS e2e: safe multi-provider usage aggregation\n');
+    process.stdout.write('PASS e2e: bounded offline ccusage aggregation + safe live limits\n');
 } finally {
     rmSync(scratch, { recursive: true, force: true });
 }

--- a/scripts/pack.mjs
+++ b/scripts/pack.mjs
@@ -21,7 +21,7 @@ const root = process.cwd();
 const out = join(root, 'dist-npm');
 const rootPackage = require(join(root, 'package.json'));
 const version = rootPackage.version ?? '0.1.0';
-const runtimeDependencies = { ws: '^8.18.0', tweetnacl: '^1.0.3', qrcode: '^1.5.4', 'web-push': '^3.6.7' };
+const runtimeDependencies = { ccusage: rootPackage.dependencies.ccusage, ws: '^8.18.0', tweetnacl: '^1.0.3', qrcode: '^1.5.4', 'web-push': '^3.6.7' };
 const external = Object.keys(runtimeDependencies);
 rmSync(out, { recursive: true, force: true });
 mkdirSync(out, { recursive: true });
@@ -74,8 +74,34 @@ const bundledDependencies = [...bundledPackagePaths]
     .sort()
     .map((path) => ({ ...packageInfoFromPath(path, true), declaredRange: null }));
 const bundledNames = new Set(bundledDependencies.map(({ name }) => name));
+const ccusagePlatformRoot = join(root, 'node_modules', '@ccusage');
+const ccusageManifestPath = join(root, 'node_modules', 'ccusage', 'package.json');
+const ccusageManifest = JSON.parse(readFileSync(ccusageManifestPath, 'utf8'));
+const ccusagePackage = packageInfoFromPath(ccusageManifestPath, false);
+const ccusagePlatformDependencies = ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64'].map((target) => {
+    const name = `@ccusage/ccusage-${target}`;
+    const version = ccusageManifest.optionalDependencies?.[name];
+    if (version !== rootPackage.dependencies.ccusage) throw new Error(`license audit: ccusage does not pin ${name} to ${rootPackage.dependencies.ccusage}`);
+    const installedManifest = join(ccusagePlatformRoot, `ccusage-${target}`, 'package.json');
+    if (existsSync(installedManifest)) {
+        const pkg = JSON.parse(readFileSync(installedManifest, 'utf8'));
+        if (pkg.name !== name || pkg.license !== ccusagePackage.license || pkg.version !== version) {
+            throw new Error(`license audit: ccusage platform metadata mismatch for ${pkg.name}@${pkg.version}`);
+        }
+    }
+    return {
+        name,
+        auditedVersion: version,
+        license: ccusagePackage.license,
+        bundled: false,
+        licensePath: ccusagePackage.licensePath,
+        declaredRange: null,
+        transitiveOf: 'ccusage',
+    };
+});
 const dependencies = [
     ...bundledDependencies,
+    ...ccusagePlatformDependencies,
     ...external
         .filter((name) => !bundledNames.has(name))
         .sort()

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,36 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
   integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
 
+"@ccusage/ccusage-darwin-arm64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-darwin-arm64/-/ccusage-darwin-arm64-20.0.20.tgz#c762ffc7f32236c934adee85ea0fa21b04f67713"
+  integrity sha512-TgvU1u9bjgBD+CuQqj55PNAl3LnrW9awCeXDkPS0acntTP72A4gdGjCBZ+LAmR8HECBlvD9lSDqWHhpCX9kZQw==
+
+"@ccusage/ccusage-darwin-x64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-darwin-x64/-/ccusage-darwin-x64-20.0.20.tgz#f00485da1b8771e1f772fbc3537f18837aef31f3"
+  integrity sha512-UkanWl+XRiC7rgTG7eZDy4xqleQOZ3xd8i6RBW77p2OhHheBpGznMkqS7/5rPT2JQ10cnkOKqjxFE09CLAmIrQ==
+
+"@ccusage/ccusage-linux-arm64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-linux-arm64/-/ccusage-linux-arm64-20.0.20.tgz#50e083b5915c2d29f0fc475863759c60830e5993"
+  integrity sha512-iiURX4sqr3S7jrDJW6P6F0QtP6lx7lkhqqxBQXzaL/66xjhUkCDHKzRglixPuSBxkNaKGL6RAtKGk/ubFGvdBg==
+
+"@ccusage/ccusage-linux-x64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-linux-x64/-/ccusage-linux-x64-20.0.20.tgz#1e23ebb111e1c8db483bebf9bf7bd884ea49646a"
+  integrity sha512-qG5LcyerzKJVPu3hTRHYaWo6VtKB9uyGbRdviw4imInIWRQdPcrEAIb22oCO7iWEfAEv5ZYmTjYWJLX+dR5HXg==
+
+"@ccusage/ccusage-win32-arm64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-win32-arm64/-/ccusage-win32-arm64-20.0.20.tgz#cbdcf3e1c4d1836133fc89a728ba22277c85b2a2"
+  integrity sha512-BUXxVGbZ6WtA8RGqjukzkKFmS2x2cjMTV1kU5weZ4+K/uPHIHJjDIDnSKJtNAllwpwlPKpC+k3UdhkapeVM10w==
+
+"@ccusage/ccusage-win32-x64@20.0.20":
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/@ccusage/ccusage-win32-x64/-/ccusage-win32-x64-20.0.20.tgz#be4ceaca27fe0565e6c889efc616015428fb57bb"
+  integrity sha512-6R9cdLuRy529ewdkKbwtjx7boCQNFK8KG1F6d5G/pw2ApKRmucWcwjFo/7sNULQtZMyUxhYa40tUnWy9L/yTMA==
+
 "@chevrotain/types@~11.1.2":
   version "11.1.2"
   resolved "https://registry.yarnpkg.com/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
@@ -3719,6 +3749,18 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
+
+ccusage@20.0.20:
+  version "20.0.20"
+  resolved "https://registry.yarnpkg.com/ccusage/-/ccusage-20.0.20.tgz#895da27d8a171d52af60eb4b9107844ec3f60b93"
+  integrity sha512-xctCxhwK4Nqo1i3zSa1+JM3wN/oSdPSglzgxIWZyk9KLsLyQQMfntG3NJHoRH3DJHzkvG1EzVwH/xSI2z6VH3Q==
+  optionalDependencies:
+    "@ccusage/ccusage-darwin-arm64" "20.0.20"
+    "@ccusage/ccusage-darwin-x64" "20.0.20"
+    "@ccusage/ccusage-linux-arm64" "20.0.20"
+    "@ccusage/ccusage-linux-x64" "20.0.20"
+    "@ccusage/ccusage-win32-arm64" "20.0.20"
+    "@ccusage/ccusage-win32-x64" "20.0.20"
 
 chai@^5.2.0:
   version "5.3.3"


### PR DESCRIPTION
## Summary
- pin `ccusage@20.0.20` as the Usage backend and invoke its platform-native binary directly
- read today's local multi-agent activity with exact `daily --last 1 --by-agent --json --no-cost --offline` flags
- keep Codex's bounded local rate-limit API for current plan headroom; never invoke other coding CLIs
- render only allowlisted agent names, rounded token totals, Codex percentages, and reset times
- cache only final bounded card text for one minute, including negative results
- audit and inventory all four supported Linux/macOS ccusage binaries
- document privacy, package size, state, fallback, and exact trust boundary

## Security / privacy
- no shell and no downloaded runtime code
- no model calls; offline ccusage + Codex local app-server only
- no costs, prompts, models, project names, or session details reach the card/cache
- 15s ccusage and 8s Codex calls run in parallel, each capped at 64 KiB with referenced SIGKILL cleanup
- missing/non-executable backend produces an honest user-visible fallback

## Verification
- full suite: 29/29 passed in 76.6s
- focused Usage E2E passed (exact argv, allowlist, no Pi execution, cost/detail stripping, positive and negative cache behavior)
- installed-package smoke passed with scripts disabled
- package smoke executes the production `require.resolve` + chmod path, runs the real pinned binary with invalid HTTP(S) proxies, and verifies non-vacuous `daily[].agents[].agent/totalTokens` plus the real `claude` id
- all Linux/macOS platform binary licenses are present in `THIRD_PARTY_LICENSES.json`
- clean packed CLI cold call produced ccusage activity with costs absent
- independent read-only review: SHIP, no blockers/high findings
