### PR TITLE
Fix Play App Actions and iOS Ghostty linking

### DIFF
--- a/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
+++ b/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
@@ -14,7 +14,7 @@
         android:shortcutLongLabel="@string/muxr_shortcut_muxr_voice_jarvis_long">
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="@string/muxr_application_id"
+            android:targetPackage="com.trymuxr.app"
             android:targetClass="com.trymuxr.app.MainActivity"
             android:data="muxr://shortcut/muxr.voice.jarvis" />
         <capability-binding android:key="actions.intent.OPEN_APP_FEATURE">

--- a/apps/mobile/ios/Podfile.properties.json
+++ b/apps/mobile/ios/Podfile.properties.json
@@ -1,4 +1,5 @@
 {
   "expo.jsEngine": "hermes",
+  "ios.deploymentTarget": "16.4",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true"
 }

--- a/apps/mobile/ios/muxr.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/muxr.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@ fi
 					"FB_SONARKIT_ENABLED=1",
 				);
 				INFOPLIST_FILE = muxr/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -326,7 +326,7 @@ fi
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 8;
 				INFOPLIST_FILE = muxr/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -395,7 +395,7 @@ fi
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -448,7 +448,7 @@ fi
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/scripts/checkBundledPlugins.mjs
+++ b/scripts/checkBundledPlugins.mjs
@@ -66,9 +66,15 @@ for (const path of shellFiles) {
 const require = createRequire(import.meta.url);
 const { bundledShortcutData, shortcutResources } = require(join(root, 'apps/mobile/plugins/withAppActions.js'));
 const bakedShortcutsPath = join(root, 'apps/mobile/sources/plugins/bundledShortcuts.json');
+const nativeShortcutsPath = join(root, 'apps/mobile/android/app/src/main/res/xml/shortcuts.xml');
 const expectedShortcuts = `${JSON.stringify(bundledShortcutData(), null, 2)}\n`;
 if (readFileSync(bakedShortcutsPath, 'utf8') !== expectedShortcuts) {
     process.stderr.write('FAIL bundledShortcuts.json is stale; run the Expo config or update it from bundled manifests\n');
+    failed += 1;
+}
+const nativeShortcuts = readFileSync(nativeShortcutsPath, 'utf8');
+if (!nativeShortcuts.includes('android:targetPackage="com.trymuxr.app"') || /android:targetPackage="@/.test(nativeShortcuts)) {
+    process.stderr.write('FAIL Android App Actions targetPackage must be the literal Play package id\n');
     failed += 1;
 }
 const localizedShortcutFixture = [{

--- a/scripts/checkMobileCommerceBuilds.mjs
+++ b/scripts/checkMobileCommerceBuilds.mjs
@@ -31,6 +31,11 @@ assert.doesNotMatch(JSON.stringify(store), /revenuecat|posthog|stripeKey|checkou
 
 const eas = JSON.parse(readFileSync(join(mobile, 'eas.json'), 'utf8'));
 assert.equal(eas.build.production.env.ORG_GRADLE_PROJECT_reactNativeArchitectures, 'arm64-v8a');
+const podProperties = JSON.parse(readFileSync(join(mobile, 'ios', 'Podfile.properties.json'), 'utf8'));
+assert.equal(podProperties['ios.deploymentTarget'], '16.4', 'iOS target must satisfy expo-libghostty');
+const xcodeTargets = [...readFileSync(join(mobile, 'ios', 'muxr.xcodeproj', 'project.pbxproj'), 'utf8').matchAll(/IPHONEOS_DEPLOYMENT_TARGET = ([0-9.]+);/g)].map((match) => Number(match[1]));
+assert.equal(xcodeTargets.length, 4, 'expected four Xcode deployment-target settings');
+assert.ok(xcodeTargets.every((target) => target >= 16.4), 'Xcode target is below expo-libghostty minimum');
 assert.match(readFileSync(join(mobile, 'android', 'app', 'build.gradle'), 'utf8'), /applicationId 'com\.trymuxr\.app'/);
 const voiceManifest = readFileSync(join(mobile, 'modules', 'voice-overlay', 'android', 'src', 'main', 'AndroidManifest.xml'), 'utf8');
 assert.match(voiceManifest, /FOREGROUND_SERVICE_DATA_SYNC/);


### PR DESCRIPTION
Two store-build blockers found by the real submission paths:

- Google Play App Actions requires literal `android:targetPackage`; resource references are rejected
- expo-libghostty requires iOS 16.4; at 15.1 Expo generated the provider import but filtered the root pod, causing `no such module ExpoLibghostty`

Regression guards now enforce both native constraints.

Verification: full suite 29/29; independent Codex reviews SHIP; rejected Play upload did not consume versionCode 8.