### PR TITLE
Fade the dev-server chip in and out instead of popping

### DIFF
--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { ActivityIndicator, AppState, BackHandler, Platform, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useKeyboardState } from 'react-native-keyboard-controller';
+import Animated, { FadeIn, FadeOut, ReduceMotion } from 'react-native-reanimated';
 import { useUnistyles } from 'react-native-unistyles';
 import { Ionicons } from '@expo/vector-icons';
 import { router, useFocusEffect } from 'expo-router';
@@ -618,7 +619,15 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
             >
                 {/* Pills lead: the key toolbar is wider than a phone, so anything
                     after it is scrolled off-screen and effectively invisible. */}
+                {/* The chip appears and disappears on its own as you scroll past
+                    a link, so a hard pop reads as a glitch rather than a state
+                    change. Opacity only: it is the one property that survives
+                    reduced motion, and the row would reflow if we moved it. */}
                 {chipLink !== undefined && chipKind !== undefined && (
+                    <Animated.View
+                        entering={FadeIn.duration(180).reduceMotion(ReduceMotion.System)}
+                        exiting={FadeOut.duration(120).reduceMotion(ReduceMotion.System)}
+                    >
                     <Pressable
                         onPress={openChipLink}
                         onLongPress={() => void Clipboard.setStringAsync(chipLink).then(() => showGestureHint('Link copied'))}
@@ -643,6 +652,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                             {displayLink(chipLink, 40)}
                         </Text>
                     </Pressable>
+                    </Animated.View>
                 )}
                 <PluginSlot slot="session.pills" context={{ sessionId: props.id }} />
                 <DeclarativeChips slot="session.pills" />


### PR DESCRIPTION
First application of the `animate-expo` skill (Emil Kowalski / Expo team).

## Why this one

The chip mounts and unmounts **on its own** as the viewport scrolls past a link — the user never triggers it. An element that appears and vanishes with no transition reads as a rendering glitch rather than a state change.

Running the skill's build sequence:

1. **Should it animate?** Occasional tier (not per-scroll, only when a link enters/leaves view) → standard animation is allowed.
2. **Purpose?** *State indication* — a link is available in what you're looking at.
3. **Cheapest tool?** Element mounting/unmounting → **layout animations** (`entering`/`exiting`), not a shared value. A two-state mount is not worth a worklet.
4. **Properties?** **Opacity only.** It is free, and it is the one property reduced motion keeps. Moving or resizing the chip would re-run Yoga on the whole pill row every frame.
5. **Timing?** No finger involved → timing, ease-out. 180ms in / 120ms out — exits are faster because nothing waits on them.
6. **Reduced motion ships with it**, not later: `ReduceMotion.System` on both.

## Deliberately not done

No scale or slide. The skill's rule is "never `scale(0)`" and reduced motion drops transforms anyway — for a 12px chip in a scrolling row, a fade is the whole effect. No haptic: the user didn't act, so there is nothing to confirm.

## Checks

`tsc --noEmit` clean; 8 terminal tests pass. Uses `react-native-reanimated@4.2.3`, already a dependency — nothing installed.