### PR TITLE
Show app/host build versions in Settings → Connection

### DIFF
--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { createDeviceGrant } from '@muxr/crypto';
 import { homedir, hostname } from 'node:os';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { assertFakeSourceCoversContract, createFakeSessionSource } from './fakeSessionSource.js';
 import { startHost } from './host.js';
 import { createHerdrSessionSource } from './herdr/herdrSessionSource.js';
@@ -18,6 +19,28 @@ function env(name: string): string | undefined {
 
 function defaultDataDir(): string {
     return join(homedir(), '.muxr', 'host');
+}
+
+/**
+ * The product/build version this host belongs to. The published artifact
+ * bundles the host to a host.js beside the @trymuxr/cli package.json; in the
+ * monorepo the workspace manifests are all 0.0.0 and the version lives at the
+ * root. Walk up to the first manifest with a real version.
+ */
+function resolveHostVersion(): string | undefined {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (let depth = 0; depth < 5; depth++) {
+        try {
+            const manifest = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { version?: unknown };
+            if (typeof manifest.version === 'string' && manifest.version !== '0.0.0') return manifest.version;
+        } catch {
+            // No manifest here — keep walking.
+        }
+        const parent = dirname(dir);
+        if (parent === dir) return undefined;
+        dir = parent;
+    }
+    return undefined;
 }
 
 class HostedAuthExpiredError extends Error {}
@@ -348,6 +371,7 @@ async function main(): Promise<void> {
               ...(hostedE2ee === undefined ? {} : { hostedE2ee }),
           });
 
+    const hostVersion = resolveHostVersion();
     startHost({
         ...(sharedKey ? { sharedKey } : {}),
         ...(hostedE2ee === undefined ? {} : { hostedE2ee }),
@@ -357,6 +381,7 @@ async function main(): Promise<void> {
         source,
         domain,
         terminals,
+        ...(hostVersion === undefined ? {} : { hostVersion }),
         onStateChange: (state) => {
             process.stdout.write(`relay link: ${state}\n`);
             if (state === 'replaced') {

--- a/apps/mobile/sources/app/(app)/settings/connection.tsx
+++ b/apps/mobile/sources/app/(app)/settings/connection.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Platform, Text, TextInput, View } from 'react-native';
+import Constants from 'expo-constants';
 import { Item } from '@/components/Item';
 import { ItemGroup } from '@/components/ItemGroup';
 import { ItemList } from '@/components/ItemList';
 import { RoundButton } from '@/components/RoundButton';
 import { Typography } from '@/constants/Typography';
-import { useSocketStatus } from '@/sync/storage';
+import { useMachine, useSocketStatus } from '@/sync/storage';
 import { syncReconnect } from '@/sync/sync';
 import { getActiveSshForward } from '@/state/sshForward';
 import {
@@ -17,6 +18,7 @@ import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { t } from '@/text';
 import { useRouter } from 'expo-router';
 import { getCachedHostedGrant } from '@/state/hostedE2ee';
+import { knownHostVersion, versionsMismatch } from '@/utils/versionStatus';
 
 const stylesheet = StyleSheet.create((theme) => ({
     label: {
@@ -53,6 +55,7 @@ const stylesheet = StyleSheet.create((theme) => ({
         ...Typography.default(),
     },
     actions: { paddingHorizontal: 16, paddingTop: 4, paddingBottom: 24 },
+    detailMismatch: { color: theme.colors.warning },
     dot: { width: 9, height: 9, borderRadius: 5 },
     dotOn: { backgroundColor: theme.colors.success },
     dotBusy: { backgroundColor: theme.colors.warning },
@@ -114,6 +117,7 @@ export default function ConnectionSettingsScreen() {
     const [encryptionKey, setEncryptionKey] = React.useState(initial.encryptionKey);
     const [error, setError] = React.useState<string | undefined>(undefined);
     const [saving, setSaving] = React.useState(false);
+    const machine = useMachine(initial.machineId);
 
     // getCachedConnectionSettings returns build-time defaults until storage has
     // hydrated. Opening this screen before that and pressing Save wrote those
@@ -141,6 +145,12 @@ export default function ConnectionSettingsScreen() {
         const where = overSsh
             ? 'Forwarded through the SSH connection you opened in Advanced setup'
             : initial.relayUrl;
+        // Diagnostic only: a mismatch never blocks anything, it answers "is my
+        // host older than my app?" without a debugging session.
+        const appVersion = Constants.expoConfig?.version || '0.0.0';
+        const reportedHost = machine?.metadata?.happyCliVersion;
+        const hostVersion = knownHostVersion(reportedHost);
+        const mismatch = versionsMismatch(appVersion, reportedHost);
         const browserExpiresAt = Platform.OS === 'web' ? getCachedHostedGrant(initial.machineId)?.expiresAt : undefined;
         const browserMinutes = browserExpiresAt === undefined ? undefined : Math.max(0, Math.ceil((browserExpiresAt - clock) / 60_000));
         return (
@@ -154,6 +164,11 @@ export default function ConnectionSettingsScreen() {
                     />
                     <Item title="Transport" subtitle={transport} detail={overSsh ? 'SSH' : 'Self-host'} />
                     <Item title="Relay" subtitle={where} subtitleLines={0} />
+                    <Item
+                        title="Versions"
+                        subtitle={`app ${appVersion} · host ${hostVersion ?? 'unknown'}`}
+                        {...(mismatch ? { detail: '⚠ mismatch', detailStyle: styles.detailMismatch } : {})}
+                    />
                     {Platform.OS === 'web' && <Item title="Browser access" subtitle={browserExpiresAt === undefined || browserMinutes === undefined
                         ? 'Read-only · pair again every eight hours'
                         : `Read-only · expires in ${Math.floor(browserMinutes / 60)}h ${browserMinutes % 60}m · ${new Date(browserExpiresAt).toLocaleString()}`} />}

--- a/apps/mobile/sources/utils/versionStatus.spec.ts
+++ b/apps/mobile/sources/utils/versionStatus.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { knownHostVersion, versionsMismatch } from './versionStatus';
+
+describe('versionStatus', () => {
+    it('flags a mismatch only when both versions are known and differ', () => {
+        expect(versionsMismatch('0.1.9', '0.1.6')).toBe(true);
+        expect(versionsMismatch('0.1.9', '0.1.9')).toBe(false);
+        // Unwired ('0.0.0') and silent ('muxr' placeholder / absent) hosts are
+        // "unknown", never a mismatch.
+        expect(knownHostVersion('0.0.0')).toBeUndefined();
+        expect(knownHostVersion('muxr')).toBeUndefined();
+        expect(knownHostVersion(undefined)).toBeUndefined();
+        expect(versionsMismatch('0.1.9', '0.0.0')).toBe(false);
+        expect(versionsMismatch('0.1.9', undefined)).toBe(false);
+        expect(knownHostVersion('0.1.6')).toBe('0.1.6');
+    });
+});

--- a/apps/mobile/sources/utils/versionStatus.ts
+++ b/apps/mobile/sources/utils/versionStatus.ts
@@ -1,0 +1,20 @@
+/**
+ * Session-scoped version diagnostic for Settings -> Connection. Nothing is
+ * persisted: the host announces its build version on `machine.hello` /
+ * `machines.list`, the app knows its own from expo-constants, and the row is
+ * recomputed on every render.
+ *
+ * Hosts predating the wire-up announce '0.0.0' (the field shipped but was
+ * never fed a real version), and the machine mapper used 'muxr' as the
+ * placeholder for a host that says nothing — both mean "unknown", and an
+ * unknown host version must not raise a mismatch.
+ */
+export function knownHostVersion(hostVersion: string | undefined): string | undefined {
+    if (hostVersion === undefined || hostVersion === '0.0.0' || hostVersion === 'muxr') return undefined;
+    return hostVersion;
+}
+
+export function versionsMismatch(appVersion: string, hostVersion: string | undefined): boolean {
+    const known = knownHostVersion(hostVersion);
+    return known !== undefined && known !== appVersion;
+}


### PR DESCRIPTION
## Problem

`The voice provider disconnected (1006)` on the phone, and no way to answer the first question: *is my host older than my app, or is this a real bug?* Every `version: 1` in the codebase is a config-schema or crypto-key version — no product version was observable anywhere.

## What was actually wrong

The wire already existed. The host announces `hostVersion` on `machine.hello` / `machines.list` — but `startHost` was never fed a real version, so **every host reported `0.0.0`**. A dead field, not a missing one.

## Change

- Host resolves its product version by walking up to the nearest `package.json` with a real version (the `@trymuxr/cli` manifest when packaged, the repo root in the monorepo — workspace manifests are all `0.0.0`).
- Settings → Connection renders a **Versions** row: `app X · host Y`, with a warning-coloured `⚠ mismatch`.
- Unwired (`0.0.0`) and silent (`muxr` placeholder) hosts read as `unknown` and never raise a false mismatch.

## Scope

Deliberately a diagnostic, not infrastructure. **Nothing is persisted, logged, or blocked** — the row is recomputed each render and dies with the session. No logs table, no telemetry, no new dependency (`expo-constants` and `useMachine` were already there).

## Test

`versionStatus.spec.ts` — mismatch only when both versions are known and differ; unknown hosts never flag.

## Note

Cherry-picked onto `origin/main`: local `main` and `origin/main` share no common ancestor, so a rebase replays 366 commits from the initial commit.