### PR TITLE
Copy link from the terminal

### DIFF
--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -14,6 +14,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import { Ionicons } from '@expo/vector-icons';
 import { router, useFocusEffect } from 'expo-router';
 import { Modal } from '@/modal';
+import * as Clipboard from 'expo-clipboard';
 import { storage, useSession, useSessions } from '@/sync/storage';
 import { sync } from '@/sync/sync';
 import type { HerdrTreeTab } from '@muxr/contract';
@@ -31,6 +32,7 @@ import { PluginSlot } from '@/plugins/PluginSlot';
 import { DeclarativeChips, DeclarativeHeaderButtons, DeclarativeTerminalKeySlot } from '@/plugins/DeclarativePluginSlot';
 import { useSlotContributions } from '@/plugins/useSlotContributions';
 import type { SessionMenu } from '@/plugins/slotTypes';
+import { recentTerminalLinks } from '@/terminal/recentOutput';
 import { resolvePluginText } from '@/plugins/pluginText';
 import { randomUUID } from 'expo-crypto';
 
@@ -341,11 +343,29 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                 <PluginSlot slot="session.header.trailing" context={{ sessionId: props.id, cwd: session?.metadata?.path }} />
                 <DeclarativeHeaderButtons cwd={session?.metadata?.path} />
                 <DeclarativeChips slot="session.header.trailing" />
-                {pluginButtons.length > 0 && (
+                {(
                     <Pressable
-                        onPress={() => setMenu({
-                            title: 'Actions',
-                            items: pluginButtons.map((button) => ({
+                        onPress={() => {
+                            const links = recentTerminalLinks(props.id);
+                            const linkItems: SessionMenu['items'] = links.length === 0 ? [] : [{
+                                label: 'Copy link',
+                                hint: links[0] !== undefined && links[0].length > 60 ? `${links[0].slice(0, 57)}…` : links[0],
+                                onPress: () => {
+                                    setMenu({
+                                        title: 'Copy link',
+                                        note: 'From the recent terminal output',
+                                        items: links.map((url) => ({
+                                            label: url.length > 72 ? `${url.slice(0, 69)}…` : url,
+                                            onPress: () => {
+                                                void Clipboard.setStringAsync(url).then(() => Modal.alert('Link copied', url));
+                                            },
+                                        })),
+                                    });
+                                },
+                            }];
+                            setMenu({
+                                title: 'Actions',
+                                items: [...linkItems, ...pluginButtons.map((button) => ({
                                 label: resolvePluginText(button.label),
                                 hint: button.name,
                                 onPress: () => {
@@ -361,8 +381,9 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                                     }).catch((error) => Modal.alert(`${button.name} failed`, error instanceof Error ? error.message : String(error)))
                                         .finally(() => setExtensionActionBusy(undefined));
                                 },
-                            })),
-                        })}
+                            }))],
+                            });
+                        }}
                         disabled={pluginActionBusy !== undefined}
                         hitSlop={10}
                         accessibilityRole="button"

--- a/apps/mobile/sources/terminal/TerminalView.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.tsx
@@ -16,6 +16,7 @@ import { View } from 'react-native';
 import { TerminalView as GhosttyView, type TerminalViewRef } from 'expo-libghostty';
 import { decodeBase64, encodeBase64 } from '@/encryption/base64';
 import { openTerminal, type TerminalChannel } from './openTerminal';
+import { recordTerminalOutput } from './recentOutput';
 
 /** herdr repaints the whole screen per scroll; don't ask it for the world. */
 const MAX_SCROLL_LINES = 40;
@@ -128,6 +129,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                     // arrive as many socket messages; one Ghostty write per
                     // frame instead of one per message.
                     channel.onData((base64) => {
+                        recordTerminalOutput(sessionId, base64);
                         pendingWritesRef.current.push(base64);
                         if (writeRafRef.current === undefined) {
                             writeRafRef.current = requestAnimationFrame(flushWrites);

--- a/apps/mobile/sources/terminal/openTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/openTerminal.spec.ts
@@ -125,3 +125,15 @@ describe('openTerminal reconnect ownership', () => {
         channel.close();
     });
 });
+
+describe('recentTerminalLinks', () => {
+    it('extracts deduped URLs latest-first from ANSI terminal output', async () => {
+        const { recordTerminalOutput, recentTerminalLinks, clearTerminalOutput } = await import('./recentOutput');
+        const { encodeBase64 } = await import('@/encryption/base64');
+        clearTerminalOutput('s1');
+        recordTerminalOutput('s1', encodeBase64(new TextEncoder().encode('\x1b[32mServing on https://localhost:8901/index.html.\x1b[0m then http://example.com/a?x=1')));
+        recordTerminalOutput('s1', encodeBase64(new TextEncoder().encode('\nagain https://localhost:8901/index.html.')));
+        expect(recentTerminalLinks('s1')).toEqual(['http://example.com/a?x=1', 'https://localhost:8901/index.html']);
+        expect(recentTerminalLinks('unknown')).toEqual([]);
+    });
+});

--- a/apps/mobile/sources/terminal/recentOutput.ts
+++ b/apps/mobile/sources/terminal/recentOutput.ts
@@ -1,0 +1,41 @@
+import { decodeBase64 } from '@/encryption/base64';
+
+/** Rolling plain-text tail of each attached terminal, for link extraction.
+ *  Bounded: the point is "the URL that just scrolled by", not a transcript. */
+const MAX_CHARS = 24 * 1024;
+const MAX_LINKS = 8;
+const tails = new Map<string, string>();
+const TEXT_DECODER = new TextDecoder();
+
+const ANSI = /(?:\[[0-9;?]*[ -/]*[@-~]|\][^\]*(?:|\\\)|[()][0-2]|[#>=()])/g;
+const URL_PATTERN = /https?:\/\/[^\s"'`<>[\]{}()\\^|]+/g;
+const TRAILING = /[.,;:!?)\]]+$/;
+
+export function recordTerminalOutput(sessionId: string, base64: string): void {
+    let bytes: Uint8Array;
+    try { bytes = decodeBase64(base64); } catch { return; }
+    const text = TEXT_DECODER.decode(bytes).replace(ANSI, '').replace(/\r/g, '');
+    const next = (tails.get(sessionId) ?? '') + text;
+    tails.set(sessionId, next.length > MAX_CHARS ? next.slice(next.length - MAX_CHARS) : next);
+}
+
+export function clearTerminalOutput(sessionId: string): void {
+    tails.delete(sessionId);
+}
+
+/** Latest-first, deduped URLs from the visible-ish terminal tail. */
+export function recentTerminalLinks(sessionId: string): string[] {
+    const tail = tails.get(sessionId);
+    if (tail === undefined || !tail.includes('http')) return [];
+    const found: string[] = [];
+    const seen = new Set<string>();
+    const matches = tail.matchAll(URL_PATTERN);
+    for (const match of matches) {
+        const url = match[0].replace(TRAILING, '');
+        if (url.length <= 12 || seen.has(url)) continue;
+        seen.add(url);
+        found.push(url);
+        if (found.length >= MAX_LINKS) break;
+    }
+    return found.reverse();
+}


### PR DESCRIPTION
Long-press word selection makes wrapped URLs nearly impossible to copy. More-actions now offers Copy link: the last few URLs seen in the session output, tap to copy.

- bounded 24KB ANSI-stripped tail per session, latest-first dedupe, 8-link cap
- menu now exists even without plugin actions
- covered by a flow check in openTerminal.spec.ts; 29/29 suite