### PR TITLE
Sanitize plugin errors; Git history empty state

### DIFF
--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -513,7 +513,7 @@ export function runPluginProcess(options: RunPluginProcessOptions): Promise<unkn
         });
         child.once('error', () => {
             if (escalationTimer !== undefined) { clearTimeout(escalationTimer); escalationTimer = undefined; }
-            finish(() => reject(new Error((stderr.toString('utf8').trim() || 'plugin call failed').slice(0, 500))));
+            finish(() => reject(new Error(pluginStderrMessage(stderr, 'plugin call failed'))));
         });
         child.once('close', (code) => {
             if (escalationTimer !== undefined) {
@@ -527,7 +527,7 @@ export function runPluginProcess(options: RunPluginProcessOptions): Promise<unkn
             finish(() => {
                 if (stdoutOversize) { reject(new Error(`plugin ${options.pluginId}.${options.method} output exceeded ${MAX_RPC_STDOUT_BYTES} bytes`)); return; }
                 if (code !== 0) {
-                    reject(new Error((stderr.toString('utf8').trim() || `plugin exited with code ${code}`).slice(0, 500)));
+                    reject(new Error(pluginStderrMessage(stderr, `plugin exited with code ${code}`)));
                     return;
                 }
                 try { resolve(boundRpcDisplay(JSON.parse(stdout.toString('utf8')))); }
@@ -542,6 +542,17 @@ export function runPluginProcess(options: RunPluginProcessOptions): Promise<unkn
         options.signal?.addEventListener('abort', onAbort, { once: true });
         if (options.signal?.aborted === true) onAbort();
     });
+}
+
+function pluginStderrMessage(stderr: Buffer, fallback: string): string {
+    const text = stderr.toString('utf8').trim();
+    if (text === '') return fallback;
+    // A plugin that crashes with an uncaught exception prints a code frame and
+    // a stack with local install paths. The phone must see one clean message,
+    // never the host's filesystem. Prefer the exception's own message line.
+    const exceptionLine = text.split('\n').map((line) => line.trim()).find((line) => /^(?:[A-Za-z]+Error|Error): /.test(line));
+    const message = (exceptionLine ?? text.split('\n')[0] ?? fallback).replace(/file:\/\/\S+/g, 'plugin').trim();
+    return message.slice(0, 300) || fallback;
 }
 
 function pluginProcessError(name: string, message: string): Error {

--- a/apps/host/src/herdr/pluginStreamManager.ts
+++ b/apps/host/src/herdr/pluginStreamManager.ts
@@ -246,8 +246,11 @@ export class PluginStreamManager {
         });
         child.once('error', (error) => attachment.close(`plugin stream failed: ${error.message}`));
         child.once('close', (code) => {
+            // Never forward stack traces or local paths: keep one clean line.
             const rawDetail = stderr.toString('utf8').trim();
-            const detail = Buffer.from(rawDetail).subarray(0, 400).toString('utf8').replace(/[\u0000-\u001F\u007F]/g, ' ').trim();
+            const exceptionLine = rawDetail.split('\n').map((line) => line.trim()).find((line) => /^(?:[A-Za-z]+Error|Error): /.test(line));
+            const detail = Buffer.from(exceptionLine ?? rawDetail.split('\n')[0] ?? '').subarray(0, 400).toString('utf8')
+                .replace(/file:\/\/\S+/g, 'plugin').replace(/[\u0000-\u001F\u007F]/g, ' ').trim();
             const finishChild = () => attachment.close(code === 0 ? undefined : detail === '' ? `plugin stream exited (${code ?? 'signal'})` : detail);
             // Let the encrypted graceful-close frame reach the phone before its
             // socket close event; decryption completes asynchronously there.

--- a/plugins/git-history/rpc.mjs
+++ b/plugins/git-history/rpc.mjs
@@ -14,6 +14,13 @@ function repo() {
 
 const method = process.argv[2];
 if (method === 'log') {
+    const cwd = String(input.cwd ?? '');
+    if (cwd === '' || cwd.includes('\0')) {
+        // A session can have no working directory yet; that is an empty state,
+        // not a crash.
+        process.stdout.write(JSON.stringify({ title: 'Git history', count: 'No repository for this session', commits: [] }));
+        process.exit(0);
+    }
     const root = execFileSync('git', ['-C', repo(), 'rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 20000 }).trim();
     const commits = git(['log', '-25', '--date=short', '--pretty=%H%x1f%h%x1f%s%x1f%an%x1f%ad']).split('\n').filter(Boolean)
         .map((line) => { const [sha, short, subject, author, date] = line.split('\x1f'); return { sha, short, subject, author, date, meta: `${short} · ${author} · ${date}`, cwd: repo() }; });


### PR DESCRIPTION
## Summary
- host RPC and stream managers now surface one clean exception line from plugin stderr and strip `file://` install paths instead of forwarding raw Node stack traces to the phone
- `git-history` returns a “No repository for this session” empty state when a session has no working directory

## Verification
- `node scripts/runSuite.mjs` — 29/29
- direct fixture: `rpc.mjs log` with no cwd returns the empty state