### PR TITLE
Add browser takeover from the phone

### DIFF
--- a/apps/mobile/sources/app/(app)/_layout.tsx
+++ b/apps/mobile/sources/app/(app)/_layout.tsx
@@ -104,6 +104,14 @@ export default function RootLayout() {
                 }}
             />
             <Stack.Screen
+                name="session/[id]/takeover"
+                options={{
+                    headerShown: true,
+                    headerTitle: t('navigation.browserTakeover'),
+                    headerBackTitle: t('common.back'),
+                }}
+            />
+            <Stack.Screen
                 name="settings/appearance"
                 options={{
                     headerTitle: t('settings.appearance'),

--- a/apps/mobile/sources/app/(app)/session/[id]/takeover.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/takeover.tsx
@@ -1,0 +1,274 @@
+import * as React from 'react';
+import { View, Image, ActivityIndicator, Pressable, TextInput, Keyboard, Platform } from 'react-native';
+import { useUnistyles } from 'react-native-unistyles';
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams } from 'expo-router';
+import { Text } from '@/components/StyledText';
+import { Typography } from '@/constants/Typography';
+import { Modal } from '@/modal';
+import { machineBash } from '@/sync/ops';
+import { useSession, useSocketStatus } from '@/sync/storage';
+import { mapDisplayToInput, type Size, type StreamFrameMetadata } from '@/takeover/coordinates';
+import { codeForKey, keyMessage, openTakeover, parseStreamFrame, touchMessage } from '@/takeover/openTakeover';
+
+function selectedPort(value: string | undefined): number | undefined {
+    if (value === undefined || !/^\d{1,5}$/.test(value)) return undefined;
+    const port = Number(value);
+    return Number.isSafeInteger(port) && port >= 1 && port <= 65_535 ? port : undefined;
+}
+
+/** Shell-safe agent-browser session names only; anything else is dropped. */
+function selectedSession(value: string | undefined): string | undefined {
+    return value !== undefined && /^[a-zA-Z0-9_-]{1,64}$/.test(value) ? value : undefined;
+}
+
+interface LiveFrame {
+    uri: string;
+    metadata: StreamFrameMetadata;
+}
+
+const TAP_SLOP_PX = 12;
+const TAP_TIMEOUT_MS = 400;
+
+/**
+ * Live view of an agent-browser stream, tunnelled through the relay preview
+ * channel. The user clears a login / 2FA / CAPTCHA wall here by touch while
+ * the agent waits. Nothing rendered or typed is logged or persisted.
+ */
+export default function TakeoverScreen() {
+    const { theme } = useUnistyles();
+    const { id, port, session: browserSession } = useLocalSearchParams<{ id: string; port?: string; session?: string }>();
+    const session = useSession(id);
+    const { status } = useSocketStatus();
+    const [frame, setFrame] = React.useState<LiveFrame | null>(null);
+    const [error, setError] = React.useState<string | null>(null);
+    const [connecting, setConnecting] = React.useState(false);
+    const [display, setDisplay] = React.useState<Size>({ width: 0, height: 0 });
+    const [keyboardOpen, setKeyboardOpen] = React.useState(false);
+    const [typed, setTyped] = React.useState('');
+    const [portDraft, setPortDraft] = React.useState('');
+    const socketRef = React.useRef<WebSocket | null>(null);
+    const closeTunnelRef = React.useRef<(() => void) | null>(null);
+    const inputRef = React.useRef<TextInput>(null);
+    const tapRef = React.useRef<{ x: number; y: number; at: number } | null>(null);
+    const streamRef = React.useRef<{ command: string; cwd: string } | null>(null);
+
+    const cwd = session?.metadata?.path ?? '.';
+    const sessionFlag = selectedSession(browserSession);
+    const agentBrowser = sessionFlag === undefined ? 'agent-browser' : `agent-browser --session ${sessionFlag}`;
+
+    const send = React.useCallback((message: string) => {
+        if (socketRef.current?.readyState === WebSocket.OPEN) socketRef.current.send(message);
+    }, []);
+
+    const disconnect = React.useCallback(() => {
+        socketRef.current?.close();
+        socketRef.current = null;
+        closeTunnelRef.current?.();
+        closeTunnelRef.current = null;
+    }, []);
+
+    // Refcounted stream lifecycle: the screen enables on mount and disables on
+    // unmount, so the screencast never outlives its last watcher.
+    const connect = React.useCallback(async (streamPort: number) => {
+        disconnect();
+        setConnecting(true);
+        setError(null);
+        try {
+            await machineBash('', `${agentBrowser} stream enable --port ${streamPort}`, cwd);
+            streamRef.current = { command: agentBrowser, cwd };
+            const opened = await openTakeover(streamPort);
+            closeTunnelRef.current = opened.close;
+            const socket = new WebSocket(opened.wsUrl);
+            socketRef.current = socket;
+            socket.onmessage = (event) => {
+                const next = parseStreamFrame(event.data);
+                if (next !== undefined) setFrame({ uri: `data:image/jpeg;base64,${next.data}`, metadata: next.metadata });
+            };
+            socket.onerror = () => setError('The takeover stream connection failed.');
+            socket.onclose = () => {
+                setFrame(null);
+                // A close on the live socket is never silent: deliberate
+                // teardown nulls the ref first, so this only fires upstream.
+                if (socketRef.current === socket) setError('The takeover stream closed.');
+            };
+        } catch (cause: unknown) {
+            disconnect();
+            setError(cause instanceof Error ? cause.message : String(cause));
+        } finally {
+            setConnecting(false);
+        }
+    }, [agentBrowser, cwd, disconnect]);
+
+    const attempted = React.useRef<string | undefined>(undefined);
+    const directPort = selectedPort(port);
+    React.useEffect(() => {
+        if (directPort === undefined || status !== 'connected' || session === undefined) return;
+        const key = `${id}:${directPort}`;
+        if (attempted.current === key) return;
+        attempted.current = key;
+        void connect(directPort);
+    }, [connect, directPort, id, session, status]);
+
+    // Unmount only: close the stream and drop the enable refcount when a
+    // stream was actually enabled by this screen.
+    const cleanupRef = React.useRef<() => void>(() => {});
+    cleanupRef.current = () => {
+        disconnect();
+        if (streamRef.current !== null) {
+            void machineBash('', `${streamRef.current.command} stream disable`, streamRef.current.cwd);
+            streamRef.current = null;
+        }
+    };
+    React.useEffect(() => () => cleanupRef.current(), []);
+
+    const releaseTap = React.useCallback((x: number, y: number) => {
+        const start = tapRef.current;
+        tapRef.current = null;
+        if (start === null || frame === null) return;
+        if (Math.abs(x - start.x) > TAP_SLOP_PX || Math.abs(y - start.y) > TAP_SLOP_PX) return;
+        if (Date.now() - start.at > TAP_TIMEOUT_MS) return;
+        const point = mapDisplayToInput({ x, y }, display, frame.metadata);
+        send(touchMessage('touchStart', point));
+        send(touchMessage('touchEnd'));
+    }, [display, frame, send]);
+
+    const pushText = React.useCallback((value: string) => {
+        const added = value.slice(typed.length);
+        for (const key of added) {
+            send(keyMessage('keyDown', key, codeForKey(key)));
+            send(keyMessage('keyUp', key, codeForKey(key)));
+        }
+        // Keep the hidden field short so diffs stay cheap and nothing accumulates.
+        setTyped(value.length > 32 ? '' : value);
+    }, [send, typed]);
+
+    const saveState = React.useCallback(async () => {
+        const accepted = await Modal.confirm(
+            'Save browser login?',
+            'Stores the cookies and session state on the machine so this wall does not come back. The file holds plaintext session tokens and is kept private to your user.',
+            { confirmText: 'Save' },
+        );
+        if (!accepted) return;
+        const name = `takeover-${Date.now()}.json`;
+        const result = await machineBash('', `${agentBrowser} state save ${name} && chmod 600 "$HOME/.agent-browser/sessions/${name}"`, cwd);
+        if (!result.success) Modal.alert('Could not save state', result.stderr || result.stdout);
+    }, [agentBrowser, cwd]);
+
+    const toggleKeyboard = React.useCallback(() => {
+        if (keyboardOpen) {
+            Keyboard.dismiss();
+            setKeyboardOpen(false);
+        } else {
+            setTyped('');
+            inputRef.current?.focus();
+            setKeyboardOpen(true);
+        }
+    }, [keyboardOpen]);
+
+    const toolbar = (
+        <View style={{ flexDirection: 'row', gap: 12, paddingHorizontal: 16, paddingVertical: 10, backgroundColor: theme.colors.surface }}>
+            <Pressable onPress={toggleKeyboard} hitSlop={10} accessibilityRole="button" accessibilityLabel="Toggle keyboard" style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                <Ionicons name={keyboardOpen ? 'keypad' : 'keypad-outline'} size={20} color={theme.colors.text} />
+                <Text style={{ ...Typography.default(), color: theme.colors.text }}>Type</Text>
+            </Pressable>
+            <View style={{ flex: 1 }} />
+            <Pressable onPress={() => void saveState()} hitSlop={10} accessibilityRole="button" accessibilityLabel="Save browser login" style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                <Ionicons name="key-outline" size={20} color={theme.colors.text} />
+                <Text style={{ ...Typography.default(), color: theme.colors.text }}>Save login</Text>
+            </Pressable>
+        </View>
+    );
+
+    const hiddenInput = (
+        <TextInput
+            ref={inputRef}
+            value={typed}
+            onChangeText={pushText}
+            onKeyPress={({ nativeEvent }) => {
+                if (nativeEvent.key === 'Backspace') {
+                    send(keyMessage('keyDown', 'Backspace', 'Backspace'));
+                    send(keyMessage('keyUp', 'Backspace', 'Backspace'));
+                }
+            }}
+            onSubmitEditing={() => {
+                send(keyMessage('keyDown', 'Enter', 'Enter'));
+                send(keyMessage('keyUp', 'Enter', 'Enter'));
+            }}
+            onBlur={() => setKeyboardOpen(false)}
+            autoCapitalize="none"
+            autoCorrect={false}
+            blurOnSubmit={false}
+            style={{ position: 'absolute', width: 1, height: 1, opacity: 0 }}
+            accessibilityLabel="Takeover keyboard input"
+        />
+    );
+
+    if (frame !== null) {
+        return (
+            <View style={{ flex: 1, backgroundColor: '#000' }}>
+                <View
+                    style={{ flex: 1 }}
+                    onLayout={(event) => setDisplay({ width: event.nativeEvent.layout.width, height: event.nativeEvent.layout.height })}
+                    onStartShouldSetResponder={() => true}
+                    onResponderGrant={(event) => {
+                        tapRef.current = { x: event.nativeEvent.locationX, y: event.nativeEvent.locationY, at: Date.now() };
+                    }}
+                    onResponderRelease={(event) => releaseTap(event.nativeEvent.locationX, event.nativeEvent.locationY)}
+                    onResponderTerminate={() => { tapRef.current = null; }}
+                >
+                    <Image source={{ uri: frame.uri }} style={{ flex: 1 }} resizeMode="contain" />
+                </View>
+                {toolbar}
+                {hiddenInput}
+            </View>
+        );
+    }
+
+    return (
+        <View style={{ flex: 1, backgroundColor: theme.colors.groupped.background, padding: 16 }}>
+            {error !== null && <Text style={{ ...Typography.default(), color: theme.colors.textDestructive, marginBottom: 12 }}>{error}</Text>}
+
+            {(connecting || (directPort !== undefined && error === null)) && (
+                <View style={{ alignItems: 'center', paddingVertical: 24, gap: 12 }}>
+                    <ActivityIndicator size="small" color={theme.colors.text} />
+                    <Text style={{ ...Typography.default(), color: theme.colors.textSecondary }}>Connecting to the browser stream…</Text>
+                </View>
+            )}
+
+            {error !== null && directPort !== undefined && !connecting && (
+                <Pressable onPress={() => void connect(directPort)} accessibilityRole="button" accessibilityLabel="Retry takeover" style={{ paddingVertical: 14, alignItems: 'center' }}>
+                    <Text style={{ ...Typography.default('semiBold'), color: theme.colors.textLink }}>Retry</Text>
+                </Pressable>
+            )}
+
+            {directPort === undefined && !connecting && (
+                <View style={{ gap: 12 }}>
+                    <Text style={{ ...Typography.default(), color: theme.colors.textSecondary }}>
+                        Enter the agent-browser stream port from the blocked-agent message.
+                    </Text>
+                    <TextInput
+                        value={portDraft}
+                        onChangeText={setPortDraft}
+                        placeholder="Stream port"
+                        placeholderTextColor={theme.colors.textSecondary}
+                        keyboardType={Platform.OS === 'web' ? undefined : 'number-pad'}
+                        style={{ ...Typography.default(), color: theme.colors.text, backgroundColor: theme.colors.surface, borderRadius: 12, paddingHorizontal: 16, paddingVertical: 12 }}
+                    />
+                    <Pressable
+                        onPress={() => {
+                            const picked = selectedPort(portDraft);
+                            if (picked !== undefined) void connect(picked);
+                        }}
+                        disabled={selectedPort(portDraft) === undefined || status !== 'connected'}
+                        accessibilityRole="button"
+                        accessibilityLabel="Connect to stream"
+                        style={{ alignItems: 'center', paddingVertical: 14, borderRadius: 12, backgroundColor: theme.colors.surface, opacity: selectedPort(portDraft) === undefined ? 0.4 : 1 }}
+                    >
+                        <Text style={{ ...Typography.default('semiBold'), color: theme.colors.textLink }}>Connect</Text>
+                    </Pressable>
+                </View>
+            )}
+        </View>
+    );
+}

--- a/apps/mobile/sources/preview/openPreview.ts
+++ b/apps/mobile/sources/preview/openPreview.ts
@@ -19,12 +19,24 @@ export interface OpenPreview {
     close: () => void;
 }
 
+export interface PreviewTunnel {
+    hostname: string;
+    port: number;
+    close: () => void;
+}
+
 /** Regex, not `new URL`: React Native's URL is partial and this is one field. */
 function relayHostname(relayUrl: string): string | undefined {
     return /^wss?:\/\/([^/:?#]+)/i.exec(relayUrl)?.[1];
 }
 
-export async function openPreview(port: number): Promise<OpenPreview> {
+/**
+ * Join a preview channel to a loopback port and hold it open. The relay
+ * listener carries raw TCP without parsing it, so anything that speaks over a
+ * socket -- HTTP for previews, a WebSocket for the takeover stream -- can
+ * ride the same tunnel.
+ */
+export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> {
     const settings = getCachedConnectionSettings();
     if (settings.mode !== 'local') throw new Error('Hosted Preview is disabled until browser trust and pinning are complete.');
     const hostname = relayHostname(settings.relayUrl);
@@ -80,8 +92,13 @@ export async function openPreview(port: number): Promise<OpenPreview> {
     });
 
     // Always http: the preview port carries raw TCP with no TLS in front of it.
+    return { hostname, port: previewPort, close: () => socket.close() };
+}
+
+export async function openPreview(port: number): Promise<OpenPreview> {
+    const tunnel = await attachPreviewTunnel(port);
     return {
-        url: `http://${hostname}:${previewPort}/`,
-        close: () => socket.close(),
+        url: `http://${tunnel.hostname}:${tunnel.port}/`,
+        close: tunnel.close,
     };
 }

--- a/apps/mobile/sources/takeover/coordinates.spec.ts
+++ b/apps/mobile/sources/takeover/coordinates.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { containRect, mapDisplayToInput, type StreamFrameMetadata } from './coordinates';
+
+const METADATA: StreamFrameMetadata = {
+    deviceWidth: 1280,
+    deviceHeight: 720,
+    pageScaleFactor: 1,
+    offsetTop: 0,
+    scrollOffsetX: 0,
+    scrollOffsetY: 0,
+};
+
+describe('takeover coordinate mapping', () => {
+    it('maps display space to device space one-to-one when the aspect ratios match', () => {
+        // A 640x360 render of a 1280x720 frame: half scale, no letterbox.
+        expect(mapDisplayToInput({ x: 320, y: 180 }, { width: 640, height: 360 }, METADATA)).toEqual({ x: 640, y: 360 });
+        expect(mapDisplayToInput({ x: 0, y: 0 }, { width: 640, height: 360 }, METADATA)).toEqual({ x: 0, y: 0 });
+        expect(mapDisplayToInput({ x: 640, y: 360 }, { width: 640, height: 360 }, METADATA)).toEqual({ x: 1280, y: 720 });
+    });
+
+    it('divides device pixels by a non-1 pageScaleFactor to reach CSS pixels', () => {
+        // Retina capture: 1280x720 device pixels at 2x is a 640x360 CSS page,
+        // so the centre of the frame is (320, 180), not (640, 360).
+        const retina = { ...METADATA, pageScaleFactor: 2 };
+        expect(mapDisplayToInput({ x: 320, y: 180 }, { width: 640, height: 360 }, retina)).toEqual({ x: 320, y: 180 });
+        expect(mapDisplayToInput({ x: 640, y: 360 }, { width: 640, height: 360 }, retina)).toEqual({ x: 640, y: 360 });
+    });
+
+    it('maps through the letterboxed rect when the phone and frame aspects differ', () => {
+        // A 1280x720 landscape frame contained in a 400x800 portrait screen:
+        // rendered 400x225, centred with a 287.5px bar above and below.
+        const display = { width: 400, height: 800 };
+        const rect = containRect(display, { width: 1280, height: 720 });
+        expect(rect.width).toBeCloseTo(400);
+        expect(rect.height).toBeCloseTo(225);
+        expect(rect.y).toBeCloseTo(287.5);
+
+        // Centre of the rendered image is the centre of the page.
+        expect(mapDisplayToInput({ x: 200, y: 400 }, display, METADATA)).toEqual({ x: 640, y: 360 });
+        // A tap a quarter of the way across the rendered image lands a quarter across the page.
+        expect(mapDisplayToInput({ x: 100, y: 287.5 + 56.25 }, display, METADATA)).toEqual({ x: 320, y: 180 });
+        // Taps in the letterbox bars clamp to the frame edge instead of firing past it.
+        expect(mapDisplayToInput({ x: 200, y: 100 }, display, METADATA)).toEqual({ x: 640, y: 0 });
+        expect(mapDisplayToInput({ x: 200, y: 799 }, display, METADATA)).toEqual({ x: 640, y: 720 });
+    });
+
+    it('adds scroll and chrome offsets after scaling', () => {
+        const scrolled = { ...METADATA, pageScaleFactor: 2, offsetTop: 80, scrollOffsetX: 40, scrollOffsetY: 1200 };
+        expect(mapDisplayToInput({ x: 320, y: 180 }, { width: 640, height: 360 }, scrolled)).toEqual({ x: 360, y: 1460 });
+    });
+});

--- a/apps/mobile/sources/takeover/coordinates.ts
+++ b/apps/mobile/sources/takeover/coordinates.ts
@@ -1,0 +1,68 @@
+/**
+ * Takeover coordinate mapping.
+ *
+ * Two spaces meet on the takeover screen: the screencast space the frames
+ * arrive in (`metadata.deviceWidth` x `metadata.deviceHeight` device pixels)
+ * and the display space the phone renders them in (the on-screen size of the
+ * <Image>). Every tap and keystroke target has to cross that gap or clicks
+ * land in the wrong place -- the classic takeover bug. The frame is drawn
+ * with resizeMode "contain", so the mapping goes through the letterboxed
+ * rect, and browser input events want CSS pixels, so device pixels divide by
+ * `pageScaleFactor` and pick up the scroll/chrome offsets.
+ */
+
+export interface StreamFrameMetadata {
+    deviceWidth: number;
+    deviceHeight: number;
+    pageScaleFactor: number;
+    offsetTop: number;
+    scrollOffsetX: number;
+    scrollOffsetY: number;
+}
+
+export interface Size {
+    width: number;
+    height: number;
+}
+
+export interface Point {
+    x: number;
+    y: number;
+}
+
+export interface Rect extends Point, Size {}
+
+/** The rect a `contain`-rendered frame actually occupies inside its container, letterbox offsets included. */
+export function containRect(container: Size, frame: Size): Rect {
+    if (container.width <= 0 || container.height <= 0 || frame.width <= 0 || frame.height <= 0) {
+        return { x: 0, y: 0, width: 0, height: 0 };
+    }
+    const scale = Math.min(container.width / frame.width, container.height / frame.height);
+    const width = frame.width * scale;
+    const height = frame.height * scale;
+    return {
+        x: (container.width - width) / 2,
+        y: (container.height - height) / 2,
+        width,
+        height,
+    };
+}
+
+function clamp01(value: number): number {
+    return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Map a tap in display space to the CSS-pixel coordinates the browser input
+ * protocol expects. Taps in the letterbox bars clamp to the nearest frame
+ * edge rather than firing into the void.
+ */
+export function mapDisplayToInput(tap: Point, display: Size, metadata: StreamFrameMetadata): Point {
+    const rect = containRect(display, { width: metadata.deviceWidth, height: metadata.deviceHeight });
+    if (rect.width === 0 || rect.height === 0) return { x: 0, y: 0 };
+    const scale = metadata.pageScaleFactor === 0 ? 1 : metadata.pageScaleFactor;
+    return {
+        x: Math.round(clamp01((tap.x - rect.x) / rect.width) * metadata.deviceWidth / scale + metadata.scrollOffsetX),
+        y: Math.round(clamp01((tap.y - rect.y) / rect.height) * metadata.deviceHeight / scale + metadata.offsetTop + metadata.scrollOffsetY),
+    };
+}

--- a/apps/mobile/sources/takeover/openTakeover.ts
+++ b/apps/mobile/sources/takeover/openTakeover.ts
@@ -1,0 +1,82 @@
+/**
+ * Browser takeover, device half.
+ *
+ * agent-browser runs a WebSocket stream server on a loopback port of the
+ * machine. The phone reaches it through the same relay preview tunnel the
+ * dev-server preview uses: the tunnel forwards raw TCP without parsing it,
+ * so the WebSocket handshake and frames ride through untouched. Frames
+ * arrive as base64 JPEG, taps and keys go back as JSON.
+ *
+ * Security: nothing seen or typed here is logged or persisted. The user
+ * clears 2FA and password walls over this channel.
+ */
+
+import { attachPreviewTunnel } from '@/preview/openPreview';
+import type { Point, StreamFrameMetadata } from './coordinates';
+
+export interface StreamFrame {
+    type: 'frame';
+    data: string;
+    metadata: StreamFrameMetadata;
+}
+
+/** Parses one stream message; anything that is not a frame is not ours. */
+export function parseStreamFrame(raw: unknown): StreamFrame | undefined {
+    if (typeof raw !== 'string') return undefined;
+    try {
+        const message = JSON.parse(raw) as Partial<StreamFrame>;
+        if (message.type !== 'frame' || typeof message.data !== 'string') return undefined;
+        const metadata = message.metadata;
+        if (metadata === undefined || typeof metadata.deviceWidth !== 'number' || typeof metadata.deviceHeight !== 'number') return undefined;
+        return {
+            type: 'frame',
+            data: message.data,
+            metadata: {
+                deviceWidth: metadata.deviceWidth,
+                deviceHeight: metadata.deviceHeight,
+                pageScaleFactor: typeof metadata.pageScaleFactor === 'number' && metadata.pageScaleFactor > 0 ? metadata.pageScaleFactor : 1,
+                offsetTop: typeof metadata.offsetTop === 'number' ? metadata.offsetTop : 0,
+                scrollOffsetX: typeof metadata.scrollOffsetX === 'number' ? metadata.scrollOffsetX : 0,
+                scrollOffsetY: typeof metadata.scrollOffsetY === 'number' ? metadata.scrollOffsetY : 0,
+            },
+        };
+    } catch {
+        return undefined;
+    }
+}
+
+export function touchMessage(eventType: 'touchStart' | 'touchEnd', point?: Point): string {
+    return JSON.stringify({
+        type: 'input_touch',
+        eventType,
+        touchPoints: point === undefined ? [] : [{ x: point.x, y: point.y }],
+    });
+}
+
+export function keyMessage(eventType: 'keyDown' | 'keyUp', key: string, code: string): string {
+    return JSON.stringify({ type: 'input_keyboard', eventType, key, code });
+}
+
+/** Best-effort `code` for a printable character; the protocol dispatches on `key`. */
+export function codeForKey(key: string): string {
+    if (/^[a-zA-Z]$/.test(key)) return `Key${key.toUpperCase()}`;
+    if (/^[0-9]$/.test(key)) return `Digit${key}`;
+    if (key === 'Enter') return 'Enter';
+    if (key === 'Backspace') return 'Backspace';
+    if (key === ' ') return 'Space';
+    return key;
+}
+
+export interface OpenTakeover {
+    wsUrl: string;
+    close: () => void;
+}
+
+export async function openTakeover(port: number): Promise<OpenTakeover> {
+    const tunnel = await attachPreviewTunnel(port);
+    // Always ws: the tunnel carries raw TCP with no TLS in front of it.
+    return {
+        wsUrl: `ws://${tunnel.hostname}:${tunnel.port}/`,
+        close: tunnel.close,
+    };
+}

--- a/apps/mobile/sources/text/_default.ts
+++ b/apps/mobile/sources/text/_default.ts
@@ -647,6 +647,7 @@ export const en = {
         linkNewDevice: 'Link New Device', 
         restoreWithSecretKey: 'Restore with Secret Key',
         browserPreview: 'Browser preview',
+        browserTakeover: 'Browser takeover',
         whatsNew: "What's New",
         friends: 'Friends',
     },

--- a/apps/mobile/sources/text/translations/ca.ts
+++ b/apps/mobile/sources/text/translations/ca.ts
@@ -632,6 +632,7 @@ export const ca: TranslationStructure = {
         linkNewDevice: 'Enllaça un nou dispositiu', 
         restoreWithSecretKey: 'Restaura amb clau secreta',
         browserPreview: 'Vista prèvia del navegador',
+        browserTakeover: 'Control del navegador',
         whatsNew: 'Novetats',
         friends: 'Amics',
     },

--- a/apps/mobile/sources/text/translations/es.ts
+++ b/apps/mobile/sources/text/translations/es.ts
@@ -632,6 +632,7 @@ export const es: TranslationStructure = {
         linkNewDevice: 'Vincular nuevo dispositivo', 
         restoreWithSecretKey: 'Restaurar con clave secreta',
         browserPreview: 'Vista previa del navegador',
+        browserTakeover: 'Control del navegador',
         whatsNew: 'Novedades',
         friends: 'Amigos',
     },

--- a/apps/mobile/sources/text/translations/it.ts
+++ b/apps/mobile/sources/text/translations/it.ts
@@ -631,6 +631,7 @@ export const it: TranslationStructure = {
         linkNewDevice: 'Collega nuovo dispositivo', 
         restoreWithSecretKey: 'Ripristina con chiave segreta',
         browserPreview: 'Anteprima del browser',
+        browserTakeover: 'Controllo del browser',
         whatsNew: 'Novità',
         friends: 'Amici',
     },

--- a/apps/mobile/sources/text/translations/ja.ts
+++ b/apps/mobile/sources/text/translations/ja.ts
@@ -634,6 +634,7 @@ export const ja: TranslationStructure = {
         linkNewDevice: '新しいデバイスをリンク',
         restoreWithSecretKey: 'シークレットキーで復元',
         browserPreview: 'ブラウザプレビュー',
+        browserTakeover: 'ブラウザ引き継ぎ',
         whatsNew: "新機能",
         friends: '友達',
     },

--- a/apps/mobile/sources/text/translations/pl.ts
+++ b/apps/mobile/sources/text/translations/pl.ts
@@ -648,6 +648,7 @@ export const pl: TranslationStructure = {
         linkNewDevice: 'Połącz nowe urządzenie',
         restoreWithSecretKey: 'Przywróć kluczem tajnym',
         browserPreview: 'Podgląd w przeglądarce',
+        browserTakeover: 'Przejęcie przeglądarki',
         whatsNew: 'Co nowego',
         friends: 'Przyjaciele',
     },

--- a/apps/mobile/sources/text/translations/pt.ts
+++ b/apps/mobile/sources/text/translations/pt.ts
@@ -632,6 +632,7 @@ export const pt: TranslationStructure = {
         linkNewDevice: 'Vincular novo dispositivo', 
         restoreWithSecretKey: 'Restaurar com chave secreta',
         browserPreview: 'Pré-visualização do navegador',
+        browserTakeover: 'Controlo do navegador',
         whatsNew: 'Novidades',
         friends: 'Amigos',
     },

--- a/apps/mobile/sources/text/translations/ru.ts
+++ b/apps/mobile/sources/text/translations/ru.ts
@@ -638,6 +638,7 @@ export const ru: TranslationStructure = {
         linkNewDevice: 'Связать новое устройство',
         restoreWithSecretKey: 'Восстановить секретным ключом',
         browserPreview: 'Предпросмотр в браузере',
+        browserTakeover: 'Управление браузером',
         whatsNew: 'Что нового',
         friends: 'Друзья',
     },

--- a/apps/mobile/sources/text/translations/zh-Hans.ts
+++ b/apps/mobile/sources/text/translations/zh-Hans.ts
@@ -634,6 +634,7 @@ export const zhHans: TranslationStructure = {
         linkNewDevice: '链接新设备', 
         restoreWithSecretKey: '通过密钥恢复',
         browserPreview: '浏览器预览',
+        browserTakeover: '浏览器接管',
         whatsNew: "更新日志",
         friends: '好友',
     },

--- a/apps/mobile/sources/text/translations/zh-Hant.ts
+++ b/apps/mobile/sources/text/translations/zh-Hant.ts
@@ -633,6 +633,7 @@ export const zhHant: TranslationStructure = {
         linkNewDevice: '連結新裝置',
         restoreWithSecretKey: '透過金鑰恢復',
         browserPreview: '瀏覽器預覽',
+        browserTakeover: '瀏覽器接管',
         whatsNew: "更新日誌",
         friends: '好友',
     },

--- a/skills/browser-takeover/SKILL.md
+++ b/skills/browser-takeover/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: "browser-takeover"
+description: "Hand a stuck browser session to the user's phone when agent-browser automation hits a login / 2FA / CAPTCHA wall — enable the stream, report blocked with the port, then STOP and wait for the human instead of clicking."
+version: 1
+created: "2026-08-19"
+updated: "2026-08-19"
+---
+## When to Use
+Use the moment browser automation (agent-browser) hits a wall only a human can clear: a login form, a 2FA/OTP prompt, a CAPTCHA, an SSO redirect, a "verify it's you" interstitial. You know you are stuck — announce it; do not wait for anyone to notice, and do not try to detect the wall with heuristics. Not for ordinary errors you can retry your way out of.
+
+## Procedure
+1. Enable the live stream so the phone can see the page. Note the port — you MUST put it in the blocked message, it is the only way the phone finds the stream:
+   `agent-browser stream enable --json` → read the port (OS-assigned). Pin it with `--port <N>` or `AGENT_BROWSER_STREAM_PORT` if you need a stable number.
+   If you run agent-browser with `--session <name>`, pass `--session <name>` here too and include the session name in the message.
+2. Report blocked through herdr (muxr reads this and pushes a notification to the phone):
+   ```
+   herdr pane report-agent "$HERDR_PANE_ID" --source "$HERDR_PANE_ID" --agent <your-label> --state blocked \
+     --message "2FA on appstoreconnect.apple.com — takeover stream port 9222"
+   ```
+   Name the SITE and the WALL ("login on …", "CAPTCHA on …"), then the port. Never include page contents, URLs with tokens, or credentials in the message.
+3. **STOP. Do not click, type, refresh, or navigate while the human may be typing a code.** One extra click can destroy an half-entered 2FA or trip a rate limit that locks the account. Wait: poll the page state no more than every 30–60s, or simply wait for the user to message you.
+4. When the wall is cleared (the page advanced past it), hand the stream back and resume:
+   `agent-browser stream disable`, then
+   `herdr pane report-agent "$HERDR_PANE_ID" --source "$HERDR_PANE_ID" --agent <your-label> --state working --message "takeover done, continuing"`
+   Continue the original task.
+5. Make it the last time: if the user logged in manually, persist the auth so the wall never appears again —
+   `agent-browser state save <site>.json` (lands in `~/.agent-browser/sessions/`; `chmod 600` it, it holds plaintext session tokens), and on future runs start with `--restore` / `--session <name> --restore` or `AGENT_BROWSER_RESTORE`. The phone app also offers this after a takeover; don't duplicate it if the user already saved.
+
+## Pitfalls
+- Forgetting the port in the blocked message leaves the phone with no way to connect — always include it.
+- `report-agent` needs `--source` and `--agent` every time; reuse the same values for the working/blocked pair so the phone can correlate them.
+- Do NOT keep automating while blocked. Waiting is the protocol; the human is typing credentials into the very page you would be clicking on.
+- The stream port is loopback-only and reached from the phone through the muxr relay tunnel. Never bind it wider, never print cookies/page content into logs, and never type the user's password or 2FA code yourself — that is the human's job, that is the whole point.
+- State files are plaintext session tokens: `chmod 600`, never commit them, never paste their contents.
+- If HERDR_PANE_ID is unset you are not in a herdr pane — there is no phone to take over; say out loud that you are blocked instead.
+
+## Verification
+1. `agent-browser stream status` shows the stream server enabled on the port you announced (and disabled after you resume).
+2. The phone shows the pane blocked with your message; the user opens the takeover screen, sees the live page, and clears the wall by touch.
+3. `agent-browser state list` shows the saved state file after step 5; a fresh `--restore` run does not hit the wall again.


### PR DESCRIPTION
## Problem

An agent drives a browser, hits a **2FA / login / CAPTCHA wall**, and stops. The user is holding a phone and has to walk to a desktop. That cost five hours in one recent case.

Most of these sites have no API and no CLI, and installing an MCP per service is not a plan. The fix has to be **site-agnostic**: whatever the wall is, take over from the phone, clear it, agent continues.

This is a differentiator, not parity — Cursor and Codex both have browser takeover, but both assume you are at the desk. muxr's premise is that you are not.

## How

`agent-browser` already runs a **per-session WebSocket stream server** that emits base64 JPEG frames and accepts `input_mouse` / `input_keyboard` / **`input_touch`**. Touch is first-class in the protocol — built for a phone. No dashboard, no WebRTC, no CDP bridge of our own.

- **New takeover screen** renders frames into an `<Image>` and sends taps/keys back.
- **Tunnel reuses the existing relay preview path** — `openPreview` was refactored to expose `attachPreviewTunnel` so both features share it rather than duplicating the transport.
- **Stream lifecycle refcounted**: enable on mount, disable on unmount. No screencast running with nobody watching.

## Coordinate mapping

The documented #1 bug in every reference implementation: screencast space (`metadata.deviceWidth/deviceHeight`) vs display space (rendered `<Image>` size). Isolated in `sources/takeover/coordinates.ts` with its own test covering non-1 `pageScaleFactor` and letterboxed aspect ratios.

## The blocked signal

herdr infers `blocked` from agent TUI patterns, so a browser 2FA wall just looks like "working". Rather than guess, **the agent announces it** — `skills/browser-takeover/SKILL.md` instructs it to call `herdr pane report-agent --state blocked` with the stream port and then *wait*, so it is not clicking while you type a code. herdr already propagates that state and muxr already pushes it. Zero new infrastructure.

## Security

Nothing typed or rendered during takeover is logged or persisted — the user is entering 2FA codes. Exposure stays on loopback; only the existing relay socket leaves the machine.

## Tests

11 passing, including the coordinate mapping.

## Unverified

The end-to-end path has **not been exercised on a physical device** — frames rendering and touch landing correctly need a real phone against a real agent-browser session.

## Note

Cherry-picked onto `origin/main`: local `main` and `origin/main` share no common ancestor.