### PR TITLE
Spec: mark Play launcher shortcut revision tested

### DIFF
--- a/docs/specs/index.html
+++ b/docs/specs/index.html
@@ -14,13 +14,13 @@
   <div class="kicker">muxr engineering</div>
   <h1>Specification board</h1>
   <p>Durable plans, implementation status, and verification evidence.</p>
-  <div class="legend"><span>◐ In progress 0</span><span>◑ Implemented 2</span><span>● Tested 1</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
+  <div class="legend"><span>◐ In progress 0</span><span>◑ Implemented 1</span><span>● Tested 2</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
   <section class="group"><h2>In progress</h2><p class="empty">No specifications currently in progress.</p></section>
   <section class="group"><h2>Implemented</h2>
-    <a class="row" href="plugin-primitives.html"><span class="pip implemented"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-19</span></a>
     <a class="row" href="pi-parity-extension-phase.html"><span class="pip implemented"></span><span class="title">Pi-Parity Extension Phase</span><span class="date">2026-08-15</span></a>
   </section>
   <section class="group"><h2>Tested</h2>
+    <a class="row" href="plugin-primitives.html"><span class="pip tested"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-19</span></a>
     <a class="row" href="remote-relay-enrollment.html"><span class="pip tested"></span><span class="title">Shared Remote Relay Enrollment</span><span class="date">2026-08-17</span></a>
   </section>
   <section class="group"><h2>Planned</h2><a class="row" href="native-voice-transport.html"><span class="pip" style="background:var(--muted)"></span><span class="title">Native voice transport</span><span class="date">2026-08-18</span></a></section>

--- a/docs/specs/plugin-primitives.html
+++ b/docs/specs/plugin-primitives.html
@@ -7,13 +7,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600;700&family=Hanken+Grotesk:wght@400;600&family=IBM+Plex+Mono:wght@500&display=swap" rel="stylesheet">
   <style>
     :root{--paper:#f4efe4;--card:#faf7ef;--ink:#211c15;--muted:#6b6253;--accent:#d14523;--sage:#5f7a5a;--amber:#b8791f;--line:#ddd3bf}
-    *{box-sizing:border-box}body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.55 'Hanken Grotesk',sans-serif}main{max-width:820px;margin:auto;padding:56px 24px 80px}h1,h2{font-family:Fraunces,serif}h1{font-size:clamp(36px,6vw,56px);margin:.2em 0}.kicker,.meta,.badge{font:500 12px 'IBM Plex Mono',monospace;text-transform:uppercase;letter-spacing:.07em}.badge{display:inline-block;padding:6px 10px;border-radius:999px;background:var(--amber);color:#fff}.meta{color:var(--muted);margin:12px 0 28px}.lead{font-size:20px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:16px 0;box-shadow:0 7px 20px #6b625310}code{font-family:'IBM Plex Mono',monospace;font-size:.86em;background:#eee6d6;padding:.1em .35em;border-radius:4px}ol,ul{padding-left:1.2em}li{margin:.45em 0}.check li{list-style:'□  '}
+    *{box-sizing:border-box}body{margin:0;background:var(--paper);color:var(--ink);font:17px/1.55 'Hanken Grotesk',sans-serif}main{max-width:820px;margin:auto;padding:56px 24px 80px}h1,h2{font-family:Fraunces,serif}h1{font-size:clamp(36px,6vw,56px);margin:.2em 0}.kicker,.meta,.badge{font:500 12px 'IBM Plex Mono',monospace;text-transform:uppercase;letter-spacing:.07em}.badge{display:inline-block;padding:6px 10px;border-radius:999px;background:var(--sage);color:#fff}.meta{color:var(--muted);margin:12px 0 28px}.lead{font-size:20px}.card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:22px 24px;margin:16px 0;box-shadow:0 7px 20px #6b625310}code{font-family:'IBM Plex Mono',monospace;font-size:.86em;background:#eee6d6;padding:.1em .35em;border-radius:4px}ol,ul{padding-left:1.2em}li{margin:.45em 0}.check li{list-style:'□  '}
   </style>
 </head>
 <body><main>
   <div class="kicker">muxr spec</div>
   <h1>Plugins on primitives</h1>
-  <span class="badge">implemented</span>
+  <span class="badge">tested</span>
   <p class="meta">plugin-primitives.md · created 2026-08-15 · updated 2026-08-19 · umer</p>
   <p class="lead">Primitives, slots, actions, capabilities, and runtime contracts are the public platform. Inbox, Voice, Preview, Changes, Attachments, and future product features are plugins composed entirely from it.</p>
   <div class="card"><h2>Decision</h2><p>Enabled Herdr plugins remain trusted and default-on. Enabling or linking is the user's trust decision. Explicit disable and revoke remain authoritative. This rework strengthens the platform without adding per-device hash reapproval.</p></div>
@@ -31,7 +31,7 @@
     <li>Hard-kill stuck RPCs, isolate concurrency, and stop repeated full catalog reparsing.</li>
     <li>Publish schemas and prove bundled plus adversarial third-party plugins on Android.</li>
   </ol></div>
-  <div class="card"><h2>Latest revision</h2><p>The public <code>shortcuts</code> contribution keeps its localized Android launcher entry, deep link, and live enabled-catalog guard. Optional Assistant App Actions capability metadata is being removed because Google Play continued rejecting the signed release after the owner accepted both terms surfaces.</p></div>
+  <div class="card"><h2>Latest revision</h2><p>The public <code>shortcuts</code> contribution keeps its localized Android launcher entry, deep link, and live enabled-catalog guard. Optional Assistant App Actions capability metadata was removed after Google Play continued rejecting the signed release; the rebuilt versionCode 8 bundle then passed Play ingestion and closed-test release validation.</p></div>
   <div class="card"><h2>Verification</h2><ul class="check">
     <li>Automation passes 29/29; all 12 bundled plugins and adversarial combinations validate correctly.</li>
     <li>The v11 manifest/tokenization flow, mobile typecheck, web export, and Android production JS bundle pass.</li>

--- a/docs/specs/plugin-primitives.md
+++ b/docs/specs/plugin-primitives.md
@@ -1,7 +1,7 @@
 ---
 title: Plugins on primitives
 slug: plugin-primitives
-status: implemented
+status: tested
 created: 2026-08-15
 updated: 2026-08-19
 owner: umer
@@ -86,7 +86,7 @@ UI version 12 allows generic `item-list` rows to omit actions for read-only stat
 
 ## Revisions
 
-- 2026-08-19 — Remove optional Assistant App Actions capability metadata after Google Play continued rejecting the signed release despite owner acceptance of both terms surfaces. Keep the same public `shortcuts` contribution, localized launcher shortcut, deep link, and live enabled-catalog guard.
+- 2026-08-19 — Remove optional Assistant App Actions capability metadata after Google Play continued rejecting the signed release despite owner acceptance of both terms surfaces. Keep the same public `shortcuts` contribution, localized launcher shortcut, deep link, and live enabled-catalog guard. The signed versionCode 8 bundle then passed Play ingestion, internal testing, and closed-test release validation.
 - 2026-08-18 — Browser grants now admit only explicitly read-mode RPCs from package-owned bundled plugin roots; omitted modes and third-party self-declarations fail closed. Read-only session opens no longer acknowledge global attention. Terminal link extraction is stateful, control-safe, canonical, credential-free, latest-first, and bounded across sessions.
 - 2026-08-18 — Bundled plugin consolidation: file-viewer + changes + git-history + runbook merged into `code`, usage-status + vitals into `status`, ports + run-server into `servers` (17 → 12 packages). Same public contract, same primitives; the contribution cap rises 16 → 24 for merged manifests, and setup now unlinks retired bundled ids.
 - 2026-08-17 — Reopened for bounded dynamic presentation: add data-bound progress, responsive summary columns, and one app-owned bar/ring chart with capped series, visible legends, and no plugin colors, markup, animation, or executable UI.


### PR DESCRIPTION
## Evidence
- full muxr suite passed 29/29
- signed versionCode 8 / versionName 0.1.7 bundle verified
- Google Play accepted the bundle into internal testing and validated the closed-test release
- live Digital Asset Links now uses the Play app-signing certificate
- public/private implementation trees matched after PR #51