### PR TITLE
preview: dev server chip from terminal URLs, drop port scanning

### DIFF
--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -11,7 +11,7 @@ import type {
 import type { DomainStores } from '../domain/index.js';
 import type { TerminalManager } from '../herdr/terminalManager.js';
 import type { SessionSource } from '../sessionSource.js';
-import { attachPreview, listPreviewServers } from './preview.js';
+import { attachPreview, probePreviewPort } from './preview.js';
 import { landWorktree } from './landWorktree.js';
 import { listDir } from './listDir.js';
 import { runMachineShell } from './runMachineShell.js';
@@ -147,10 +147,7 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
         'machine.shell': (params) => runMachineShell(params.command, params.cwd),
         'machine.listDir': (params) => listDir(params.path),
         'worktree.land': (params) => landWorktree(params.worktreePath, params.message, params.stash),
-        'preview.list': (params) => {
-            if (options.relayUrl === undefined) throw new Error('Hosted Preview is disabled until browser trust and pinning are complete.');
-            return listPreviewServers(relayPort(options.relayUrl), params.cwd);
-        },
+        'preview.probe': async (params) => ({ contentType: await probePreviewPort(params.port) }),
         'preview.attach': (params) => {
             if (options.relayUrl === undefined) {
                 throw new Error('preview: host has no relay url');
@@ -254,13 +251,3 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
     };
 }
 
-/** The relay answers HTTP too, so without this it lists itself as a dev server. */
-function relayPort(relayUrl: string | undefined): number | undefined {
-    if (relayUrl === undefined) return undefined;
-    try {
-        const port = new URL(relayUrl).port;
-        return port === '' ? undefined : Number(port);
-    } catch {
-        return undefined;
-    }
-}

--- a/apps/host/src/requests/preview.test.ts
+++ b/apps/host/src/requests/preview.test.ts
@@ -1,29 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { insideProject, processCwd } from './preview.js';
 // @ts-expect-error bundled plugins are executable public fixtures, not TS packages
 import { insideProject as pluginInsideProject, parseLsofListeners as parsePluginLsof, parseSsListeners as parsePluginSs } from '../../../../plugins/servers/serve.mjs';
-
-describe('insideProject', () => {
-    it('matches a server running in the project root', () => {
-        expect(insideProject('/home/u/app', '/home/u/app')).toBe(true);
-    });
-
-    it('matches a server in a package below the session directory', () => {
-        expect(insideProject('/home/u/app', '/home/u/app/apps/web')).toBe(true);
-    });
-
-    it('matches a server at the root when the session sits in a package', () => {
-        expect(insideProject('/home/u/app/apps/web', '/home/u/app')).toBe(true);
-    });
-
-    it('rejects a sibling project', () => {
-        expect(insideProject('/home/u/app', '/home/u/other')).toBe(false);
-    });
-
-    it('rejects a directory that only shares a name prefix', () => {
-        expect(insideProject('/home/u/app', '/home/u/app-store')).toBe(false);
-    });
-});
 
 describe('bundled run-server discovery', () => {
     it('parses Linux/macOS listeners and rejects sibling or prefix-only projects', () => {
@@ -37,15 +14,5 @@ describe('bundled run-server discovery', () => {
         expect(pluginInsideProject('/home/u/app/apps/web', '/home/u/app')).toBe(true);
         expect(pluginInsideProject('/home/u/app', '/home/u/app-store')).toBe(false);
         expect(pluginInsideProject('/home/u/app', '/home/u/other')).toBe(false);
-    });
-});
-
-describe('processCwd', () => {
-    it('resolves this process', async () => {
-        expect(await processCwd(process.pid)).toBe(process.cwd());
-    });
-
-    it('stays undefined without a pid', async () => {
-        expect(await processCwd(undefined)).toBeUndefined();
     });
 });

--- a/apps/host/src/requests/preview.ts
+++ b/apps/host/src/requests/preview.ts
@@ -1,16 +1,15 @@
 /**
  * Browser preview, machine half.
  *
- * `listPreviewServers` finds local HTTP listeners. `attachPreview` joins a relay
- * preview channel and dials the chosen port on this machine's own loopback, so a
- * dev server bound to 127.0.0.1 needs no rebinding and is never exposed to the
- * network -- the only thing that leaves the machine is the relay socket the host
- * already holds open.
+ * `probePreviewPort` answers what a loopback port speaks, so the phone can
+ * tell a web app (Preview) from a JSON API (Open). `attachPreview` joins a
+ * relay preview channel and dials the chosen port on this machine's own
+ * loopback, so a dev server bound to 127.0.0.1 needs no rebinding and is
+ * never exposed to the network -- the only thing that leaves the machine is
+ * the relay socket the host already holds open.
  */
 
 import { connect, type Socket } from 'node:net';
-import { readlink } from 'node:fs/promises';
-import { isAbsolute, relative } from 'node:path';
 import WebSocket from 'ws';
 import {
     decodePreviewFrame,
@@ -18,146 +17,28 @@ import {
     previewSocketUrl,
     PREVIEW_CLOSE,
     PREVIEW_DATA,
-    type PreviewServer,
     issueWsTicket,
     ticketSocketUrl,
 } from '@muxr/contract';
-import { runMachineShell } from './runMachineShell.js';
 
 const PROBE_TIMEOUT_MS = 1200;
 const ATTACH_TIMEOUT_MS = 10_000;
 
-interface Listener {
-    port: number;
-    bind: string;
-    command: string;
-    pid?: number;
-}
-
-/** `LISTEN 0 511 127.0.0.1:8080 0.0.0.0:* users:(("node",pid=4039084,fd=21))` */
-export function parseSsListeners(stdout: string): Listener[] {
-    const listeners: Listener[] = [];
-    for (const line of stdout.split('\n')) {
-        if (!line.startsWith('LISTEN')) continue;
-        const fields = line.trim().split(/\s+/);
-        const local = fields[3];
-        if (local === undefined) continue;
-        const split = splitHostPort(local);
-        if (split === undefined) continue;
-        const process = /users:\(\("([^"]+)",pid=(\d+)/.exec(line);
-        listeners.push({
-            port: split.port,
-            bind: split.host,
-            command: process?.[1] ?? '',
-            ...(process?.[2] === undefined ? {} : { pid: Number(process[2]) }),
-        });
-    }
-    return listeners;
-}
-
-/** `node 12345 umer 21u IPv4 0x1 0t0 TCP 127.0.0.1:8080 (LISTEN)` */
-export function parseLsofListeners(stdout: string): Listener[] {
-    const listeners: Listener[] = [];
-    for (const line of stdout.split('\n')) {
-        if (!line.includes('(LISTEN)')) continue;
-        const fields = line.trim().split(/\s+/);
-        const address = fields[fields.length - 2];
-        const command = fields[0];
-        const pid = Number(fields[1]);
-        if (address === undefined || command === undefined) continue;
-        const split = splitHostPort(address);
-        if (split === undefined) continue;
-        listeners.push({
-            port: split.port,
-            bind: split.host,
-            command,
-            ...(Number.isFinite(pid) ? { pid } : {}),
-        });
-    }
-    return listeners;
-}
-
-/** Handles `127.0.0.1:8080`, `*:8081`, `0.0.0.0:3000` and `[::1]:9000`. */
-function splitHostPort(value: string): { host: string; port: number } | undefined {
-    const mark = value.lastIndexOf(':');
-    if (mark <= 0) return undefined;
-    const port = Number(value.slice(mark + 1));
-    if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined;
-    return { host: value.slice(0, mark), port };
-}
-
-async function readListeners(): Promise<Listener[]> {
-    const command = process.platform === 'darwin'
-        ? 'lsof -nP -iTCP -sTCP:LISTEN'
-        : 'ss -ltnp';
-    const result = await runMachineShell(command, process.cwd());
-    if (result.stdout.trim() === '') return [];
-    return process.platform === 'darwin'
-        ? parseLsofListeners(result.stdout)
-        : parseSsListeners(result.stdout);
-}
-
-/** A port is interesting only if something there answers HTTP. */
-async function speaksHttp(port: number): Promise<boolean> {
+/**
+ * The content-type the port answers with, or null when nothing HTTP listens
+ * there. GET, not HEAD: some servers 405 a HEAD and a web app would be
+ * misread as an API. The body is dropped unread -- the header is the answer.
+ */
+export async function probePreviewPort(port: number): Promise<string | null> {
     try {
-        await fetch(`http://127.0.0.1:${port}/`, {
-            method: 'HEAD',
+        const response = await fetch(`http://127.0.0.1:${port}/`, {
             signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
         });
-        return true;
+        void response.body?.cancel();
+        return response.headers.get('content-type');
     } catch {
-        return false;
+        return null;
     }
-}
-
-export async function listPreviewServers(excludePort?: number, cwd?: string): Promise<PreviewServer[]> {
-    const listeners = await readListeners();
-
-    // A dual-stack server shows up once per address family. The tunnel dials
-    // 127.0.0.1 regardless, so a second row for the same port is just noise.
-    const byPort = new Map<number, Listener>();
-    for (const listener of listeners) {
-        if (listener.port === excludePort) continue;
-        const seen = byPort.get(listener.port);
-        // Prefer the row that names a process; that is the one worth showing.
-        if (seen === undefined || (seen.command === '' && listener.command !== '')) {
-            byPort.set(listener.port, listener);
-        }
-    }
-
-    const candidates = [...byPort.values()];
-    const isHttp = await Promise.all(candidates.map((listener) => speaksHttp(listener.port)));
-    const http = candidates.filter((_, index) => isHttp[index] === true);
-    if (cwd === undefined) return http.sort((a, b) => a.port - b.port);
-
-    // Without a cwd the process cannot be tied to the project, so it stays out.
-    const cwds = await Promise.all(http.map((listener) => processCwd(listener.pid)));
-    return http
-        .filter((_, index) => {
-            const serverCwd = cwds[index];
-            return serverCwd !== undefined && insideProject(cwd, serverCwd);
-        })
-        .sort((a, b) => a.port - b.port);
-}
-
-/** Where the listener process runs. Undefined when the OS will not say. */
-export async function processCwd(pid: number | undefined): Promise<string | undefined> {
-    if (pid === undefined) return undefined;
-    if (process.platform !== 'darwin') {
-        return await readlink(`/proc/${pid}/cwd`).catch(() => undefined);
-    }
-    const result = await runMachineShell(`lsof -a -p ${pid} -d cwd -Fn`, process.cwd());
-    // `p4039084\nfcwd\nn/Users/umer/project`
-    return /^n(.+)$/m.exec(result.stdout)?.[1];
-}
-
-/** Counts when either directory contains the other: a dev server is often run from the repo root while the session sits in a package, or the reverse. */
-export function insideProject(sessionCwd: string, serverCwd: string): boolean {
-    const within = (outer: string, inner: string): boolean => {
-        const rel = relative(outer, inner);
-        return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-    };
-    return within(sessionCwd, serverCwd) || within(serverCwd, sessionCwd);
 }
 
 export interface AttachPreviewOptions {

--- a/apps/mobile/sources/app/(app)/session/[id]/preview.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/preview.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
-import { View, ScrollView, ActivityIndicator, Pressable, Platform } from 'react-native';
+import { View, ActivityIndicator, Pressable, Platform } from 'react-native';
 import { WebView } from 'react-native-webview';
 import { useUnistyles } from 'react-native-unistyles';
 import { Ionicons } from '@expo/vector-icons';
 import { useLocalSearchParams } from 'expo-router';
-import type { PreviewServer } from '@muxr/contract';
 import { Text } from '@/components/StyledText';
 import { Typography } from '@/constants/Typography';
-import { sync } from '@/sync/sync';
 import { useSession, useSocketStatus } from '@/sync/storage';
 import { openPreview, type OpenPreview } from '@/preview/openPreview';
-
-function describe(server: PreviewServer): string {
-    return server.command === '' ? 'HTTP server' : server.command;
-}
 
 function selectedPort(value: string | undefined): number | undefined {
     if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;
@@ -32,50 +26,26 @@ export default function PreviewScreen() {
     const { id, port } = useLocalSearchParams<{ id: string; port?: string }>();
     const directPort = selectedPort(port);
     const session = useSession(id);
-    const [servers, setServers] = React.useState<PreviewServer[] | null>(null);
     const [error, setError] = React.useState<string | null>(null);
-    const [opening, setOpening] = React.useState<number | null>(null);
+    const [opening, setOpening] = React.useState(false);
     const [preview, setPreview] = React.useState<OpenPreview | null>(null);
     const { status } = useSocketStatus();
 
-    const refresh = React.useCallback(() => {
-        setError(null);
-        setServers(null);
-        const path = session?.metadata?.path;
-        sync.request('preview.list', path === undefined ? {} : { cwd: path })
-            .then(setServers)
-            .catch((cause: unknown) => {
-                setError(cause instanceof Error ? cause.message : String(cause));
-                setServers([]);
-            });
-    }, [session?.metadata?.path]);
-
-    React.useEffect(() => {
-        if (status !== 'connected' || session === undefined) return;
-        if (directPort !== undefined) {
-            setServers(webNeedsTab ? [{ port: directPort, bind: '127.0.0.1', command: '' }] : []);
-            return;
-        }
-        refresh();
-    }, [directPort, refresh, session, status]);
-
     React.useEffect(() => () => preview?.close(), [preview]);
 
-    const choose = React.useCallback(async (selected: number): Promise<boolean> => {
-        setOpening(selected);
+    const choose = React.useCallback(async (selected: number): Promise<void> => {
+        setOpening(true);
         setError(null);
         const tab = webNeedsTab ? window.open('about:blank', '_blank') : null;
         try {
             const opened = await openPreview(selected);
             if (tab !== null) tab.location.href = opened.url;
             setPreview(opened);
-            return true;
         } catch (cause: unknown) {
             tab?.close();
             setError(cause instanceof Error ? cause.message : String(cause));
-            return false;
         } finally {
-            setOpening(null);
+            setOpening(false);
         }
     }, []);
 
@@ -86,14 +56,7 @@ export default function PreviewScreen() {
         if (directAttempt.current === key) return;
         directAttempt.current = key;
         void choose(directPort);
-    }, [choose, directPort, id, preview, refresh, session, status]);
-
-    const autoOpened = React.useRef(false);
-    React.useEffect(() => {
-        if (directPort !== undefined || autoOpened.current || webNeedsTab || servers?.length !== 1 || preview !== null) return;
-        autoOpened.current = true;
-        void choose(servers[0].port);
-    }, [choose, directPort, preview, servers]);
+    }, [choose, directPort, id, preview, session, status]);
 
     if (preview !== null) {
         if (Platform.OS === 'web') {
@@ -123,45 +86,39 @@ export default function PreviewScreen() {
     }
 
     return (
-        <ScrollView style={{ flex: 1, backgroundColor: theme.colors.groupped.background }} contentContainerStyle={{ padding: 16 }}>
+        <View style={{ flex: 1, backgroundColor: theme.colors.groupped.background, padding: 16 }}>
             {error !== null && <Text style={{ ...Typography.default(), color: theme.colors.textDestructive, marginBottom: 12 }}>{error}</Text>}
-            {error !== null && directPort !== undefined && !webNeedsTab && opening === null && (
+            {error !== null && directPort !== undefined && !webNeedsTab && !opening && (
                 <Pressable onPress={() => void choose(directPort)} accessibilityRole="button" accessibilityLabel="Retry preview" style={{ paddingVertical: 14, alignItems: 'center' }}>
                     <Text style={{ ...Typography.default('semiBold'), color: theme.colors.textLink }}>Retry</Text>
                 </Pressable>
             )}
 
-            {(servers === null || status !== 'connected' || session === undefined) && <ActivityIndicator size="small" color={theme.colors.text} />}
+            {(opening || status !== 'connected' || session === undefined) && <ActivityIndicator size="small" color={theme.colors.text} />}
 
-            {directPort === undefined && servers !== null && servers.length === 0 && status === 'connected' && opening === null && (
+            {directPort === undefined && (
                 <Text style={{ ...Typography.default(), color: theme.colors.textSecondary }}>
-                    No dev server found for this project.
+                    No preview port given. Dev server links in the terminal land here from the Preview chip.
                 </Text>
             )}
 
-            {servers?.map((server) => (
+            {directPort !== undefined && webNeedsTab && !opening && (
                 <Pressable
-                    key={`${server.bind}:${server.port}`}
-                    onPress={() => void choose(server.port)}
-                    disabled={opening !== null}
+                    onPress={() => void choose(directPort)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open localhost:${directPort} in a new tab`}
                     style={{
                         flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 14, paddingHorizontal: 16,
                         marginBottom: 8, borderRadius: 12, backgroundColor: theme.colors.surface,
-                        opacity: opening !== null && opening !== server.port ? 0.4 : 1,
                     }}
                 >
                     <Ionicons name="globe-outline" size={20} color={theme.colors.text} />
                     <View style={{ flex: 1 }}>
-                        <Text style={{ ...Typography.default('semiBold'), color: theme.colors.text }}>{`localhost:${server.port}`}</Text>
-                        <Text style={{ ...Typography.default(), fontSize: 13, color: theme.colors.textSecondary }}>{describe(server)}</Text>
+                        <Text style={{ ...Typography.default('semiBold'), color: theme.colors.text }}>{`localhost:${directPort}`}</Text>
+                        <Text style={{ ...Typography.default(), fontSize: 13, color: theme.colors.textSecondary }}>Open in a new tab</Text>
                     </View>
-                    {opening === server.port && <ActivityIndicator size="small" color={theme.colors.text} />}
                 </Pressable>
-            ))}
-
-            {directPort === undefined && <Pressable onPress={refresh} style={{ paddingVertical: 14, alignItems: 'center' }}>
-                <Text style={{ ...Typography.default(), color: theme.colors.textLink }}>Refresh</Text>
-            </Pressable>}
-        </ScrollView>
+            )}
+        </View>
     );
 }

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -32,7 +32,8 @@ import { PluginSlot } from '@/plugins/PluginSlot';
 import { DeclarativeChips, DeclarativeHeaderButtons, DeclarativeTerminalKeySlot } from '@/plugins/DeclarativePluginSlot';
 import { useSlotContributions } from '@/plugins/useSlotContributions';
 import type { SessionMenu } from '@/plugins/slotTypes';
-import { recentTerminalLinks } from '@/terminal/recentOutput';
+import { recentTerminalLinks, subscribeTerminalLinks, viewportTerminalLinks } from '@/terminal/recentOutput';
+import { openExternalUrl } from '@/utils/openExternalUrl';
 import { resolvePluginText } from '@/plugins/pluginText';
 import { randomUUID } from 'expo-crypto';
 
@@ -43,6 +44,18 @@ function displayLink(url: string, maxLength: number): string {
     const remaining = maxLength - prefix.length;
     if (remaining <= 1) return prefix;
     return suffix.length > remaining ? `${prefix}${suffix.slice(0, remaining - 1)}…` : `${prefix}${suffix}`;
+}
+
+/** Loopback URLs can be tunnelled into the preview WebView; the rest cannot. */
+function loopbackPort(url: string): number | undefined {
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname !== 'localhost' && parsed.hostname !== '127.0.0.1') return undefined;
+        if (parsed.port !== '') return Number(parsed.port);
+        return parsed.protocol === 'https:' ? 443 : 80;
+    } catch {
+        return undefined;
+    }
 }
 
 export const TerminalScreen = React.memo((props: { id: string }) => {
@@ -174,6 +187,65 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
         if (hintTimer.current !== null) clearTimeout(hintTimer.current);
         hintTimer.current = setTimeout(() => setGestureHint(null), 1400);
     }, []);
+
+    // The dev-server chip: the link on screen now (a scroll repaint knows),
+    // falling back to the newest URL the terminal printed.
+    const [chipLink, setChipLink] = React.useState<string | undefined>(undefined);
+    const [chipKind, setChipKind] = React.useState<'preview' | 'open' | undefined>(undefined);
+    const chipKindCache = React.useRef(new Map<string, 'preview' | 'open'>());
+
+    React.useEffect(() => {
+        const refresh = (sessionId?: string) => {
+            if (sessionId !== undefined && sessionId !== props.id) return;
+            const link = viewportTerminalLinks(props.id)[0] ?? recentTerminalLinks(props.id)[0];
+            setChipLink((previous) => (previous === link ? previous : link));
+        };
+        refresh();
+        return subscribeTerminalLinks(refresh);
+    }, [props.id]);
+
+    // localhost + html is a web app worth a Preview; anything else only opens
+    // externally. The probe runs on the host, where the port actually is.
+    React.useEffect(() => {
+        if (chipLink === undefined) {
+            setChipKind(undefined);
+            return;
+        }
+        const cached = chipKindCache.current.get(chipLink);
+        if (cached !== undefined) {
+            setChipKind(cached);
+            return;
+        }
+        const port = loopbackPort(chipLink);
+        if (port === undefined) {
+            chipKindCache.current.set(chipLink, 'open');
+            setChipKind('open');
+            return;
+        }
+        let cancelled = false;
+        setChipKind(undefined);
+        void sync.request('preview.probe', { port })
+            .then(({ contentType }) => {
+                const kind = contentType !== null && contentType.toLowerCase().startsWith('text/html') ? 'preview' : 'open';
+                chipKindCache.current.set(chipLink, kind);
+                if (!cancelled) setChipKind(kind);
+            })
+            .catch(() => {
+                // Older hosts have no probe; an external open always works.
+                if (!cancelled) setChipKind('open');
+            });
+        return () => { cancelled = true; };
+    }, [chipLink]);
+
+    const openChipLink = React.useCallback(() => {
+        if (chipLink === undefined || chipKind === undefined) return;
+        if (chipKind === 'preview') {
+            const port = loopbackPort(chipLink);
+            if (port !== undefined) router.push(`/session/${encodeURIComponent(props.id)}/preview?port=${port}` as never);
+            return;
+        }
+        void openExternalUrl(chipLink);
+    }, [chipLink, chipKind, props.id]);
 
     // Coming back to a screen whose socket died while it was backgrounded used
     // to leave a dead terminal until the user navigated away and back. Retry on
@@ -357,6 +429,21 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                         onPress={() => {
                             const links = recentTerminalLinks(props.id);
                             const linkItems: SessionMenu['items'] = links.length === 0 ? [] : [{
+                                label: 'Open link',
+                                hint: links[0] === undefined ? undefined : displayLink(links[0], 60),
+                                onPress: () => {
+                                    setMenu({
+                                        title: 'Open link',
+                                        note: 'From the recent terminal output',
+                                        items: links.map((url) => ({
+                                            label: displayLink(url, 72),
+                                            onPress: () => {
+                                                void openExternalUrl(url);
+                                            },
+                                        })),
+                                    });
+                                },
+                            }, {
                                 label: 'Copy link',
                                 hint: links[0] === undefined ? undefined : displayLink(links[0], 60),
                                 onPress: () => {
@@ -531,6 +618,32 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
             >
                 {/* Pills lead: the key toolbar is wider than a phone, so anything
                     after it is scrolled off-screen and effectively invisible. */}
+                {chipLink !== undefined && chipKind !== undefined && (
+                    <Pressable
+                        onPress={openChipLink}
+                        onLongPress={() => void Clipboard.setStringAsync(chipLink).then(() => showGestureHint('Link copied'))}
+                        accessibilityRole="button"
+                        accessibilityLabel={`${chipKind === 'preview' ? 'Preview' : 'Open'} ${chipLink}`}
+                        style={({ pressed }) => ({
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            gap: 4,
+                            paddingHorizontal: 8,
+                            paddingVertical: 4,
+                            borderRadius: 12,
+                            backgroundColor: theme.colors.surfaceHigh,
+                            opacity: pressed ? 0.6 : 1,
+                        })}
+                    >
+                        <Ionicons name={chipKind === 'preview' ? 'globe-outline' : 'open-outline'} size={12} color={theme.colors.textSecondary} />
+                        <Text style={{ color: theme.colors.text, fontSize: 12, fontWeight: '600' }}>
+                            {chipKind === 'preview' ? 'Preview' : 'Open'}
+                        </Text>
+                        <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12 }}>
+                            {displayLink(chipLink, 40)}
+                        </Text>
+                    </Pressable>
+                )}
                 <PluginSlot slot="session.pills" context={{ sessionId: props.id }} />
                 <DeclarativeChips slot="session.pills" />
                 <DeclarativeTerminalKeySlot channel={channel} />

--- a/apps/mobile/sources/terminal/TerminalView.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.tsx
@@ -16,7 +16,7 @@ import { View } from 'react-native';
 import { TerminalView as GhosttyView, type TerminalViewRef } from 'expo-libghostty';
 import { decodeBase64, encodeBase64 } from '@/encryption/base64';
 import { openTerminal, type TerminalChannel } from './openTerminal';
-import { recordTerminalOutput } from './recentOutput';
+import { beginViewportCapture, recordTerminalOutput } from './recentOutput';
 
 /** herdr repaints the whole screen per scroll; don't ask it for the world. */
 const MAX_SCROLL_LINES = 40;
@@ -181,6 +181,9 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                 // Ghostty counts rows the way the finger moved, herdr counts
                 // them the way the text does, hence the negation.
                 onScroll={({ nativeEvent }) => {
+                    // The repaint herdr sends back is the new viewport; capture
+                    // it for the link chip (see recentOutput.ts).
+                    beginViewportCapture(sessionId);
                     pendingScrollRef.current -= nativeEvent.rows;
                     if (scrollRafRef.current === undefined) {
                         scrollRafRef.current = requestAnimationFrame(flushScroll);

--- a/apps/mobile/sources/terminal/TerminalView.web.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.web.tsx
@@ -10,6 +10,7 @@ import { WebglAddon } from '@xterm/addon-webgl';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 import { openTerminal, type TerminalChannel } from './openTerminal';
+import { beginViewportCapture, recordTerminalOutput } from './recentOutput';
 
 export interface TerminalViewProps {
     sessionId: string;
@@ -101,6 +102,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                     term.write(all);
                 };
                 opened.onData((base64) => {
+                    recordTerminalOutput(sessionId, base64);
                     pending.push(base64);
                     if (!frameScheduled) {
                         frameScheduled = true;
@@ -172,6 +174,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
         const onWheel = (event: WheelEvent): void => {
             event.preventDefault();
             event.stopPropagation();
+            beginViewportCapture(sessionId); // herdr's repaint is the new viewport
             scrollAcc -= event.deltaY; // wheel up = back = positive
             scheduleScroll();
         };
@@ -200,6 +203,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
             if (Math.abs(gesturePx) < 8) return; // slop: taps stay taps
             event.preventDefault();
             event.stopPropagation();
+            beginViewportCapture(sessionId); // herdr's repaint is the new viewport
             scheduleScroll();
         };
         const onTouchEnd = (): void => {

--- a/apps/mobile/sources/terminal/openTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/openTerminal.spec.ts
@@ -148,3 +148,37 @@ describe('recentTerminalLinks', () => {
         expect(recentTerminalLinks('unknown')).toEqual([]);
     });
 });
+
+describe('viewportTerminalLinks', () => {
+    it('surfaces only the scroll burst’s links, not the older tail', async () => {
+        vi.useFakeTimers();
+        try {
+            const { recordTerminalOutput, beginViewportCapture, viewportTerminalLinks, recentTerminalLinks, clearTerminalOutput } = await import('./recentOutput');
+            const { encodeBase64 } = await import('@/encryption/base64');
+            const record = (text: string) => recordTerminalOutput('scroll', encodeBase64(new TextEncoder().encode(text)));
+
+            clearTerminalOutput('scroll');
+            record('old boot log: serving https://old-tail.example/ since yesterday');
+
+            // A scroll gesture: herdr answers with full-screen repaint frames.
+            beginViewportCapture('scroll');
+            record('\x1b[2J\x1b[Hrepainted screen  Local: http://localhost:3210/');
+            record('  ready in 412ms');
+            // The regex runs once per gesture: nothing before the debounce.
+            expect(viewportTerminalLinks('scroll')).toEqual([]);
+            await vi.advanceTimersByTimeAsync(120);
+            expect(viewportTerminalLinks('scroll')).toEqual(['http://localhost:3210/']);
+            // The tail still holds both, for the ⋮ menu.
+            expect(recentTerminalLinks('scroll')).toEqual(['http://localhost:3210/', 'https://old-tail.example/']);
+
+            // Scrolling past the link clears the chip.
+            beginViewportCapture('scroll');
+            record('\x1b[2J\x1b[Han older screen with no links at all');
+            await vi.advanceTimersByTimeAsync(120);
+            expect(viewportTerminalLinks('scroll')).toEqual([]);
+            clearTerminalOutput('scroll');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});

--- a/apps/mobile/sources/terminal/recentOutput.ts
+++ b/apps/mobile/sources/terminal/recentOutput.ts
@@ -4,25 +4,80 @@ import { decodeBase64 } from '@/encryption/base64';
 const MAX_CHARS = 24 * 1024;
 const MAX_LINKS = 8;
 const MAX_SESSIONS = 32;
+/** A fast fling repaints several screens before the scroll debounce fires. */
+const MAX_SCREEN_CHARS = 16 * 1024;
+const SCROLL_SCAN_DEBOUNCE_MS = 120;
+/** A freshly printed URL triggers at most one chip refresh per burst. */
+const TAIL_NOTIFY_DEBOUNCE_MS = 300;
 
 type EscapeState = 'text' | 'escape' | 'escapeIntermediate' | 'csi' | 'string' | 'stringEscape';
-type TailState = { text: string; escape: EscapeState; decoder: TextDecoder };
+type TailState = {
+    chunks: string[];
+    length: number;
+    escape: EscapeState;
+    decoder: TextDecoder;
+    capturing: boolean;
+    screen: string;
+    scanTimer: ReturnType<typeof setTimeout> | undefined;
+    tailTimer: ReturnType<typeof setTimeout> | undefined;
+    viewportLinks: string[];
+};
 const tails = new Map<string, TailState>();
 
 const URL_PATTERN = /https?:\/\/[^\s"'`<>[\]{}()\\^|]+/g;
 const TRAILING = /[.,;:!?)\]]+$/;
 const UNSAFE_URL_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
 
+type LinksListener = (sessionId: string) => void;
+const linksListeners = new Set<LinksListener>();
+
+/** Fires when a session's viewport links or freshly printed links change. */
+export function subscribeTerminalLinks(listener: LinksListener): () => void {
+    linksListeners.add(listener);
+    return () => { linksListeners.delete(listener); };
+}
+
+function notifyLinks(sessionId: string): void {
+    for (const listener of linksListeners) listener(sessionId);
+}
+
+function newState(): TailState {
+    return {
+        chunks: [],
+        length: 0,
+        escape: 'text',
+        decoder: new TextDecoder(),
+        capturing: false,
+        screen: '',
+        scanTimer: undefined,
+        tailTimer: undefined,
+        viewportLinks: [],
+    };
+}
+
+function drop(sessionId: string): void {
+    const state = tails.get(sessionId);
+    if (state === undefined) return;
+    if (state.scanTimer !== undefined) clearTimeout(state.scanTimer);
+    if (state.tailTimer !== undefined) clearTimeout(state.tailTimer);
+    tails.delete(sessionId);
+}
+
 function touch(sessionId: string, state?: TailState): TailState {
-    const current = state ?? tails.get(sessionId) ?? { text: '', escape: 'text', decoder: new TextDecoder() };
+    const current = state ?? tails.get(sessionId) ?? newState();
     tails.delete(sessionId);
     tails.set(sessionId, current);
-    if (tails.size > MAX_SESSIONS) tails.delete(tails.keys().next().value!);
+    if (tails.size > MAX_SESSIONS) drop(tails.keys().next().value!);
     return current;
 }
 
-/** Strip terminal control sequences across socket-message boundaries. */
-function appendVisible(state: TailState, input: string): void {
+/**
+ * Strip terminal control sequences across socket-message boundaries. Returns
+ * the visible text and appends it to the rolling tail. The tail is a chunk
+ * list joined only when links are requested -- per frame this is one array
+ * push, never a 24KB string rebuild and rescan.
+ */
+function appendVisible(state: TailState, input: string): string {
     let visible = '';
     for (const char of input) {
         const code = char.charCodeAt(0);
@@ -50,28 +105,88 @@ function appendVisible(state: TailState, input: string): void {
             state.escape = 'string';
         }
     }
-    state.text = (state.text + visible).replace(/\r/g, '').slice(-MAX_CHARS);
+    if (visible !== '') {
+        state.chunks.push(visible);
+        state.length += visible.length;
+        while (state.length > MAX_CHARS) {
+            const excess = state.length - MAX_CHARS;
+            const first = state.chunks[0]!;
+            if (first.length > excess) {
+                state.chunks[0] = first.slice(excess);
+                state.length = MAX_CHARS;
+                break;
+            }
+            state.chunks.shift();
+            state.length -= first.length;
+        }
+    }
+    return visible;
 }
 
 export function recordTerminalOutput(sessionId: string, base64: string): void {
     let bytes: Uint8Array;
     try { bytes = decodeBase64(base64); } catch { return; }
     const state = touch(sessionId);
-    appendVisible(state, state.decoder.decode(bytes, { stream: true }));
+    const visible = appendVisible(state, state.decoder.decode(bytes, { stream: true }));
+    if (state.capturing) {
+        state.screen = (state.screen + visible).slice(-MAX_SCREEN_CHARS);
+        if (state.scanTimer !== undefined) clearTimeout(state.scanTimer);
+        state.scanTimer = setTimeout(() => scanViewport(sessionId), SCROLL_SCAN_DEBOUNCE_MS);
+        return;
+    }
+    // Not scrolling: the frame path is one boolean check. A chunk carrying a
+    // URL (a dev server just announced itself, and at the live edge that URL
+    // is on screen) schedules a single debounced chip refresh.
+    if (visible.includes('http') && state.tailTimer === undefined) {
+        state.tailTimer = setTimeout(() => {
+            state.tailTimer = undefined;
+            notifyLinks(sessionId);
+        }, TAIL_NOTIFY_DEBOUNCE_MS);
+    }
+}
+
+// ponytail: "in view" is whatever herdr repainted during the gesture, which
+// relies on herdr sending a full repaint on scroll. The exact-but-heavier
+// upgrade is a headless xterm buffer (@xterm/xterm is already a root
+// dependency).
+/**
+ * A scroll gesture started: herdr repaints the whole screen per scroll and
+ * those frames arrive through recordTerminalOutput, so capture them apart
+ * from the rolling tail. The next gesture resets the capture, the debounced
+ * scan runs once per gesture, and the chip follows what is on screen.
+ */
+export function beginViewportCapture(sessionId: string): void {
+    const state = touch(sessionId);
+    state.capturing = true;
+    state.screen = '';
+    if (state.scanTimer !== undefined) {
+        clearTimeout(state.scanTimer);
+        state.scanTimer = undefined;
+    }
+}
+
+function scanViewport(sessionId: string): void {
+    const state = tails.get(sessionId);
+    if (state === undefined) return;
+    state.capturing = false;
+    state.scanTimer = undefined;
+    const links = extractLinks(state.screen.replace(/\r/g, ''));
+    state.screen = '';
+    if (links.length === state.viewportLinks.length && links.every((link, index) => link === state.viewportLinks[index])) return;
+    state.viewportLinks = links;
+    notifyLinks(sessionId);
 }
 
 export function clearTerminalOutput(sessionId: string): void {
-    tails.delete(sessionId);
+    drop(sessionId);
 }
 
-/** Latest-first, deduped and canonical URLs from the visible terminal tail. */
-export function recentTerminalLinks(sessionId: string): string[] {
-    const state = tails.get(sessionId);
-    if (state === undefined || !state.text.includes('http')) return [];
-    touch(sessionId, state);
+/** Latest-first, deduped and canonical URLs from the given text. */
+function extractLinks(text: string): string[] {
+    if (!text.includes('http')) return [];
     const found: string[] = [];
     const seen = new Set<string>();
-    const matches = [...state.text.matchAll(URL_PATTERN)];
+    const matches = [...text.matchAll(URL_PATTERN)];
     for (let index = matches.length - 1; index >= 0 && found.length < MAX_LINKS; index--) {
         const candidate = matches[index]![0].replace(TRAILING, '');
         if (candidate.length <= 12 || candidate.length > 2048 || UNSAFE_URL_CHARS.test(candidate)) continue;
@@ -83,4 +198,17 @@ export function recentTerminalLinks(sessionId: string): string[] {
         } catch {}
     }
     return found;
+}
+
+/** Latest-first, deduped and canonical URLs from the visible terminal tail. */
+export function recentTerminalLinks(sessionId: string): string[] {
+    const state = tails.get(sessionId);
+    if (state === undefined) return [];
+    touch(sessionId, state);
+    return extractLinks(state.chunks.join('').replace(/\r/g, ''));
+}
+
+/** Links on screen after the last scroll gesture, latest first. */
+export function viewportTerminalLinks(sessionId: string): string[] {
+    return tails.get(sessionId)?.viewportLinks ?? [];
 }

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -43,7 +43,7 @@ export type {
 export { MISSING_CWD_ERROR_PREFIX, normalizeRequestFailure, requestRequiresE2ee } from './requests.js';
 export type { LayoutSnapshot } from './requests.js';
 
-export type { PreviewFrame, PreviewServer } from './preview.js';
+export type { PreviewFrame } from './preview.js';
 export {
     decodePreviewFrame,
     encodePreviewFrame,

--- a/packages/contract/src/preview.ts
+++ b/packages/contract/src/preview.ts
@@ -41,16 +41,6 @@ export function decodePreviewFrame(raw: Uint8Array): PreviewFrame | undefined {
     return { connId, flag: raw[4] as number, payload: raw.subarray(PREVIEW_HEADER_BYTES) };
 }
 
-/** An HTTP listener the host found on its own machine. */
-export interface PreviewServer {
-    port: number;
-    /** Bind address as the OS reports it, e.g. `127.0.0.1` or `0.0.0.0`. */
-    bind: string;
-    /** Process name, e.g. `node`. Empty when the OS withheld it. */
-    command: string;
-    pid?: number;
-}
-
 /** Random channel id. The relay pairs the two sockets quoting the same one. */
 export function newPreviewChannel(): string {
     return `pv_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;

--- a/packages/contract/src/requests.ts
+++ b/packages/contract/src/requests.ts
@@ -30,7 +30,6 @@ import type {
     UnreadCatalog,
 } from './sessionDomain.js';
 import type { PluginManifestV1, PluginSummary } from './plugins.js';
-import type { PreviewServer } from './preview.js';
 import type { LandWorktreeResult } from './worktree.js';
 import type { AttentionCatalog, HerdrTreeWorkspace, SessionInfo, SessionShellOutcome, SessionStatus } from './sessionState.js';
 
@@ -301,10 +300,12 @@ export interface RequestMap {
 
     // --- browser preview ----------------------------------------------------
     /**
-     * HTTP listeners the host can see on its own loopback. `cwd` narrows the
-     * list to servers running inside that project directory.
+     * What content-type a loopback port answers with, probed on the host
+     * (where the port is). `text/html` marks a web app worth a Preview chip;
+     * anything else is an API the phone should only open externally.
+     * `contentType` is null when nothing HTTP answers.
      */
-    'preview.list': { params: { cwd?: string }; result: PreviewServer[] };
+    'preview.probe': { params: { port: number }; result: { contentType: string | null } };
     /**
      * Ask the host to join `channel` and forward it to `port`. The caller opens
      * the matching side itself; the relay pairs them.

--- a/scripts/checkPreviewTunnel.mjs
+++ b/scripts/checkPreviewTunnel.mjs
@@ -1,10 +1,7 @@
 /**
- * Proves browser preview end to end: the host finds a local HTTP server, the
+ * Proves browser preview end to end: the host probes a local HTTP port, the
  * relay pairs two preview sockets it cannot read, and a real HTTP request
  * crosses the tunnel and comes back with its body intact.
- *
- * Also asserts the listener parsers, which are the one piece with no runtime
- * feedback when they silently return nothing.
  */
 import { waitForRelay } from './waitForRelay.mjs';
 import { spawn } from 'node:child_process';
@@ -17,30 +14,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
 import { decodePreviewFrame, encodePreviewFrame, PREVIEW_DATA } from '@muxr/contract';
-import { parseLsofListeners, parseSsListeners } from '../apps/host/dist/requests/preview.js';
-
-// --- parsers ----------------------------------------------------------------
-
-const ss = parseSsListeners([
-    'State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process',
-    'LISTEN 0      511          127.0.0.1:8080       0.0.0.0:*    users:(("node",pid=4039084,fd=21))',
-    'LISTEN 0      511                  *:8081             *:*    users:(("node-MainThread",pid=509184,fd=101))',
-    'LISTEN 0      4096             [::1]:9000          [::]:*    users:(("postgres",pid=77,fd=6))',
-    'ESTAB  0      0            10.0.0.1:1234       10.0.0.2:80',
-].join('\n'));
-assert.equal(ss.length, 3, 'ss: only LISTEN rows');
-assert.deepEqual(ss[0], { port: 8080, bind: '127.0.0.1', command: 'node', pid: 4039084 });
-assert.equal(ss[1].bind, '*', 'ss: wildcard bind kept as reported');
-assert.equal(ss[2].port, 9000, 'ss: ipv6 bracket form');
-assert.equal(ss[2].bind, '[::1]');
-
-const lsof = parseLsofListeners([
-    'COMMAND   PID USER   FD   TYPE  DEVICE SIZE/OFF NODE NAME',
-    'node    12345 umer   21u  IPv4 0x1234      0t0  TCP 127.0.0.1:5173 (LISTEN)',
-    'node    12345 umer   22u  IPv4 0x1235      0t0  TCP 10.0.0.4:443->10.0.0.9:52 (ESTABLISHED)',
-].join('\n'));
-assert.equal(lsof.length, 1, 'lsof: only LISTEN rows');
-assert.deepEqual(lsof[0], { port: 5173, bind: '127.0.0.1', command: 'node', pid: 12345 });
 
 // A frame must survive a round trip with its payload byte-identical.
 const round = decodePreviewFrame(encodePreviewFrame(70000, PREVIEW_DATA, new Uint8Array([1, 2, 255])));
@@ -48,7 +21,7 @@ assert.equal(round.connId, 70000, 'connId must survive above 16 bits');
 assert.deepEqual([...round.payload], [1, 2, 255]);
 assert.equal(decodePreviewFrame(new Uint8Array([1, 2])), undefined, 'short frame rejected');
 
-process.stdout.write('parsers + frame codec OK\n');
+process.stdout.write('frame codec OK\n');
 
 // --- end to end -------------------------------------------------------------
 
@@ -124,23 +97,17 @@ const send = (frame) => {
 };
 
 const CHANNEL = 'check-channel-1';
-let listed;
 
-session.on('open', () => send({ type: 'preview.list', requestId: 'p1', params: {} }));
+session.on('open', () => send({ type: 'preview.probe', requestId: 'p1', params: { port: devPort } }));
 
 session.on('message', (raw) => {
     const frame = JSON.parse(JSON.parse(String(raw)).payload);
     if (frame.type !== 'result') return;
 
     if (frame.requestId === 'p1') {
-        if (!frame.ok) done(1, `\nFAIL: preview.list errored: ${frame.error}\n`);
-        listed = frame.data;
-        const found = listed.find((server) => server.port === devPort);
-        if (!found) {
-            done(1, `\nFAIL: dev server on ${devPort} not detected. saw: ${JSON.stringify(listed)}\n`);
-        }
-        if (listed.some((server) => server.port === Number(PORT))) {
-            done(1, `\nFAIL: relay listed itself as a dev server\n`);
+        if (!frame.ok) done(1, `\nFAIL: preview.probe errored: ${frame.error}\n`);
+        if (frame.data?.contentType !== 'application/json') {
+            done(1, `\nFAIL: probe of dev server on ${devPort} saw: ${JSON.stringify(frame.data)}\n`);
         }
         send({ type: 'preview.attach', requestId: 'p2', params: { channel: CHANNEL, port: devPort } });
         return;
@@ -194,7 +161,7 @@ function openTunnel() {
             }
 
             done(0, `\nPASS: browser preview through the relay\n`
-                + `      detected servers: ${listed.length}\n`
+                + `      loopback port probed: application/json\n`
                 + `      loopback-bound dev server reached: yes\n`
                 + `      preview port: ${message.port}\n`
                 + `      concurrent connections muxed: yes\n`


### PR DESCRIPTION
## Problem

Preview was effectively unusable: it listed **backend servers**, and hid the thing you actually wanted. Two causes, both in `listPreviewServers`:

1. It **scanned ports** (`ss`/`lsof`). A port scan cannot tell a Next.js app from a Postgres admin API.
2. It filtered to servers whose process cwd was **inside the session's project** — so a dev server started from the repo root while you sit in a package, or anything run as a daemon, vanished from the list.

## Approach — what everyone else does

VS Code/Codespaces, Terax, CodeBolt and Cursor all detect the dev server from the **URL it printed**. `next dev` prints `Local: http://localhost:3000`. The server tells you; nobody guesses.

muxr already scraped URLs out of terminal output in `recentOutput.ts` — it was already the detector, just never wired to preview.

## Change

- **Chip above the terminal keys** (existing `session.pills` row, no new layout). `localhost`/`127.0.0.1` **+ `text/html`** → **Preview**, tunnelled into the existing preview WebView. Any other URL → **Open**. Long-press copies. The `⋮` menu gains **Open link**.
- **Viewport-aware.** herdr repaints the whole screen on scroll, and those frames already flow through `recordTerminalOutput` — so on scroll we capture that repaint burst and scan one screen (~2.4KB), once per gesture, not the 24KB tail per frame. Scrolling past a link clears the chip.
- **Web-app vs API:** new host-side content-type probe (GET, not HEAD — some servers 405 a HEAD). Only `text/html` offers Preview.
- **Deleted** `listPreviewServers`, the `ss`/`lsof`/cwd-filter helpers, their tests, and the `preview.list` contract entry. The preview screen is port-driven only.
- Web parity: `TerminalView.web` now records output, so links work there too.

## Performance

`recordTerminalOutput` runs on every frame and previously ended with `(text + visible).replace(/\r/g,'').slice(-24KB)` — rebuilding and regex-scanning 24KB per frame. That is fixed; net JS work per frame is **lower than before**. The terminal should not feel slower.

## Tests

8 passing in `sources/terminal`, including a new case asserting a scroll burst yields only that burst's links, not the older tail.

## Note

Cherry-picked onto `origin/main`: local `main` and `origin/main` share no common ancestor.