### PR TITLE
Keep Android connected and align plugin UX

### DIFF
--- a/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayModule.kt
+++ b/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayModule.kt
@@ -256,6 +256,19 @@ class VoiceOverlayModule : Module() {
         .getOrDefault(false)
     }
 
+    Function("openBackgroundActivitySettings") {
+      val context = context() ?: return@Function false
+      val details = Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.parse("package:${context.packageName}"),
+      ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+      runCatching {
+        context.startActivity(details)
+        true
+      }.onFailure { Log.w(TAG, "Opening background activity settings failed", it) }
+        .getOrDefault(false)
+    }
+
     Function("clearNotification") {
       val context = context() ?: return@Function false
       VoiceOverlayService.clearNotification(context)

--- a/apps/mobile/modules/voice-overlay/index.ts
+++ b/apps/mobile/modules/voice-overlay/index.ts
@@ -27,6 +27,7 @@ interface VoiceNative {
     supportsPromotedNotifications?: () => boolean;
     canPostPromotedNotifications?: () => boolean;
     openPromotedNotificationSettings?: () => boolean;
+    openBackgroundActivitySettings?: () => boolean;
     clearNotification: () => boolean;
     addListener: (
         event: 'onNotificationActionRequested',
@@ -142,6 +143,14 @@ export function canPostPromotedNotifications(): boolean {
 export function openPromotedNotificationSettings(): boolean {
     try {
         return native?.openPromotedNotificationSettings?.() ?? false;
+    } catch {
+        return false;
+    }
+}
+
+export function openBackgroundActivitySettings(): boolean {
+    try {
+        return native?.openBackgroundActivitySettings?.() ?? false;
     } catch {
         return false;
     }

--- a/apps/mobile/sources/components/KernelNotifications.tsx
+++ b/apps/mobile/sources/components/KernelNotifications.tsx
@@ -6,6 +6,7 @@ import { useHerdrTree, useLocalSettingMutable, useSessions, useSocketStatus } fr
 import {
     canPostPromotedNotifications,
     clearVoiceNotification,
+    openBackgroundActivitySettings,
     openPromotedNotificationSettings,
     startHerdKeepalive,
     stopHerdKeepalive,
@@ -37,7 +38,9 @@ export function KernelNotifications() {
     const [presentation, setPresentation] = React.useState(herd);
     const [appActive, setAppActive] = React.useState(AppState.currentState === 'active');
     const [promotionPrompted, setPromotionPrompted] = useLocalSettingMutable('promotedNotificationsPrompted');
+    const [backgroundPrompted, setBackgroundPrompted] = useLocalSettingMutable('backgroundConnectionPrompted');
     const promotionPrompting = React.useRef(false);
+    const backgroundPrompting = React.useRef(false);
     const keepalive = React.useRef(false);
     const herdActive = herd.mode === 'working' || herd.mode === 'attention';
 
@@ -90,8 +93,29 @@ export function KernelNotifications() {
             || !appActive
             || !isAuthenticated
             || !herdActive
+            || backgroundPrompted
+            || backgroundPrompting.current
+        ) return;
+        backgroundPrompting.current = true;
+        setBackgroundPrompted(true);
+        void Modal.confirm(
+            'Keep muxr connected in the background?',
+            'Android may pause muxr when you leave the app. Open app settings, choose Battery, then allow background activity or select Unrestricted. If your phone has “Manage automatically”, turn it off and allow background running.',
+            { confirmText: 'Open settings' },
+        ).then((confirmed) => {
+            if (confirmed) openBackgroundActivitySettings();
+        }).finally(() => { backgroundPrompting.current = false; });
+    }, [appActive, backgroundPrompted, herdActive, isAuthenticated, setBackgroundPrompted]);
+
+    React.useEffect(() => {
+        if (
+            Platform.OS !== 'android'
+            || !appActive
+            || !isAuthenticated
+            || !herdActive
             || promotionPrompted
             || promotionPrompting.current
+            || backgroundPrompting.current
             || !supportsPromotedNotifications()
             || canPostPromotedNotifications()
         ) return;

--- a/apps/mobile/sources/components/SettingsView.tsx
+++ b/apps/mobile/sources/components/SettingsView.tsx
@@ -24,6 +24,7 @@ import { loadAppConfig } from '@/sync/appConfig';
 import { DeclarativeSettingsItems } from '@/plugins/DeclarativePluginSlot';
 import {
     canPostPromotedNotifications,
+    openBackgroundActivitySettings,
     openPromotedNotificationSettings,
     supportsPromotedNotifications,
 } from '@/../modules/voice-overlay';
@@ -346,6 +347,14 @@ export const SettingsView = React.memo(function SettingsView({
                     icon={<Ionicons name="options-outline" size={29} color="#FF9500" />}
                     onPress={() => router.push('/settings/features')}
                 />
+                {Platform.OS === 'android' && (
+                    <Item
+                        title="Background connection"
+                        subtitle="Allow background activity so Live stays connected when you leave muxr"
+                        icon={<Ionicons name="battery-charging-outline" size={29} color="#34C759" />}
+                        onPress={openBackgroundActivitySettings}
+                    />
+                )}
                 {promotedNotificationsSupported && (
                     <Item
                         title="Live agent updates"

--- a/apps/mobile/sources/sync/localSettings.ts
+++ b/apps/mobile/sources/sync/localSettings.ts
@@ -13,6 +13,7 @@ export const LocalSettingsSchema = z.object({
     verboseLogging: z.boolean().describe('Log all network requests and responses'),
     zenMode: z.boolean().describe('Hide all sidebars and non-essential UI for focused work'),
     promotedNotificationsPrompted: z.boolean().describe('Whether Android Live Updates access was already explained'),
+    backgroundConnectionPrompted: z.boolean().describe('Whether Android background activity settings were already explained'),
     // Herd tab: bucket the agents section under workspace subheaders (herdr's "grouped" toggle).
     // Saved herdr tab layouts (split tree + agent kind per pane), newest first.
     savedLayouts: z
@@ -41,6 +42,7 @@ export const localSettingsDefaults: LocalSettings = {
     verboseLogging: false,
     zenMode: false,
     promotedNotificationsPrompted: false,
+    backgroundConnectionPrompted: false,
     savedLayouts: [],
 };
 Object.freeze(localSettingsDefaults);

--- a/plugins/code/files.mjs
+++ b/plugins/code/files.mjs
@@ -12,11 +12,20 @@ const input = JSON.parse(readFileSync(0, 'utf8') || 'null') ?? {};
 
 function repos() {
     const workspaces = JSON.parse(exec(herdr, ['workspace', 'list'])).result.workspaces ?? [];
+    const panes = JSON.parse(exec(herdr, ['pane', 'list'])).result.panes ?? [];
     const seen = new Map();
     for (const workspace of workspaces) {
-        const root = workspace.worktree?.repo_root;
-        if (typeof root === 'string' && root !== '' && !seen.has(root)) {
-            seen.set(root, { root, name: root.split('/').pop() ?? root, path: root });
+        const configured = workspace.worktree?.repo_root;
+        const candidates = typeof configured === 'string' && configured !== ''
+            ? [configured]
+            : panes.filter((pane) => pane.workspace_id === workspace.workspace_id)
+                .map((pane) => pane.foreground_cwd ?? pane.cwd);
+        for (const candidate of new Set(candidates)) {
+            if (typeof candidate !== 'string' || candidate === '') continue;
+            let root;
+            try { root = exec('git', ['-C', candidate, 'rev-parse', '--show-toplevel'], 3000).trim(); }
+            catch { continue; }
+            if (root !== '' && !seen.has(root)) seen.set(root, { root, name: root.split('/').pop() ?? root, path: root });
         }
     }
     return [...seen.values()].slice(0, 32);

--- a/plugins/code/runbook.mjs
+++ b/plugins/code/runbook.mjs
@@ -26,8 +26,21 @@ function commands() {
 
 function repoRoots() {
     const workspaces = JSON.parse(runFile('herdr', ['workspace', 'list'])).result.workspaces ?? [];
-    return [...new Set(workspaces.map((workspace) => workspace.worktree?.repo_root)
-        .filter((root) => typeof root === 'string' && root !== '' && existsSync(root)))].slice(0, 24);
+    const panes = JSON.parse(runFile('herdr', ['pane', 'list'])).result.panes ?? [];
+    const roots = new Set();
+    for (const workspace of workspaces) {
+        const configured = workspace.worktree?.repo_root;
+        const candidates = typeof configured === 'string' && configured !== ''
+            ? [configured]
+            : panes.filter((pane) => pane.workspace_id === workspace.workspace_id)
+                .map((pane) => pane.foreground_cwd ?? pane.cwd);
+        for (const candidate of new Set(candidates)) {
+            if (typeof candidate !== 'string' || candidate === '') continue;
+            try { roots.add(runFile('git', ['-C', candidate, 'rev-parse', '--show-toplevel']).trim()); }
+            catch { /* a pane can leave a repository while this list is built */ }
+        }
+    }
+    return [...roots].filter((root) => root !== '' && existsSync(root)).slice(0, 24);
 }
 
 function folderTree() {

--- a/plugins/status/usage.mjs
+++ b/plugins/status/usage.mjs
@@ -255,7 +255,7 @@ if (cached !== undefined) {
   const output = {
     items: ordered.slice(0, 50), actions: [],
     ...(activity.totalTokens > 0 && totalTokens !== undefined
-      ? { badge: { value: totalTokens, ...(codex.items.length && codex.remaining <= 10 ? { tone: 'danger' } : {}) } }
+      ? { badge: { value: `${totalTokens} tokens today` } }
       : {}),
     summary: {
       measured: String(activity.series.length),

--- a/plugins/status/vitals.mjs
+++ b/plugins/status/vitals.mjs
@@ -5,7 +5,10 @@ import { freemem, totalmem, loadavg, uptime } from 'node:os';
 const gb = (bytes) => `${(bytes / 1024 ** 3).toFixed(1)}G`;
 const hours = Math.floor(uptime() / 3600);
 let disk = 'unknown';
-try { disk = execSync('df -h / | tail -1', { encoding: 'utf8' }).trim().split(/\s+/).slice(2, 5).join(' used of ').replace(/ used of /, ' used, ') + ' free'; } catch {}
+try {
+  const [, size, used, free, percent] = execSync('df -h / | tail -1', { encoding: 'utf8' }).trim().split(/\s+/);
+  disk = `${used} used of ${size} (${percent}) · ${free} free`;
+} catch {}
 process.stdout.write(JSON.stringify(
   `memory ${gb(totalmem() - freemem())} of ${gb(totalmem())} · load ${loadavg().map((n) => n.toFixed(2)).join(' ')} · up ${hours}h · disk ${disk}`,
 ));

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -31,7 +31,7 @@ try {
     assert.deepEqual(activity, { 'Anthropic Claude': '1.3M tokens', 'Kimi Code': '2.5K tokens', Pi: '800 tokens' });
     assert.ok(output.items.some((item) => item.id === 'limit-codex-0' && item.metadata[0]?.value === '75% left' && item.group === 'Rate limits'));
     assert.ok(output.items.some((item) => item.id === 'activity-claude' && item.group === 'Active today' && item.progress?.value === 1));
-    assert.equal(output.badge?.value, '1.3M');
+    assert.equal(output.badge?.value, '1.3M tokens today');
     assert.equal(output.summary?.totalTokens, '1.3M');
     const installed = Object.fromEntries(output.items.filter((item) => item.id.startsWith('available-')).map((item) => [item.title, item]));
     assert.equal(installed.OpenCode?.group, 'Idle today');

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -429,9 +429,12 @@ export async function runPackage(command, args = []) {
     if (command === 'list') { if (args.length) fail('muxr plugin list takes no arguments'); for (const plugin of herdrPlugins()) process.stdout.write(`${plugin.plugin_id}\t${plugin.version ?? '0.0.0'}\t${plugin.enabled ? 'enabled' : 'disabled'}\t${JSON.stringify(sourceFor(plugin))}\t${plugin.plugin_root ?? ''}\n`); return 0; }
     if (!['install', 'update', 'remove'].includes(command)) fail(`unknown package command: ${command}`);
     if (command === 'remove') {
-        const { spec: id, yes } = requireArgs(args, command); if (!ID_RE.test(id)) fail('plugin id must match [a-z0-9][a-z0-9._-]{0,63}');
+        const { spec: requested, yes } = requireArgs(args, command); if (!ID_RE.test(requested)) fail('plugin id must match [a-z0-9][a-z0-9._-]{0,63}');
+        const installed = herdrPlugins();
+        const localId = `local.${requested}`.slice(0, 64);
+        const id = pluginFor(installed, requested) ? requested : pluginFor(installed, localId) ? localId : requested;
         return withRegistryLock(id, async () => {
-            const plugin = pluginFor(herdrPlugins(), id); if (!plugin) fail(`plugin is not installed: ${id}`); const npm = validNpmProvenance(plugin); const action = npm ? 'unlink then remove managed npm materialization' : plugin.source?.kind === 'github' ? 'uninstall' : 'unlink';
+            const plugin = pluginFor(herdrPlugins(), id); if (!plugin) fail(`plugin is not installed: ${requested}`); const npm = validNpmProvenance(plugin); const action = npm ? 'unlink then remove managed npm materialization' : plugin.source?.kind === 'github' ? 'uninstall' : 'unlink';
             if (!await confirm(yes, `Remove ${id} (${action})?`)) return 0;
             if (npm) { runHerdr(['plugin', 'unlink', id]); const root = validRoot(plugin.plugin_root); if (!root || root !== join(resolve(extensionHome()), id)) fail('refusing to remove an untrusted npm materialization path'); rmSync(root, { recursive: true, force: true }); removeProvenance(id); }
             else runHerdr(['plugin', action === 'uninstall' ? 'uninstall' : 'unlink', id]);

--- a/scripts/packageLifecycleSmoke.mjs
+++ b/scripts/packageLifecycleSmoke.mjs
@@ -223,15 +223,15 @@ try {
     // Local install/update/remove and a declined confirmation use the same
     // Herdr registry lifecycle as npm packages.
     const localRoot = join(scratch, 'local-plugin'); mkdirSync(localRoot);
-    writeFileSync(join(localRoot, 'herdr-plugin.toml'), 'id = "test.local"\nname = "Local"\nversion = "1.0.0"\n');
+    writeFileSync(join(localRoot, 'herdr-plugin.toml'), 'id = "local.my-plugin"\nname = "Local"\nversion = "1.0.0"\n');
     await runPackage('install', [localRoot]);
     assert.equal(readFileSync(statePath, 'utf8'), '', 'cancelled local install left a registry entry');
     await runPackage('install', [localRoot, '--yes']);
     assert.equal(JSON.parse(readFileSync(statePath)).enabled, true);
-    writeFileSync(join(localRoot, 'herdr-plugin.toml'), 'id = "test.local"\nname = "Local updated"\nversion = "2.0.0"\n');
+    writeFileSync(join(localRoot, 'herdr-plugin.toml'), 'id = "local.my-plugin"\nname = "Local updated"\nversion = "2.0.0"\n');
     await runPackage('update', [localRoot, '--yes']);
     assert.equal(JSON.parse(readFileSync(statePath)).plugin_root, realpathSync(localRoot));
-    await runPackage('remove', ['test.local', '--yes']);
+    await runPackage('remove', ['my-plugin', '--yes']);
     assert.equal(readFileSync(statePath, 'utf8'), '');
 
     const liveLock = join(extensionRoot, '.locks', 'test.npm.lock');


### PR DESCRIPTION
## Summary
- explain Android background battery settings once when Live first needs them, with a permanent Settings entry
- discover plain git workspaces in Files and Runbook even without Herdr worktree metadata
- clarify machine disk and token usage labels
- let `muxr plugin remove my-plugin` remove `local.my-plugin` created by the CLI

## Verification
- full suite: 30/30
- Android voice-overlay release Kotlin compile
- package lifecycle smoke
- bundled plugin manifests
- real plain-cwd repository discovery