### PR TITLE
Use a valid TestFlight key path

### DIFF
--- a/.github/workflows/mobile-internal.yml
+++ b/.github/workflows/mobile-internal.yml
@@ -264,7 +264,7 @@ jobs:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       EXPO_STATE_JSON: ${{ secrets.EXPO_STATE_JSON }}
       EXPO_APPLE_TEAM_ID: FKBTSU84AY
-      EXPO_ASC_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+      EXPO_ASC_API_KEY_PATH: /tmp/AuthKey.p8
       EXPO_ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
       EXPO_ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
       ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}


### PR DESCRIPTION
GitHub rejected the workflow before creating jobs because the `runner` context is unavailable at job-level `env`. Use the fixed Ubuntu temp path instead.

Verification: actionlint 1.7.12 passes both mobile workflows; diff check clean.