### PR TITLE
eas.json: production env for cloud builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -21,6 +21,10 @@
             "env": {
                 "APP_ENV": "production",
                 "MUXR_EAS_PROJECT_ID": "94c02367-50fe-44e0-a6d5-8461a0d06058",
+                "MUXR_PUBLIC_BASE_URL": "https://trymuxr.com",
+                "MUXR_DISTRIBUTION": "store",
+                "EXPO_PUBLIC_MUXR_MODE": "hosted",
+                "EXPO_PUBLIC_MUXR_RELAY_URL": "wss://trymuxr.com",
                 "ORG_GRADLE_PROJECT_reactNativeArchitectures": "arm64-v8a"
             }
         },


### PR DESCRIPTION
Cloud builds do not inherit the shell: the production profile now carries the public config (relay URL, hosted mode, public base URL, store distribution) so `eas build --platform android --profile production` works unattended. All values are public configuration, no secrets.