### PR TITLE
Use current release workflow actions

### DIFF
--- a/.github/workflows/mobile-internal.yml
+++ b/.github/workflows/mobile-internal.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           node-version: 22.23.2
           cache: yarn
-      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: temurin
           java-version: "21"
@@ -134,7 +134,7 @@ jobs:
           test -n "$app_version"
           echo "app-version=$app_version" >> "$GITHUB_OUTPUT"
           echo "version-code=$version_code" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-internal
           path: ${{ runner.temp }}/muxr.aab
@@ -142,7 +142,7 @@ jobs:
           if-no-files-found: error
       - name: Upload Android diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-internal-log
           path: ${{ runner.temp }}/android-eas.log
@@ -197,7 +197,7 @@ jobs:
           test -n "$build_number"
           echo "app-version=$app_version" >> "$GITHUB_OUTPUT"
           echo "build-number=$build_number" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-internal
           path: ${{ runner.temp }}/muxr.ipa
@@ -205,7 +205,7 @@ jobs:
           if-no-files-found: error
       - name: Upload iOS diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-internal-log
           path: ${{ runner.temp }}/ios-eas.log
@@ -233,7 +233,7 @@ jobs:
           ruby-version: "3.3"
           bundler-cache: true
       - run: yarn install --frozen-lockfile --non-interactive
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: android-internal
           path: artifacts/android
@@ -271,7 +271,7 @@ jobs:
         with:
           ruby-version: "3.3"
           bundler-cache: true
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ios-internal
           path: artifacts/ios


### PR DESCRIPTION
Remove the Node 20/deprecated-action warnings from the proven mobile release lane.

- setup-java v5
- upload-artifact v7.0.1
- download-artifact v8.0.1

All references remain pinned to full commit SHAs used by current large open-source mobile pipelines. Verification: actionlint 1.7.12 passes both workflows; diff check clean.