### PR TITLE
Read-only browsers get read-mode plugin RPCs

### DIFF
--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -1161,6 +1161,10 @@ export async function createHerdrSessionSource(
             }
         },
 
+        pluginRpcMode({ pluginId, manifestHash, contributionId }: { pluginId: string; manifestHash: string; contributionId: string }): 'read' | 'write' | undefined {
+            try { return catalog.call(pluginId, manifestHash, contributionId).mode; } catch { return undefined; }
+        },
+
         async pluginCall({ deviceId, pluginId, manifestHash, contributionId, input, idempotencyKey }): Promise<unknown> {
             // Force one authoritative catalog read before entering the bounded
             // process queue. The active hash is checked again at dequeue.

--- a/apps/host/src/requests/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/createRequestDispatcher.test.ts
@@ -51,6 +51,7 @@ describe('plugin device authority', () => {
         const source = {
             async pluginApprove(options: unknown) { calls.push(options); },
             async pluginCall(options: unknown) { calls.push(options); return { ok: true }; },
+            pluginRpcMode(options: { contributionId: string }) { return options.contributionId === 'rpc' ? 'read' as const : 'write' as const; },
         } as unknown as SessionSource;
         const { dispatch } = createRequestDispatcher({
             source,
@@ -67,7 +68,9 @@ describe('plugin device authority', () => {
         const call = { type: 'plugin.call', requestId: 'call', params: { pluginId: 'example.ui', manifestHash: 'hash', contributionId: 'rpc', input: { value: 1 } } } as never;
         expect(await dispatch(call, 'native-1')).toMatchObject({ ok: true, data: { ok: true } });
         expect(calls[1]).toMatchObject({ deviceId: 'native-1', contributionId: 'rpc' });
-        expect(await dispatch(call, 'browser-1')).toMatchObject({ ok: false, error: expect.stringContaining('read-only') });
+        expect(await dispatch(call, 'browser-1')).toMatchObject({ ok: true, data: { ok: true } });
+        const writeCall = { type: 'plugin.call', requestId: 'call-2', params: { pluginId: 'example.ui', manifestHash: 'hash', contributionId: 'write-rpc' } } as never;
+        expect(await dispatch(writeCall, 'browser-1')).toMatchObject({ ok: false, error: expect.stringContaining('read-only') });
     });
 });
 

--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -183,7 +183,11 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
                 'attachment.fetch', 'attachment.read', 'unread.catalog',
                 'attention.catalog', 'machines.list', 'terminal.attach',
             ]);
-            if (readOnly && !readOnlyRequests.has(request.type)) {
+            // A read-only browser may still call read-mode plugin RPCs (Usage,
+            // Files, Git history); write RPCs, invokes, and streams stay fenced.
+            const readOnlyPluginRead = readOnly && request.type === 'plugin.call'
+                && source.pluginRpcMode?.(request.params) === 'read';
+            if (readOnly && !readOnlyRequests.has(request.type) && !readOnlyPluginRead) {
                 return { type: 'result', requestId: request.requestId, ok: false, error: 'browser grant is read-only; use the native app for control' };
             }
             if (readOnly && request.type === 'terminal.attach') {

--- a/apps/host/src/sessionSource.ts
+++ b/apps/host/src/sessionSource.ts
@@ -93,6 +93,8 @@ export interface SessionSource {
     pluginApprove(options: { deviceId: string; pluginId: string; manifestHash: string; approved: boolean }): Promise<void>;
     pluginInvoke(options: { deviceId: string; pluginId: string; manifestHash: string; contributionId: string; sessionId: string; idempotencyKey: string }): Promise<void>;
     pluginCall(options: { deviceId: string; pluginId: string; manifestHash: string; contributionId: string; input?: unknown; idempotencyKey?: string }): Promise<unknown>;
+    /** Declared RPC mode for a catalog contribution, so read-only devices can be allowed through read paths only. */
+    pluginRpcMode?(options: { pluginId: string; manifestHash: string; contributionId: string }): 'read' | 'write' | undefined;
     pluginStream(options: { deviceId: string; pluginId: string; manifestHash: string; contributionId: string; channel: string; sessionId?: string }): Promise<null>;
     /** Split layout of one tab (rects in terminal cells) for grid views. */
     herdrLayout(tabId: string): Promise<{

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -14,6 +14,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import { Ionicons } from '@expo/vector-icons';
 import { router, useFocusEffect } from 'expo-router';
 import { Modal } from '@/modal';
+import * as Clipboard from 'expo-clipboard';
 import { storage, useSession, useSessions } from '@/sync/storage';
 import { sync } from '@/sync/sync';
 import type { HerdrTreeTab } from '@muxr/contract';
@@ -31,6 +32,7 @@ import { PluginSlot } from '@/plugins/PluginSlot';
 import { DeclarativeChips, DeclarativeHeaderButtons, DeclarativeTerminalKeySlot } from '@/plugins/DeclarativePluginSlot';
 import { useSlotContributions } from '@/plugins/useSlotContributions';
 import type { SessionMenu } from '@/plugins/slotTypes';
+import { recentTerminalLinks } from '@/terminal/recentOutput';
 import { resolvePluginText } from '@/plugins/pluginText';
 import { randomUUID } from 'expo-crypto';
 
@@ -341,11 +343,29 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                 <PluginSlot slot="session.header.trailing" context={{ sessionId: props.id, cwd: session?.metadata?.path }} />
                 <DeclarativeHeaderButtons cwd={session?.metadata?.path} />
                 <DeclarativeChips slot="session.header.trailing" />
-                {pluginButtons.length > 0 && (
+                {(
                     <Pressable
-                        onPress={() => setMenu({
-                            title: 'Actions',
-                            items: pluginButtons.map((button) => ({
+                        onPress={() => {
+                            const links = recentTerminalLinks(props.id);
+                            const linkItems: SessionMenu['items'] = links.length === 0 ? [] : [{
+                                label: 'Copy link',
+                                hint: links[0] !== undefined && links[0].length > 60 ? `${links[0].slice(0, 57)}…` : links[0],
+                                onPress: () => {
+                                    setMenu({
+                                        title: 'Copy link',
+                                        note: 'From the recent terminal output',
+                                        items: links.map((url) => ({
+                                            label: url.length > 72 ? `${url.slice(0, 69)}…` : url,
+                                            onPress: () => {
+                                                void Clipboard.setStringAsync(url).then(() => Modal.alert('Link copied', url));
+                                            },
+                                        })),
+                                    });
+                                },
+                            }];
+                            setMenu({
+                                title: 'Actions',
+                                items: [...linkItems, ...pluginButtons.map((button) => ({
                                 label: resolvePluginText(button.label),
                                 hint: button.name,
                                 onPress: () => {
@@ -361,8 +381,9 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                                     }).catch((error) => Modal.alert(`${button.name} failed`, error instanceof Error ? error.message : String(error)))
                                         .finally(() => setExtensionActionBusy(undefined));
                                 },
-                            })),
-                        })}
+                            }))],
+                            });
+                        }}
                         disabled={pluginActionBusy !== undefined}
                         hitSlop={10}
                         accessibilityRole="button"

--- a/apps/mobile/sources/terminal/TerminalView.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.tsx
@@ -16,6 +16,7 @@ import { View } from 'react-native';
 import { TerminalView as GhosttyView, type TerminalViewRef } from 'expo-libghostty';
 import { decodeBase64, encodeBase64 } from '@/encryption/base64';
 import { openTerminal, type TerminalChannel } from './openTerminal';
+import { recordTerminalOutput } from './recentOutput';
 
 /** herdr repaints the whole screen per scroll; don't ask it for the world. */
 const MAX_SCROLL_LINES = 40;
@@ -128,6 +129,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                     // arrive as many socket messages; one Ghostty write per
                     // frame instead of one per message.
                     channel.onData((base64) => {
+                        recordTerminalOutput(sessionId, base64);
                         pendingWritesRef.current.push(base64);
                         if (writeRafRef.current === undefined) {
                             writeRafRef.current = requestAnimationFrame(flushWrites);

--- a/apps/mobile/sources/terminal/openTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/openTerminal.spec.ts
@@ -125,3 +125,15 @@ describe('openTerminal reconnect ownership', () => {
         channel.close();
     });
 });
+
+describe('recentTerminalLinks', () => {
+    it('extracts deduped URLs latest-first from ANSI terminal output', async () => {
+        const { recordTerminalOutput, recentTerminalLinks, clearTerminalOutput } = await import('./recentOutput');
+        const { encodeBase64 } = await import('@/encryption/base64');
+        clearTerminalOutput('s1');
+        recordTerminalOutput('s1', encodeBase64(new TextEncoder().encode('\x1b[32mServing on https://localhost:8901/index.html.\x1b[0m then http://example.com/a?x=1')));
+        recordTerminalOutput('s1', encodeBase64(new TextEncoder().encode('\nagain https://localhost:8901/index.html.')));
+        expect(recentTerminalLinks('s1')).toEqual(['http://example.com/a?x=1', 'https://localhost:8901/index.html']);
+        expect(recentTerminalLinks('unknown')).toEqual([]);
+    });
+});

--- a/apps/mobile/sources/terminal/recentOutput.ts
+++ b/apps/mobile/sources/terminal/recentOutput.ts
@@ -1,0 +1,41 @@
+import { decodeBase64 } from '@/encryption/base64';
+
+/** Rolling plain-text tail of each attached terminal, for link extraction.
+ *  Bounded: the point is "the URL that just scrolled by", not a transcript. */
+const MAX_CHARS = 24 * 1024;
+const MAX_LINKS = 8;
+const tails = new Map<string, string>();
+const TEXT_DECODER = new TextDecoder();
+
+const ANSI = /(?:\[[0-9;?]*[ -/]*[@-~]|\][^\]*(?:|\\\)|[()][0-2]|[#>=()])/g;
+const URL_PATTERN = /https?:\/\/[^\s"'`<>[\]{}()\\^|]+/g;
+const TRAILING = /[.,;:!?)\]]+$/;
+
+export function recordTerminalOutput(sessionId: string, base64: string): void {
+    let bytes: Uint8Array;
+    try { bytes = decodeBase64(base64); } catch { return; }
+    const text = TEXT_DECODER.decode(bytes).replace(ANSI, '').replace(/\r/g, '');
+    const next = (tails.get(sessionId) ?? '') + text;
+    tails.set(sessionId, next.length > MAX_CHARS ? next.slice(next.length - MAX_CHARS) : next);
+}
+
+export function clearTerminalOutput(sessionId: string): void {
+    tails.delete(sessionId);
+}
+
+/** Latest-first, deduped URLs from the visible-ish terminal tail. */
+export function recentTerminalLinks(sessionId: string): string[] {
+    const tail = tails.get(sessionId);
+    if (tail === undefined || !tail.includes('http')) return [];
+    const found: string[] = [];
+    const seen = new Set<string>();
+    const matches = tail.matchAll(URL_PATTERN);
+    for (const match of matches) {
+        const url = match[0].replace(TRAILING, '');
+        if (url.length <= 12 || seen.has(url)) continue;
+        seen.add(url);
+        found.push(url);
+        if (found.length >= MAX_LINKS) break;
+    }
+    return found.reverse();
+}


### PR DESCRIPTION
The blanket plugin.call denial left Usage, Files, Changes, and Git history dead in the eight-hour read-only browser client. The dispatcher now consults the catalog-declared RPC mode: read calls pass, writes/invokes/streams stay fenced, unknown manifests deny.

## Verification
- dispatcher test covers read-allowed / write-blocked
- 29/29 suite