### PR TITLE
Rotate expired pending pair sessions

### DIFF
--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -1633,7 +1633,12 @@ async function runSelfhostPair(state, requestedKind = 'native') {
     const base = selfhostControlBase(state);
     const authHeaders = { authorization: `Bearer ${selfhostCredential(state)}` };
     let pending = state.machine.crypto.pendingPair;
-    if (pending !== undefined && (pending.deviceKind ?? 'native') !== requestedKind) {
+    if (pending !== undefined
+        && ((pending.deviceKind ?? 'native') !== requestedKind
+            || (typeof pending.expiresAt === 'number' && pending.expiresAt <= Date.now()))) {
+        // A kind change or an expired five-minute session must mint a fresh
+        // claim; reusing a dead one strands every later `muxr pair` on the
+        // relay's expired session.
         delete state.machine.crypto.pendingPair;
         writeSelfhostState(state);
         pending = undefined;


### PR DESCRIPTION
`muxr pair` reused a locally stored pending pair without checking its five-minute expiry: once a session died unclaimed, every later attempt printed the same dead QR and the phone reported it expired. Expired or kind-mismatched pending pairs now mint a fresh claim.

Found by driving the real pairing flow against an emulator.

## Verification
- 29/29 suite, package smoke
- reproduced the dead-QR loop, then completed pairing after the fix