### PR TITLE
voice: report why the provider refused, not just the close code

### DIFF
--- a/plugins/voice/providerRefusal.spec.mjs
+++ b/plugins/voice/providerRefusal.spec.mjs
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { providerRefusal } from './stream.mjs';
+
+/**
+ * A close code alone sent someone hunting a version mismatch for an account
+ * that had simply run out of credits. The body is the only place that says so.
+ */
+describe('providerRefusal', () => {
+    it('surfaces the provider explanation the close code loses', () => {
+        const body = JSON.stringify({
+            code: 'The caller does not have permission to execute the specified operation',
+            error: 'Your team has either used all available credits or reached its monthly spending limit.',
+        });
+        expect(providerRefusal(403, body)).toBe(
+            'Voice provider refused the connection (HTTP 403): Your team has either used all available credits or reached its monthly spending limit.',
+        );
+    });
+
+    it('falls back to code when there is no error field', () => {
+        expect(providerRefusal(403, JSON.stringify({ code: 'forbidden' })))
+            .toBe('Voice provider refused the connection (HTTP 403): forbidden');
+    });
+
+    it('falls back to the raw body when it is not JSON', () => {
+        expect(providerRefusal(502, '  upstream boom  '))
+            .toBe('Voice provider refused the connection (HTTP 502): upstream boom');
+    });
+
+    it('still names the status when the body is empty', () => {
+        expect(providerRefusal(429, '')).toBe('Voice provider refused the connection (HTTP 429).');
+    });
+});

--- a/plugins/voice/stream.mjs
+++ b/plugins/voice/stream.mjs
@@ -228,6 +228,24 @@ function handleClientFrame(frame) {
     // mute/unmute are enforced on the phone's capture side; nothing to forward.
 }
 
+/**
+ * The provider explains a refusal in the HTTP body; the close code does not.
+ * An out-of-credits 403 is otherwise indistinguishable from a dropped network,
+ * and reporting only the code costs a debugging session to rediscover.
+ */
+export function providerRefusal(status, body) {
+    let detail = '';
+    try {
+        const parsed = JSON.parse(body);
+        if (typeof parsed?.error === 'string') detail = parsed.error;
+        else if (typeof parsed?.code === 'string') detail = parsed.code;
+    } catch { /* not JSON: fall back to the raw body */ }
+    if (detail === '') detail = body.trim();
+    return detail === ''
+        ? `Voice provider refused the connection (HTTP ${status}).`
+        : `Voice provider refused the connection (HTTP ${status}): ${detail.slice(0, 300)}`;
+}
+
 function connectProvider(key) {
     if (stopped) return;
     state('connecting', providerReconnects === 0 ? undefined : 'Voice provider reconnecting');
@@ -236,6 +254,15 @@ function connectProvider(key) {
         maxPayload: 4 * 1024 * 1024,
     });
     ws = current;
+    const onDown = (reason) => {
+        if (stopped || ws !== current) return;
+        if (providerReconnects >= 2) {
+            close(reason);
+            return;
+        }
+        providerReconnects += 1;
+        reconnectTimer = setTimeout(() => connectProvider(key), providerReconnects * 500);
+    };
     current.on('open', () => {
         if (stopped || ws !== current) return;
         current.send(JSON.stringify({
@@ -260,15 +287,21 @@ function connectProvider(key) {
         stableTimer = setTimeout(() => { providerReconnects = 0; }, PROVIDER_STABLE_AFTER_MS);
     });
     current.on('message', (data) => { if (ws === current) handleXaiEvent(String(data)); });
-    current.on('close', (code) => {
-        if (stopped || ws !== current) return;
-        if (providerReconnects >= 2) {
-            close(`The voice provider disconnected (${code}).`);
-            return;
-        }
-        providerReconnects += 1;
-        reconnectTimer = setTimeout(() => connectProvider(key), providerReconnects * 500);
+    // ws suppresses 'error' and 'close' once this is handled, so the failure
+    // path is driven from here. Auth and permission refusals are terminal:
+    // retrying an out-of-credits account only delays the real message.
+    current.on('unexpected-response', (_request, response) => {
+        let body = '';
+        response.on('data', (chunk) => { body += chunk; });
+        response.on('end', () => {
+            current.terminate();
+            if (stopped || ws !== current) return;
+            const reason = providerRefusal(response.statusCode, body);
+            if (response.statusCode === 401 || response.statusCode === 403) close(reason);
+            else onDown(reason);
+        });
     });
+    current.on('close', (code) => onDown(`The voice provider disconnected (${code}).`));
     current.on('error', (error) => {
         if (!stopped && ws === current) state('connecting', `Voice provider connection interrupted: ${String(error.message).slice(0, 160)}`);
     });


### PR DESCRIPTION
## Problem

Voice died on the phone with `The voice provider disconnected (1006).` A close code carries no information, so the only way to find the cause was to hand-probe the provider. It turned out to be:

```
HTTP 403 — "Your team has either used all available credits or reached its
monthly spending limit."
```

That message *was* being produced — `stream.mjs` caught it, put it in a transient `connecting` status, and immediately overwrote it. The message that survived was the useless one.

## Root cause

`ws` suppresses `error` and `close` once `unexpected-response` is handled, and the plugin never handled it — so the HTTP body, the only place the provider explains itself, was dropped on the floor.

## Change

- Handle `unexpected-response`, parse the refusal out of the body, and drive the failure path from there.
- `providerRefusal(status, body)` prefers the JSON `error` field, falls back to `code`, then the raw body, then bare status.
- **401/403 stop retrying.** An account without credits will not recover in 1.5s; three attempts only delayed the real message.

## Test

`plugins/voice/providerRefusal.spec.mjs` — 4 cases (JSON error, code fallback, non-JSON body, empty body). Passing.

## Note

Cherry-picked onto `origin/main` rather than rebased: local `main` and `origin/main` have no common ancestor, so a rebase replays 366 commits from the initial commit.