### PR TITLE
Chip shows only the link that is actually on screen

### DIFF
--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -189,8 +189,10 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
         hintTimer.current = setTimeout(() => setGestureHint(null), 1400);
     }, []);
 
-    // The dev-server chip: the link on screen now (a scroll repaint knows),
-    // falling back to the newest URL the terminal printed.
+    // The dev-server chip: strictly the link on screen now. Every whole-screen
+    // repaint herdr sends -- attach, resize, scroll -- is a viewport capture,
+    // so there is nothing to fall back to: falling back to the newest URL ever
+    // printed left the chip advertising a link that had scrolled away.
     const [chipLink, setChipLink] = React.useState<string | undefined>(undefined);
     const [chipKind, setChipKind] = React.useState<'preview' | 'open' | undefined>(undefined);
     const chipKindCache = React.useRef(new Map<string, 'preview' | 'open'>());
@@ -198,7 +200,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     React.useEffect(() => {
         const refresh = (sessionId?: string) => {
             if (sessionId !== undefined && sessionId !== props.id) return;
-            const link = viewportTerminalLinks(props.id)[0] ?? recentTerminalLinks(props.id)[0];
+            const link = viewportTerminalLinks(props.id)[0];
             setChipLink((previous) => (previous === link ? previous : link));
         };
         refresh();

--- a/apps/mobile/sources/terminal/TerminalView.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.tsx
@@ -110,6 +110,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                     // its own for a keyboard or a pinch, and herdr would keep
                     // sending diffs for a screen that no longer matches.
                     channelRef.current?.resize(cols, rows);
+                    beginViewportCapture(sessionId);
                     channelRef.current?.repaint();
                 }, RESIZE_DEBOUNCE_MS);
                 return;
@@ -125,6 +126,10 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                 .then(() => openTerminal(sessionId, { cols, rows }))
                 .then((channel) => {
                     channelRef.current = channel;
+                    // The first thing herdr sends is the whole screen, so this
+                    // attach is a viewport capture. Without it the chip has no
+                    // viewport until the first scroll.
+                    beginViewportCapture(sessionId);
                     // Same discipline as the web view: herdr repaint bursts
                     // arrive as many socket messages; one Ghostty write per
                     // frame instead of one per message.
@@ -148,6 +153,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
                         if (resizeTimerRef.current !== undefined) clearTimeout(resizeTimerRef.current);
                         resizeTimerRef.current = undefined;
                         channel.resize(latest.cols, latest.rows);
+                        beginViewportCapture(sessionId);
                         channel.repaint();
                     }
                 })


### PR DESCRIPTION
Found by manual testing on an emulator against a real dev server — the unit tests passed throughout, because the bug was in the consumer, not the store.

## The bug

```js
const link = viewportTerminalLinks(props.id)[0] ?? recentTerminalLinks(props.id)[0];
```

When the viewport held no link, the chip fell back to the newest URL the terminal had **ever** printed. So after scrolling past a dev-server URL, the chip kept advertising it — the exact opposite of what a viewport chip promises, and the opposite of the agreed behaviour ("as I scroll past, it goes away").

Observed: viewport showing lines 29–76 with no URL anywhere, chip still offering `http://localhost:3000/`.

## Why the fallback was there

`beginViewportCapture` was only called from `onScroll`. A freshly attached terminal therefore had **no viewport at all**, and without the fallback the chip would never appear until the user happened to drag. The fallback papered over that.

## The fix

Capture on every whole-screen repaint herdr sends — **attach, resize, and scroll** — not just scroll. herdr repaints the entire screen in all three cases, so all three are viewport captures. With attach covered, the fallback is unnecessary and is removed.

`recentTerminalLinks` stays where it belongs: the `⋮` menu, which is meant to list every link in the session.

## Verified on device

Release build, emulator, real HTTP server on :3000:

1. Open session → **chip appears immediately**, no scroll needed (attach capture)
2. `seq 1 120` pushes the URL off, scroll → **chip disappears**
3. Scroll back to the URL → **chip returns**

Also verified in the same session: long-press copies (system clipboard confirmation), tap opens the external browser, and the Versions row reads `app 0.1.9 · host unknown` — correctly "unknown" because the running host is CLI 0.1.7, which predates the version wire-up.

8 terminal tests still pass.