### PR TITLE
Android: keep Play release to launcher shortcuts

### DIFF
--- a/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
+++ b/apps/mobile/android/app/src/main/res/xml/shortcuts.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
-    <capability android:name="actions.intent.OPEN_APP_FEATURE">
-        <intent>
-            <url-template android:value="muxr://shortcut{/featureParam}" />
-            <parameter android:name="feature" android:key="featureParam" />
-        </intent>
-    </capability>
     <shortcut
         android:shortcutId="muxr.voice.jarvis"
         android:enabled="true"
@@ -17,10 +11,5 @@
             android:targetPackage="com.trymuxr.app"
             android:targetClass="com.trymuxr.app.MainActivity"
             android:data="muxr://shortcut/muxr.voice.jarvis" />
-        <capability-binding android:key="actions.intent.OPEN_APP_FEATURE">
-            <parameter-binding
-                android:key="feature"
-                android:value="@array/muxr_shortcut_muxr_voice_jarvis_synonyms" />
-        </capability-binding>
     </shortcut>
 </shortcuts>

--- a/apps/mobile/plugins/withAppActions.js
+++ b/apps/mobile/plugins/withAppActions.js
@@ -1,9 +1,8 @@
-// Expo config plugin: Google Assistant App Actions.
+// Expo config plugin: Android launcher shortcuts.
 //
-// Shortcuts come from the bundled plugins' own muxr-ui.json, so adding a voice
-// shortcut is a manifest edit rather than an Android change. Static shortcuts
+// Shortcuts come from the bundled plugins' own muxr-ui.json. Static shortcuts
 // are baked at build time by Android's design. Runtime-installed plugins use
-// the same contribution through ShortcutManagerCompat for launcher shortcuts.
+// the same contribution through ShortcutManagerCompat.
 const { readdirSync, readFileSync, mkdirSync, writeFileSync, existsSync, unlinkSync } = require('fs');
 const { join } = require('path');
 const { withAndroidManifest, withDangerousMod, AndroidConfig } = require('expo/config-plugins');
@@ -78,7 +77,7 @@ function bundledShortcutData(shortcuts = bundledShortcuts()) {
     return shortcuts.map((shortcut) => ({
         id: shortcut.shortcutId,
         action: shortcut.action,
-        // OPEN_APP_FEATURE puts the spoken synonym in the URL, not shortcutId.
+        // Keep aliases so old deep links still resolve to the canonical id.
         aliases: dedupe([
             ...shortcut.synonyms,
             ...Object.values(shortcut.localized).flatMap((value) => value.synonyms),
@@ -141,8 +140,6 @@ module.exports = function withAppActions(config) {
             writeStable(join(values, 'muxr_shortcuts.xml'), shortcutResources(shortcuts, locale));
         }
 
-        // url-template turns the Assistant match into an ordinary deep link, so
-        // no native intent bridging is needed: expo-router already handles it.
         const target = packageName === undefined ? [] : [
             `            android:targetPackage="${escapeXml(packageName)}"`,
             `            android:targetClass="${escapeXml(packageName)}.MainActivity"`,
@@ -158,23 +155,12 @@ module.exports = function withAppActions(config) {
             `            android:action="android.intent.action.VIEW"`,
             ...target,
             `            android:data="muxr://shortcut/${escapeXml(shortcut.shortcutId)}" />`,
-            `        <capability-binding android:key="actions.intent.OPEN_APP_FEATURE">`,
-            `            <parameter-binding`,
-            `                android:key="feature"`,
-            `                android:value="@array/muxr_shortcut_${shortcut.resourceName}_synonyms" />`,
-            `        </capability-binding>`,
             `    </shortcut>`,
         ].join('\n'));
 
         writeStable(join(res, 'xml', 'shortcuts.xml'), [
             '<?xml version="1.0" encoding="utf-8"?>',
             '<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">',
-            '    <capability android:name="actions.intent.OPEN_APP_FEATURE">',
-            '        <intent>',
-            '            <url-template android:value="muxr://shortcut{/featureParam}" />',
-            '            <parameter android:name="feature" android:key="featureParam" />',
-            '        </intent>',
-            '    </capability>',
             ...entries,
             '</shortcuts>',
             '',

--- a/apps/mobile/sources/app/(app)/settings/plugins.tsx
+++ b/apps/mobile/sources/app/(app)/settings/plugins.tsx
@@ -141,6 +141,6 @@ const SLOT_LABELS: Record<string, string> = {
     'home.composer.leading': 'a composer button',
     'home.composer.trailing': 'a composer button',
     'session.composer.trailing': 'a composer button',
-    'shortcuts': 'an Assistant shortcut',
+    'shortcuts': 'a launcher shortcut',
     'events': 'an event trigger',
 };

--- a/apps/mobile/sources/app/(app)/shortcut/[id].tsx
+++ b/apps/mobile/sources/app/(app)/shortcut/[id].tsx
@@ -4,7 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { runShortcut } from '@/plugins/runShortcut';
 
 /**
- * Assistant deep-link target. Home is restored first so the shortcut's action
+ * Launcher deep-link target. Home is restored first so the shortcut's action
  * lands on a mounted app rather than racing this screen's own teardown.
  */
 export default function ShortcutRoute() {

--- a/apps/mobile/sources/plugins/runShortcut.ts
+++ b/apps/mobile/sources/plugins/runShortcut.ts
@@ -22,8 +22,8 @@ function canonicalShortcutId(shortcutId: string): string {
 }
 
 /**
- * Run a plugin shortcut by its Assistant shortcut id (`<pluginId>.<contributionId>`)
- * or by the spoken OPEN_APP_FEATURE synonym Assistant puts in the deep link.
+ * Run a plugin shortcut by its canonical id (`<pluginId>.<contributionId>`)
+ * or a legacy alias from an older deep link.
  *
  * The baked Android mapping is identity/alias data only. The enabled catalog is
  * authoritative even on cold start, so a disabled plugin can never open the mic.

--- a/docs/NATIVE-BUILD.md
+++ b/docs/NATIVE-BUILD.md
@@ -20,9 +20,9 @@ can silently replace the committed identity.
 
 The first `eas build --local` creates a keystore through your Expo account
 (`eas credentials` in `apps/mobile`). `credentials.json` is gitignored; do not
-commit it. Google Assistant / App Actions shortcuts from bundled plugins are
-baked into `res/xml/shortcuts.xml` at prebuild — a new APK is required after
-changing `plugins/*/muxr-ui.json` shortcuts.
+commit it. Android launcher shortcuts from bundled plugins are baked into
+`res/xml/shortcuts.xml` at prebuild, so changing `plugins/*/muxr-ui.json`
+shortcuts requires a new APK.
 
 In-app SSH (Settings → SSH) is TOFU host-key pinning via
 `apps/mobile/modules/ssh-tunnel`. It is Android-only.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -122,7 +122,7 @@ Every slot below is shipped. **JSON** means you edit `muxr-ui.json` and the chan
 | Slot | What you contribute | How |
 |---|---|---|
 | `events` | a trigger: when app state changes, run a kernel action | JSON |
-| `shortcuts` | an Android launcher shortcut; build-bundled contributions also become Assistant App Actions | JSON (launcher) / app rebuild (Assistant) |
+| `shortcuts` | an Android launcher shortcut | JSON; bundled entries require an app rebuild |
 | `host.rpc` | a bounded one-shot backend entrypoint | JSON + `.mjs` |
 | `host.stream` | a persistent provider adapter over bounded NDJSON frames | `.mjs` |
 | `navigation.primary` | a top-level destination | JSON (`navigation-item`) |
@@ -500,7 +500,7 @@ validates shape; `plugin call` proves wiring.
 { "schemaVersion": 1, "pluginId": "you.thing", "minMuxrVersion": 8, "contributions": [] }
 ```
 
-`minMuxrVersion` is optional and is preserved when the host parses the manifest. UI version 12 allows generic `item-list` rows to omit actions for honest read-only status and metric lists; actionable rows still require a validated closed action. UI version 11 adds the bounded declarative `code` node and syntax highlighting for source previews and native unified diffs. UI version 10 adds the generic declarative `tree` node: per-folder expand/collapse, expand/collapse-all controls, optional lazy `host.rpc` children, closed leaf actions, and folder selection into an existing form field. UI version 9 adds provider-neutral `host.stream` contributions and strict encrypted stream transport. UI version 8 adds bounded per-row icons/metadata and optional sheet-level actions to the generic `item-list` response. UI version 7 adds plugin-owned `navigation-item.badge` read sources and singleton tree-sheet cardinality. UI version 6 adds bounded localized values for every user-visible manifest string and runtime Android launcher projection for shortcut contributions. UI version 5 removes `url-chip`; adds bounded active-only refresh and presentation parameters to `item-list`; adds current-session preview navigation by validated port; and defines capability actions, Assistant shortcuts, the realtime indicator, and singleton realtime-overlay cardinality. UI version 4 added source-driven grouped collections/tree sheets and allow-listed public RPC context. Each phone compares it with its own `MUXR_UI_VERSION`; an older app lists the plugin as unavailable with an update message and refuses to mount its contributions instead of quietly rendering partial UI.
+`minMuxrVersion` is optional and is preserved when the host parses the manifest. UI version 12 allows generic `item-list` rows to omit actions for honest read-only status and metric lists; actionable rows still require a validated closed action. UI version 11 adds the bounded declarative `code` node and syntax highlighting for source previews and native unified diffs. UI version 10 adds the generic declarative `tree` node: per-folder expand/collapse, expand/collapse-all controls, optional lazy `host.rpc` children, closed leaf actions, and folder selection into an existing form field. UI version 9 adds provider-neutral `host.stream` contributions and strict encrypted stream transport. UI version 8 adds bounded per-row icons/metadata and optional sheet-level actions to the generic `item-list` response. UI version 7 adds plugin-owned `navigation-item.badge` read sources and singleton tree-sheet cardinality. UI version 6 adds bounded localized values for every user-visible manifest string and runtime Android launcher projection for shortcut contributions. UI version 5 removes `url-chip`; adds bounded active-only refresh and presentation parameters to `item-list`; adds current-session preview navigation by validated port; and defines capability actions, Android launcher shortcuts, the realtime indicator, and singleton realtime-overlay cardinality. UI version 4 added source-driven grouped collections/tree sheets and allow-listed public RPC context. Each phone compares it with its own `MUXR_UI_VERSION`; an older app lists the plugin as unavailable with an update message and refuses to mount its contributions instead of quietly rendering partial UI.
 
 ## Capabilities
 
@@ -548,7 +548,7 @@ in the same plugin (see `plugins/code/muxr-ui.json`).
 
 ## Shortcuts
 
-Contribute Google Assistant / App Actions entries with the `shortcuts` slot:
+Contribute Android launcher entries with the `shortcuts` slot:
 
 ```json
 {
@@ -561,22 +561,15 @@ Contribute Google Assistant / App Actions entries with the `shortcuts` slot:
 }
 ```
 
-Assistant matches a synonym and deep-links `muxr://shortcut/<pluginId>.<contributionId>`;
-the app runs the same closed action union events use (`capability` or `plugin.call`).
-A cold shortcut first refreshes the enabled catalog and resolves the live
-contribution before any capability or RPC runs. If the host is unavailable or
-the plugin is disabled, the shortcut does nothing.
+The app runs the same closed action union events use (`capability` or `plugin.call`). A cold shortcut first refreshes the enabled catalog and resolves the live contribution before any capability or RPC runs. If the host is unavailable or the plugin is disabled, the shortcut does nothing.
 
-`synonyms` feed Assistant only when the contribution is present at app build time; Android's runtime launcher API cannot register spoken aliases. The app projects every currently enabled runtime contribution into Android's dynamic launcher shortcuts with `ShortcutManagerCompat`; disabling or uninstalling the plugin removes it on the next catalog refresh. Build-bundled plugins are also baked into `res/xml/shortcuts.xml` by `apps/mobile/plugins/withAppActions.js`, using the same public manifest contribution and localized resources.
+The app projects every currently enabled runtime contribution into Android's dynamic launcher shortcuts with `ShortcutManagerCompat`; disabling or uninstalling the plugin removes it on the next catalog refresh. Build-bundled plugins are also baked into `res/xml/shortcuts.xml` by `apps/mobile/plugins/withAppActions.js`, using the same public manifest contribution and localized resources. Both paths deep-link through `muxr://shortcut/<id>` and re-check the live enabled catalog before acting.
 
-Android does not permit runtime dynamic shortcuts to add Assistant `capability-binding` metadata. Therefore runtime-installed plugins get launcher long-press shortcuts, while any plugin included in a custom app build gets the same Assistant App Action as muxr's bundled plugins. This is an Android lifecycle limit, not a private bundled-plugin API. Both paths deep-link through `muxr://shortcut/<id>` and re-check the live enabled catalog before acting.
+`synonyms` remain accepted as legacy aliases for deep links made by older builds. The Play build intentionally omits optional Assistant App Actions capability metadata because Google Play rejects those resources unless its separate Actions terms entitlement is active.
 
 ### Testing on a physical device
 
-1. Install the release build on a phone signed into the same Google account.
-2. Android Studio → Tools → App Actions → App Actions Test Tool; create a preview for the app.
-3. Say “Hey Google, open Jarvis in muxr”.
-4. Inline-inventory previews expire after 6 hours — recreate them when they go stale.
-5. Locale must be one of `en-US` / `en-GB` / `en-CA` / `en-IN` / `en-BE` / `en-SG` / `en-AU`.
-6. No-Assistant fallback:
+1. Install the release build on a phone.
+2. Long-press the launcher icon and tap the contributed shortcut.
+3. Or test the deep link directly:
    `adb shell am start -a android.intent.action.VIEW -d "muxr://shortcut/muxr.voice.jarvis"`

--- a/docs/specs/index.html
+++ b/docs/specs/index.html
@@ -14,13 +14,13 @@
   <div class="kicker">muxr engineering</div>
   <h1>Specification board</h1>
   <p>Durable plans, implementation status, and verification evidence.</p>
-  <div class="legend"><span>◐ In progress 0</span><span>◑ Implemented 1</span><span>● Tested 2</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
+  <div class="legend"><span>◐ In progress 0</span><span>◑ Implemented 2</span><span>● Tested 1</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
   <section class="group"><h2>In progress</h2><p class="empty">No specifications currently in progress.</p></section>
   <section class="group"><h2>Implemented</h2>
+    <a class="row" href="plugin-primitives.html"><span class="pip implemented"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-19</span></a>
     <a class="row" href="pi-parity-extension-phase.html"><span class="pip implemented"></span><span class="title">Pi-Parity Extension Phase</span><span class="date">2026-08-15</span></a>
   </section>
   <section class="group"><h2>Tested</h2>
-    <a class="row" href="plugin-primitives.html"><span class="pip tested"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-18</span></a>
     <a class="row" href="remote-relay-enrollment.html"><span class="pip tested"></span><span class="title">Shared Remote Relay Enrollment</span><span class="date">2026-08-17</span></a>
   </section>
   <section class="group"><h2>Planned</h2><a class="row" href="native-voice-transport.html"><span class="pip" style="background:var(--muted)"></span><span class="title">Native voice transport</span><span class="date">2026-08-18</span></a></section>

--- a/docs/specs/plugin-primitives.html
+++ b/docs/specs/plugin-primitives.html
@@ -7,14 +7,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;700&family=Hanken+Grotesk:wght@400;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
   <style>
     :root{--paper:#f4efe4;--card:#faf7ef;--ink:#211c15;--muted:#6b6253;--accent:#d14523;--sage:#5f7a5a;--amber:#b8791f;--line:#ddd3bf}
-    *{box-sizing:border-box}body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.55 'Hanken Grotesk',sans-serif}main{max-width:820px;margin:auto;padding:56px 24px 80px}h1,h2{font-family:Fraunces,serif}h1{font-size:clamp(36px,6vw,56px);margin:.2em 0}.kicker,.meta,.badge{font:500 12px 'IBM Plex Mono',monospace;text-transform:uppercase;letter-spacing:.07em}.badge{display:inline-block;padding:6px 10px;border-radius:999px;background:var(--sage);color:#fff}.meta{color:var(--muted);margin:12px 0 28px}.lead{font-size:20px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:16px 0;box-shadow:0 7px 20px #6b625310}code{font-family:'IBM Plex Mono',monospace;font-size:.86em;background:#eee6d6;padding:.1em .35em;border-radius:4px}ol,ul{padding-left:1.2em}li{margin:.45em 0}.check li{list-style:'□  '}
+    *{box-sizing:border-box}body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.55 'Hanken Grotesk',sans-serif}main{max-width:820px;margin:auto;padding:56px 24px 80px}h1,h2{font-family:Fraunces,serif}h1{font-size:clamp(36px,6vw,56px);margin:.2em 0}.kicker,.meta,.badge{font:500 12px 'IBM Plex Mono',monospace;text-transform:uppercase;letter-spacing:.07em}.badge{display:inline-block;padding:6px 10px;border-radius:999px;background:var(--amber);color:#fff}.meta{color:var(--muted);margin:12px 0 28px}.lead{font-size:20px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:16px 0;box-shadow:0 7px 20px #6b625310}code{font-family:'IBM Plex Mono',monospace;font-size:.86em;background:#eee6d6;padding:.1em .35em;border-radius:4px}ol,ul{padding-left:1.2em}li{margin:.45em 0}.check li{list-style:'□  '}
   </style>
 </head>
 <body><main>
   <div class="kicker">muxr spec</div>
   <h1>Plugins on primitives</h1>
-  <span class="badge">tested</span>
-  <p class="meta">plugin-primitives.md · created 2026-08-15 · updated 2026-08-18 · umer</p>
+  <span class="badge">implemented</span>
+  <p class="meta">plugin-primitives.md · created 2026-08-15 · updated 2026-08-19 · umer</p>
   <p class="lead">Primitives, slots, actions, capabilities, and runtime contracts are the public platform. Inbox, Voice, Preview, Changes, Attachments, and future product features are plugins composed entirely from it.</p>
   <div class="card"><h2>Decision</h2><p>Enabled Herdr plugins remain trusted and default-on. Enabling or linking is the user's trust decision. Explicit disable and revoke remain authoritative. This rework strengthens the platform without adding per-device hash reapproval.</p></div>
   <div class="card"><h2>Five platform layers</h2><ol>
@@ -31,7 +31,7 @@
     <li>Hard-kill stuck RPCs, isolate concurrency, and stop repeated full catalog reparsing.</li>
     <li>Publish schemas and prove bundled plus adversarial third-party plugins on Android.</li>
   </ol></div>
-  <div class="card"><h2>Latest revision</h2><p>Browser grants admit only explicitly read-mode RPCs from package-owned bundled plugin roots. Omitted modes and third-party self-declarations fail closed, while read-only session opens leave global attention untouched. Terminal links are stripped statefully, reject control, bidi, and credential-bearing forms, canonicalize through the platform URL parser, and remain latest-first and bounded across sessions.</p></div>
+  <div class="card"><h2>Latest revision</h2><p>The public <code>shortcuts</code> contribution keeps its localized Android launcher entry, deep link, and live enabled-catalog guard. Optional Assistant App Actions capability metadata is being removed because Google Play continued rejecting the signed release after the owner accepted both terms surfaces.</p></div>
   <div class="card"><h2>Verification</h2><ul class="check">
     <li>Automation passes 29/29; all 12 bundled plugins and adversarial combinations validate correctly.</li>
     <li>The v11 manifest/tokenization flow, mobile typecheck, web export, and Android production JS bundle pass.</li>

--- a/docs/specs/plugin-primitives.md
+++ b/docs/specs/plugin-primitives.md
@@ -1,9 +1,9 @@
 ---
 title: Plugins on primitives
 slug: plugin-primitives
-status: tested
+status: implemented
 created: 2026-08-15
-updated: 2026-08-18
+updated: 2026-08-19
 owner: umer
 links:
   - ../decisions/0005-pi-like-extension-runtime.md
@@ -50,7 +50,7 @@ The Usage plugin uses the exact pinned ccusage native package as its backend agg
 
 UI version 13 makes dynamic plugin data genuinely visual without creating a plugin layout engine: progress may bind one bounded numeric data path; sections may arrange safe summary nodes in two or three responsive columns; and one bounded `chart` node renders app-owned bar or ring presentation with a visible text legend and full accessibility summary. Series are capped, plugins cannot supply colors, markup, axes, animation, or interaction, and malformed runtime values degrade to an empty state. Usage is the load-bearing proof: today’s measured agent activity and Codex limits use the same public nodes available to every third-party plugin.
 
-UI version 12 allows generic `item-list` rows to omit actions for read-only status/metric presentation while preserving closed validation for actionable rows. UI version 11 adds a bounded declarative `code` node with app-owned Prism tokenization, line numbers, selection, shared theme tokens, and plain-text fallback. The same tokenizer now powers native/web file views, Markdown code fences, and native diff lines, replacing the duplicate hand-rolled regex highlighter. File previews read at most 24 KiB / 240 lines and report truncation; ordinary text remains capped at 4 KiB while a sanitized RPC result string may use the existing 64 KiB total transport budget. UI version 7 adds plugin-owned navigation badge read sources and singleton tree-sheet cardinality. UI version 6 makes user-visible manifest strings bounded localized values with exact-locale, base-locale, then default fallback on the phone. The same public `shortcuts` contribution drives build-time localized Assistant resources and the live Android launcher projection. Runtime-installed plugins cannot add Assistant capability bindings because Android only accepts those from packaged XML; a third-party plugin included in a custom build receives the identical build-time behavior.
+UI version 12 allows generic `item-list` rows to omit actions for read-only status/metric presentation while preserving closed validation for actionable rows. UI version 11 adds a bounded declarative `code` node with app-owned Prism tokenization, line numbers, selection, shared theme tokens, and plain-text fallback. The same tokenizer now powers native/web file views, Markdown code fences, and native diff lines, replacing the duplicate hand-rolled regex highlighter. File previews read at most 24 KiB / 240 lines and report truncation; ordinary text remains capped at 4 KiB while a sanitized RPC result string may use the existing 64 KiB total transport budget. UI version 7 adds plugin-owned navigation badge read sources and singleton tree-sheet cardinality. UI version 6 makes user-visible manifest strings bounded localized values with exact-locale, base-locale, then default fallback on the phone. The same public `shortcuts` contribution drives build-time localized launcher resources and the live Android launcher projection. Optional Assistant capability metadata is intentionally absent from every build.
 
 ## Files
 
@@ -86,6 +86,7 @@ UI version 12 allows generic `item-list` rows to omit actions for read-only stat
 
 ## Revisions
 
+- 2026-08-19 — Remove optional Assistant App Actions capability metadata after Google Play continued rejecting the signed release despite owner acceptance of both terms surfaces. Keep the same public `shortcuts` contribution, localized launcher shortcut, deep link, and live enabled-catalog guard.
 - 2026-08-18 — Browser grants now admit only explicitly read-mode RPCs from package-owned bundled plugin roots; omitted modes and third-party self-declarations fail closed. Read-only session opens no longer acknowledge global attention. Terminal link extraction is stateful, control-safe, canonical, credential-free, latest-first, and bounded across sessions.
 - 2026-08-18 — Bundled plugin consolidation: file-viewer + changes + git-history + runbook merged into `code`, usage-status + vitals into `status`, ports + run-server into `servers` (17 → 12 packages). Same public contract, same primitives; the contribution cap rises 16 → 24 for merged manifests, and setup now unlinks retired bundled ids.
 - 2026-08-17 — Reopened for bounded dynamic presentation: add data-bound progress, responsive summary columns, and one app-owned bar/ring chart with capped series, visible legends, and no plugin colors, markup, animation, or executable UI.

--- a/packages/contract/src/plugins.ts
+++ b/packages/contract/src/plugins.ts
@@ -565,16 +565,16 @@ export type PluginEventAction =
     };
 
 /**
- * An Android launcher shortcut. Packaged contributions additionally become
- * Assistant App Actions; runtime-installed contributions become dynamic
- * launcher shortcuts. Both run the same closed action union events use.
+ * An Android launcher shortcut. Packaged contributions are baked into the app;
+ * runtime-installed contributions become dynamic shortcuts. Both run the same
+ * closed action union events use.
  */
 export interface PluginShortcut {
     slot: 'shortcuts';
     id: string;
     label: PluginText;
     longLabel?: PluginText;
-    /** Spoken phrases, e.g. ["Jarvis", "voice agent", "talk"]. */
+    /** Legacy aliases retained for deep links made by older builds. */
     synonyms: PluginText[];
     action: PluginEventAction;
 }

--- a/scripts/checkBundledPlugins.mjs
+++ b/scripts/checkBundledPlugins.mjs
@@ -74,7 +74,11 @@ if (readFileSync(bakedShortcutsPath, 'utf8') !== expectedShortcuts) {
 }
 const nativeShortcuts = readFileSync(nativeShortcutsPath, 'utf8');
 if (!nativeShortcuts.includes('android:targetPackage="com.trymuxr.app"') || /android:targetPackage="@/.test(nativeShortcuts)) {
-    process.stderr.write('FAIL Android App Actions targetPackage must be the literal Play package id\n');
+    process.stderr.write('FAIL Android launcher shortcut targetPackage must be the literal Play package id\n');
+    failed += 1;
+}
+if (/<capability(?:-binding)?\b/.test(nativeShortcuts) || nativeShortcuts.includes('actions.intent.')) {
+    process.stderr.write('FAIL Android launcher shortcuts must not declare Play-blocked App Actions capabilities\n');
     failed += 1;
 }
 const localizedShortcutFixture = [{


### PR DESCRIPTION
## Summary
- remove optional Assistant App Actions capability metadata that blocks Play submission
- preserve localized launcher shortcuts, deep links, aliases, and live catalog checks
- add a regression guard and update current docs/spec state

## Verification
- `node scripts/runSuite.mjs` — 29/29
- signed local AAB versionCode 8 / versionName 0.1.7
- final AAB shortcuts resource contains no App Actions capability metadata
- Google Play accepted the AAB into internal testing
- independent Kimi rereview: SHIP