### PR TITLE
Usage by provider, typed file tree, session-scoped code screens

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -101,6 +101,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.22.0",
     "react-native-svg": "15.12.1",
+    "react-native-tcp-socket": "6.4.2",
     "react-native-typography": "^1.4.1",
     "react-native-unistyles": "~3.1.1",
     "react-native-web": "^0.21.0",

--- a/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
+++ b/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
@@ -173,17 +173,19 @@ function DataChip({ contribution, pluginId, manifestHash }: { contribution: Plug
 }
 
 /**
- * Header icon that opens a plugin screen for the session's directory. Without
- * the cwd the screen has no repository to act on, so it stays hidden.
+ * Header icon that opens a plugin screen for the session's directory. The screen
+ * travels with the session id, not the path: the host replaces a caller-supplied
+ * cwd with the one it holds for that session, so a path sent from here is
+ * dropped and the screen opens with no repository.
  */
-export function DeclarativeHeaderButtons({ cwd }: { cwd?: string }) {
+export function DeclarativeHeaderButtons({ cwd, sessionId }: { cwd?: string; sessionId: string }) {
     const { theme } = useUnistyles();
     const router = useRouter();
     useSlotContributions('session.header.trailing');
     if (cwd === undefined || cwd === '') return null;
     return <>{pluginSnapshot().flatMap(({ summary, manifest }) => manifest.contributions.flatMap((contribution) => 'type' in contribution && contribution.type === 'screen-button' ? [
         <Pressable key={`${summary.pluginId}:${contribution.id}`} accessibilityRole="button" accessibilityLabel={resolvePluginText(contribution.title)} hitSlop={8}
-            onPress={() => router.push(pluginHref(summary.pluginId, contribution.contentContributionId, { cwd }))}
+            onPress={() => router.push(pluginHref(summary.pluginId, contribution.contentContributionId, { sessionId }))}
             style={{ width: 30, height: 30, alignItems: 'center', justifyContent: 'center', borderRadius: 999, backgroundColor: theme.colors.surfaceHigh }}>
             <Ionicons name={contribution.icon as any} size={16} color={theme.colors.textSecondary} />
         </Pressable>,

--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View, useWindowDimensions, type StyleProp, type ViewStyle } from 'react-native';
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { PolarChart, Pie } from 'victory-native';
 import Animated, { Easing, FadeInDown, useAnimatedStyle, useReducedMotion, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import { useUnistyles } from 'react-native-unistyles';
@@ -20,6 +20,7 @@ import { bindText, initialFieldValues, loadScreenData, resolvePath, runScreenBut
 import { resolvePluginText } from './pluginText';
 import { asScreenTree, type RuntimeTreeItem } from './screenTreeModel';
 import { asChartSeries, type PluginChartItem } from './chartModel';
+import { fileIcon, folderIcon, type FileIcon } from './fileIcon';
 import { t } from '@/text';
 import { boundText } from '@/utils/boundedText';
 import { Typography } from '@/constants/Typography';
@@ -87,12 +88,19 @@ function ScreenRow(props: {
     );
 }
 
-function treeIcon(item: RuntimeTreeItem, expanded: boolean): React.ComponentProps<typeof Ionicons>['name'] {
-    if (item.kind === 'folder') return expanded ? 'folder-open-outline' : 'folder-outline';
-    if (/\.(png|jpe?g|gif|webp)$/i.test(item.name)) return 'image-outline';
-    if (/\.(mp4|mov|webm|wav|mp3)$/i.test(item.name)) return 'play-circle-outline';
-    if (/\.(ts|tsx|js|jsx|mjs|py|kt|swift|rs|go|java|c|cpp|h)$/i.test(item.name)) return 'code-slash-outline';
-    return 'document-text-outline';
+/** Plugin replies are untrusted: keep only well-formed, bounded tab entries. */
+function asScreenTabs(value: unknown): Array<{ id: string; label: string }> {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((entry) => {
+        if (typeof entry !== 'object' || entry === null) return [];
+        const { id, label } = entry as { id?: unknown; label?: unknown };
+        if (typeof id !== 'string' || id === '' || typeof label !== 'string' || label === '') return [];
+        return [{ id: id.slice(0, 64), label: label.slice(0, 32) }];
+    }).slice(0, 16);
+}
+
+function treeIcon(item: RuntimeTreeItem, expanded: boolean): FileIcon {
+    return item.kind === 'folder' ? folderIcon(expanded) : fileIcon(item.name);
 }
 
 function ScreenTree(props: {
@@ -146,6 +154,7 @@ function ScreenTree(props: {
                 const open = expanded.has(item.path);
                 const busy = loading.has(item.path);
                 const selected = props.node.selectionField !== undefined && props.fields[props.node.selectionField] === item.path;
+                const icon = treeIcon(item, open);
                 return <Pressable key={item.path} accessibilityRole="button" accessibilityState={{ expanded: isFolder ? open : undefined, selected }}
                     accessibilityLabel={`${isFolder ? 'Folder' : 'File'} ${item.name}`}
                     onPress={() => {
@@ -173,11 +182,11 @@ function ScreenTree(props: {
                         }).catch(props.onError)
                             .finally(() => setLoading((current) => { const next = new Set(current); next.delete(item.path); return next; }));
                     }}
-                    style={({ pressed }) => ({ flexDirection: 'row', alignItems: 'center', minHeight: 44, paddingLeft: 12 + Math.min(depth, 8) * 20, paddingRight: 12, opacity: pressed ? 0.6 : 1, backgroundColor: selected ? theme.colors.surfaceHighest : 'transparent' })}>
-                    {isFolder && (busy ? <ActivityIndicator size="small" color={theme.colors.textSecondary} style={{ width: 14 }} /> : <Ionicons name={open ? 'chevron-down' : 'chevron-forward'} size={14} color={theme.colors.textSecondary} />)}
-                    {!isFolder && <View style={{ width: 14 }} />}
-                    <Ionicons name={treeIcon(item, open)} size={18} color={selected ? theme.colors.accent : theme.colors.textSecondary} style={{ marginHorizontal: 7 }} />
-                    <Text numberOfLines={1} style={{ color: selected ? theme.colors.accent : theme.colors.text, fontSize: 14, flex: 1 }}>{item.name}</Text>
+                    style={({ pressed }) => ({ flexDirection: 'row', alignItems: 'center', minHeight: 34, paddingLeft: 8 + Math.min(depth, 8) * 14, paddingRight: 12, opacity: pressed ? 0.6 : 1, backgroundColor: selected ? theme.colors.surfaceHighest : 'transparent' })}>
+                    {isFolder && (busy ? <ActivityIndicator size="small" color={theme.colors.textSecondary} style={{ width: 12 }} /> : <Ionicons name={open ? 'chevron-down' : 'chevron-forward'} size={12} color={theme.colors.textSecondary} />)}
+                    {!isFolder && <View style={{ width: 12 }} />}
+                    <MaterialCommunityIcons name={icon.name} size={16} color={selected ? theme.colors.accent : icon.color ?? theme.colors.textSecondary} style={{ marginHorizontal: 6 }} />
+                    <Text numberOfLines={1} style={{ color: selected ? theme.colors.accent : theme.colors.text, fontSize: 13.5, flex: 1 }}>{item.name}</Text>
                 </Pressable>;
             })}
         </View>
@@ -253,6 +262,7 @@ function ScreenNode(props: {
     onRowAction: (action: PluginScreenRowAction, item: unknown) => void;
     onTreeLoad: (node: PluginScreenTreeNode, path: string) => Promise<RuntimeTreeItem[]>;
     onTreeError: (error: unknown) => void;
+    onSelectTab: (param: string, value: string) => void;
 }) {
     const { theme } = useUnistyles();
     const { width } = useWindowDimensions();
@@ -331,6 +341,26 @@ function ScreenNode(props: {
                             : <View key={index} style={{ flexBasis: `${100 / columns - 2}%`, flexGrow: 1, maxWidth: `${100 / columns}%` }}><ScreenNode {...props} node={child} /></View>)}
                     </View>
                 </View>
+            );
+        }
+        case 'tabs': {
+            const tabs = asScreenTabs(resolvePath(data, node.path));
+            if (tabs.length === 0) return null;
+            const selected = resolvePath(data, node.selectedPath);
+            const active = typeof selected === 'string' && selected !== '' ? selected : tabs[0]!.id;
+            return (
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 12 }} contentContainerStyle={{ gap: 6 }}>
+                    {tabs.map((tab) => (
+                        <Pressable key={tab.id} accessibilityRole="tab" accessibilityState={{ selected: tab.id === active }} accessibilityLabel={tab.label}
+                            onPress={() => props.onSelectTab(node.param, tab.id)}
+                            style={({ pressed }) => ({
+                                paddingHorizontal: 12, paddingVertical: 7, borderRadius: 999, opacity: pressed ? 0.6 : 1,
+                                backgroundColor: tab.id === active ? theme.colors.accent : theme.colors.surfaceHigh,
+                            })}>
+                            <Text style={{ fontSize: 13, fontWeight: '600', color: tab.id === active ? theme.colors.surface : theme.colors.textSecondary }}>{tab.label}</Text>
+                        </Pressable>
+                    ))}
+                </ScrollView>
             );
         }
         case 'tree':
@@ -453,6 +483,13 @@ function ScreenBody(props: {
     const [running, setRunning] = React.useState(false);
     const [status, setStatus] = React.useState<{ ok: boolean; text: string }>();
     const [refreshNonce, setRefreshNonce] = React.useState(0);
+    // A pressed tab is just another screen param, so one payload per tab keeps
+    // the plugin's reply small instead of shipping every tab's detail at once.
+    const [tabParams, setTabParams] = React.useState<Record<string, string>>({});
+    const callParams = React.useMemo(() => {
+        const merged = { ...(props.params ?? {}), ...tabParams };
+        return Object.keys(merged).length === 0 ? undefined : merged;
+    }, [props.params, tabParams]);
     const operationVersion = React.useRef(0);
     const dirtyFields = React.useRef(new Set<string>());
     const writeKeys = sharedPluginWriteKeys;
@@ -462,6 +499,7 @@ function ScreenBody(props: {
         operationVersion.current += 1;
         dirtyFields.current.clear();
         setRunning(false);
+        setTabParams({});
         return () => { operationVersion.current += 1; };
     }, [props.manifest, props.manifestHash, props.params]);
     React.useEffect(() => subscribePluginDataInvalidation(props.pluginId, () => {
@@ -472,7 +510,7 @@ function ScreenBody(props: {
         let cancelled = false;
         setData(undefined);
         setDataError(undefined);
-        void loadScreenData(dataContributionId, props.manifest, props.pluginId, props.manifestHash, request, props.params)
+        void loadScreenData(dataContributionId, props.manifest, props.pluginId, props.manifestHash, request, callParams)
             .then((value) => {
                 if (cancelled) return;
                 setData(value);
@@ -482,7 +520,7 @@ function ScreenBody(props: {
             })
             .catch((error: unknown) => { if (!cancelled) setDataError(error instanceof Error ? error.message : String(error)); });
         return () => { cancelled = true; };
-    }, [dataContributionId, props.manifest, props.pluginId, props.manifestHash, props.params, request, refreshNonce]);
+    }, [dataContributionId, props.manifest, props.pluginId, props.manifestHash, callParams, request, refreshNonce]);
 
     const onRowAction = React.useCallback((action: PluginScreenRowAction, item: unknown) => {
         const bound = action.type === 'screen' && action.params !== undefined
@@ -515,7 +553,7 @@ function ScreenBody(props: {
         void runScreenButton({
             button, fields, pluginId: props.pluginId, manifestHash: props.manifestHash,
             manifest: props.manifest, writeKeys,
-            ...(props.params === undefined ? {} : { params: props.params }),
+            ...(callParams === undefined ? {} : { params: callParams }),
             slot, newIdempotencyKey: () => newIdempotencyKey(),
         }, request).then((outcome) => {
             setRunning(false);
@@ -523,7 +561,7 @@ function ScreenBody(props: {
             setStatus(outcome);
             if (shouldReloadAfterAction(props.manifest, button.action, outcome.ok)) setRefreshNonce((value) => value + 1);
         });
-    }, [fields, props.pluginId, props.manifestHash, props.manifest, props.params, request, router, writeKeys]);
+    }, [fields, props.pluginId, props.manifestHash, props.manifest, callParams, request, router, writeKeys]);
 
     const setField = React.useCallback((id: string, value: string | boolean) => {
         dirtyFields.current.add(id);
@@ -537,10 +575,10 @@ function ScreenBody(props: {
             props.pluginId,
             props.manifestHash,
             request,
-            { ...(props.params ?? {}), path },
+            { ...(callParams ?? {}), path },
         );
         return asScreenTree(resolvePath(value, node.path));
-    }, [props.manifest, props.manifestHash, props.params, props.pluginId, request]);
+    }, [props.manifest, props.manifestHash, callParams, props.pluginId, request]);
 
     const { theme } = useUnistyles();
     const reduceMotion = useReducedMotion();
@@ -548,12 +586,11 @@ function ScreenBody(props: {
     // charts would otherwise flash their empty text before real data lands.
     const loadingData = dataContributionId !== undefined && data === undefined && dataError === undefined;
     return (
-        <ScrollView style={{ flex: 1, backgroundColor: theme.colors.surface }} contentContainerStyle={{ padding: 16, paddingBottom: 40 }}>
-            <View style={{ marginBottom: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.divider, paddingBottom: 10 }}>
-                <Text style={{ color: theme.colors.text, fontSize: 13, fontWeight: '600' }}>{props.pluginName}</Text>
-                <Text style={{ color: theme.colors.textSecondary, fontSize: 12, marginTop: 1 }}>{sourceLabel(props.source)}</Text>
-            </View>
-            {screen.title !== undefined && <Text style={{ color: theme.colors.text, fontSize: 26, fontWeight: '700', marginBottom: 12 }}>{bindText(resolvePluginText(screen.title), data)}</Text>}
+        <ScrollView style={{ flex: 1, backgroundColor: theme.colors.surface }} contentContainerStyle={{ padding: 14, paddingTop: 10, paddingBottom: 40 }}>
+            {/* One provenance line, not a header block: the navigation bar already
+                names the plugin, and the screen's own title needs the room. */}
+            <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 11, marginBottom: 6 }}>{`${props.pluginName} · ${sourceLabel(props.source)}`}</Text>
+            {screen.title !== undefined && <Text style={{ color: theme.colors.text, fontSize: 21, fontWeight: '700', marginBottom: 8 }}>{bindText(resolvePluginText(screen.title), data)}</Text>}
             {/* Show why, not just that: a plugin author debugging a screen has
                 nothing to go on otherwise. The host already bounds this text. */}
             {dataError !== undefined && <Pressable onPress={() => setRefreshNonce((value) => value + 1)} accessibilityRole="button" accessibilityLabel={`${capUtf8Bytes(sanitizeDisplayText(dataError), 300)}. ${t('plugins.retry')}`} style={{ marginBottom: 8, paddingVertical: 10 }}>
@@ -565,6 +602,7 @@ function ScreenBody(props: {
                 : screen.children.map((node, index) => (
                     <Animated.View key={index} entering={reduceMotion ? undefined : FadeInDown.duration(280).delay(Math.min(index, 8) * 40).easing(Easing.bezier(0.23, 1, 0.32, 1))}>
                         <ScreenNode node={node} data={data} fields={fields} setField={setField} running={running} onButton={onButton} onRowAction={onRowAction} onTreeLoad={onTreeLoad}
+                            onSelectTab={(param, value) => setTabParams((current) => ({ ...current, [param]: value }))}
                             onTreeError={(error) => setStatus({ ok: false, text: error instanceof Error ? error.message : String(error) })} />
                     </Animated.View>
                 ))}

--- a/apps/mobile/sources/plugins/fileIcon.ts
+++ b/apps/mobile/sources/plugins/fileIcon.ts
@@ -1,0 +1,96 @@
+/**
+ * File-type icons for the plugin explorer, keyed by extension the way editors
+ * do it. Colours are the language's own so a long tree is scannable without
+ * reading a single name.
+ */
+
+import type { MaterialCommunityIcons } from '@expo/vector-icons';
+
+type IconName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
+
+export interface FileIcon {
+    name: IconName;
+    color?: string;
+}
+
+const BY_EXTENSION: Record<string, FileIcon> = {
+    ts: { name: 'language-typescript', color: '#3178c6' },
+    tsx: { name: 'language-typescript', color: '#3178c6' },
+    js: { name: 'language-javascript', color: '#f1e05a' },
+    jsx: { name: 'language-javascript', color: '#f1e05a' },
+    mjs: { name: 'language-javascript', color: '#f1e05a' },
+    cjs: { name: 'language-javascript', color: '#f1e05a' },
+    json: { name: 'code-json', color: '#cbcb41' },
+    py: { name: 'language-python', color: '#4b8bbe' },
+    rs: { name: 'language-rust', color: '#dea584' },
+    go: { name: 'language-go', color: '#00add8' },
+    java: { name: 'language-java', color: '#b07219' },
+    kt: { name: 'language-kotlin', color: '#a97bff' },
+    kts: { name: 'language-kotlin', color: '#a97bff' },
+    swift: { name: 'language-swift', color: '#f05138' },
+    c: { name: 'language-c', color: '#8ab4f8' },
+    h: { name: 'language-c', color: '#8ab4f8' },
+    cc: { name: 'language-cpp', color: '#f34b7d' },
+    cpp: { name: 'language-cpp', color: '#f34b7d' },
+    hpp: { name: 'language-cpp', color: '#f34b7d' },
+    rb: { name: 'language-ruby', color: '#cc342d' },
+    php: { name: 'language-php', color: '#8993be' },
+    html: { name: 'language-html5', color: '#e34c26' },
+    css: { name: 'language-css3', color: '#8f7ddb' },
+    scss: { name: 'language-css3', color: '#cf649a' },
+    sh: { name: 'console', color: '#89e051' },
+    bash: { name: 'console', color: '#89e051' },
+    zsh: { name: 'console', color: '#89e051' },
+    fish: { name: 'console', color: '#89e051' },
+    md: { name: 'language-markdown', color: '#8ab4f8' },
+    mdx: { name: 'language-markdown', color: '#8ab4f8' },
+    yml: { name: 'cog-outline', color: '#e6a44e' },
+    yaml: { name: 'cog-outline', color: '#e6a44e' },
+    toml: { name: 'cog-outline', color: '#e6a44e' },
+    ini: { name: 'cog-outline', color: '#e6a44e' },
+    env: { name: 'key-variant', color: '#e6a44e' },
+    lock: { name: 'lock-outline', color: '#8a8f98' },
+    sql: { name: 'database-outline', color: '#e38c00' },
+    png: { name: 'file-image-outline', color: '#a074c4' },
+    jpg: { name: 'file-image-outline', color: '#a074c4' },
+    jpeg: { name: 'file-image-outline', color: '#a074c4' },
+    gif: { name: 'file-image-outline', color: '#a074c4' },
+    webp: { name: 'file-image-outline', color: '#a074c4' },
+    svg: { name: 'svg', color: '#ffb13b' },
+    ico: { name: 'file-image-outline', color: '#a074c4' },
+    mp4: { name: 'file-video-outline', color: '#8ab4f8' },
+    mov: { name: 'file-video-outline', color: '#8ab4f8' },
+    webm: { name: 'file-video-outline', color: '#8ab4f8' },
+    mp3: { name: 'file-music-outline', color: '#8ab4f8' },
+    wav: { name: 'file-music-outline', color: '#8ab4f8' },
+    pdf: { name: 'file-pdf-box', color: '#e05a4e' },
+    zip: { name: 'folder-zip-outline', color: '#e6a44e' },
+    gz: { name: 'folder-zip-outline', color: '#e6a44e' },
+    tar: { name: 'folder-zip-outline', color: '#e6a44e' },
+};
+
+const BY_NAME: Record<string, FileIcon> = {
+    '.gitignore': { name: 'git', color: '#f14e32' },
+    '.gitattributes': { name: 'git', color: '#f14e32' },
+    '.gitmodules': { name: 'git', color: '#f14e32' },
+    dockerfile: { name: 'docker', color: '#2496ed' },
+    'docker-compose.yml': { name: 'docker', color: '#2496ed' },
+    'package.json': { name: 'npm', color: '#cb3837' },
+    'yarn.lock': { name: 'lock-outline', color: '#8a8f98' },
+    'package-lock.json': { name: 'lock-outline', color: '#8a8f98' },
+    makefile: { name: 'cog-outline', color: '#e6a44e' },
+    license: { name: 'scale-balance', color: '#8a8f98' },
+};
+
+export function fileIcon(name: string): FileIcon {
+    const lower = name.toLowerCase();
+    const named = BY_NAME[lower];
+    if (named !== undefined) return named;
+    const dot = lower.lastIndexOf('.');
+    const extension = dot <= 0 ? '' : lower.slice(dot + 1);
+    return BY_EXTENSION[extension] ?? { name: 'file-outline' };
+}
+
+export function folderIcon(expanded: boolean): FileIcon {
+    return { name: expanded ? 'folder-open' : 'folder', color: '#7aa2d6' };
+}

--- a/apps/mobile/sources/preview/openPreview.ts
+++ b/apps/mobile/sources/preview/openPreview.ts
@@ -1,16 +1,18 @@
 /**
  * Browser preview, device half.
  *
- * The relay opens the TCP listener; this only asks for one and holds the control
- * socket open, because the listener lives exactly as long as that socket. The
- * preview URL is built from the relay host the app is already connected to, so a
- * preview reaches as far as the session does -- LAN, Tailscale, a tunnel -- with
- * nothing extra to configure.
+ * The device binds the listener and the relay only forwards frames, so the page
+ * loads from the phone's own loopback over whatever transport the session
+ * already uses -- LAN, Tailscale, a tunnel, a hosted relay. Asking the relay for
+ * an ephemeral port instead only works where the relay is published beyond 443,
+ * and is plain HTTP across the internet where it is, so web -- which cannot bind
+ * a listener -- is the only caller left on that path.
  */
 
 import { issueWsTicket, newPreviewChannel, previewSocketUrl, ticketSocketUrl } from '@muxr/contract';
 import { getCachedConnectionSettings } from '@/state/connectionSettings';
 import { sync } from '@/sync/sync';
+import { previewBridgeAvailable, startPreviewBridge } from './previewBridge';
 
 const READY_TIMEOUT_MS = 15_000;
 
@@ -30,6 +32,24 @@ function relayHostname(relayUrl: string): string | undefined {
     return /^wss?:\/\/([^/:?#]+)/i.exec(relayUrl)?.[1];
 }
 
+function waitForRelay(socket: WebSocket, type: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.close();
+            reject(new Error('The relay did not pair the preview in time.'));
+        }, READY_TIMEOUT_MS);
+        socket.onmessage = (event) => {
+            try {
+                if ((JSON.parse(String(event.data)) as { type?: string }).type !== type) return;
+            } catch { return; }
+            clearTimeout(timer);
+            resolve();
+        };
+        socket.onclose = () => { clearTimeout(timer); reject(new Error('The relay closed the preview before it was ready.')); };
+        socket.onerror = () => { clearTimeout(timer); reject(new Error('Could not reach the relay to open a preview.')); };
+    });
+}
+
 /**
  * Join a preview channel to a loopback port and hold it open. The relay
  * listener carries raw TCP without parsing it, so anything that speaks over a
@@ -38,7 +58,9 @@ function relayHostname(relayUrl: string): string | undefined {
  */
 export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> {
     const settings = getCachedConnectionSettings();
-    if (settings.mode !== 'local') throw new Error('Hosted Preview is disabled until browser trust and pinning are complete.');
+    if (!previewBridgeAvailable && settings.mode !== 'local') {
+        throw new Error('Browser preview needs the muxr app on this platform.');
+    }
     const hostname = relayHostname(settings.relayUrl);
     if (hostname === undefined) {
         throw new Error(`Cannot read a host from the relay URL "${settings.relayUrl}".`);
@@ -54,6 +76,7 @@ export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> 
             channel,
             role: 'client',
             ...(settings.token === '' ? {} : { token: settings.token }),
+            ...(previewBridgeAvailable ? { bridge: true } : {}),
         })
         : ticketSocketUrl(settings.relayUrl, await issueWsTicket({
             relayUrl: settings.relayUrl,
@@ -62,8 +85,15 @@ export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> 
             role: 'client',
             transport: 'preview',
             channel,
-        }), 'preview');
+        }), 'preview', previewBridgeAvailable);
     const socket = new WebSocket(socketUrl);
+
+    if (previewBridgeAvailable) {
+        socket.binaryType = 'arraybuffer';
+        await waitForRelay(socket, 'preview.bridge');
+        const bridge = await startPreviewBridge(socket);
+        return { hostname: '127.0.0.1', port: bridge.port, close: bridge.close };
+    }
 
     const previewPort = await new Promise<number>((resolve, reject) => {
         const timer = setTimeout(() => {

--- a/apps/mobile/sources/preview/previewBridge.ts
+++ b/apps/mobile/sources/preview/previewBridge.ts
@@ -1,0 +1,89 @@
+/**
+ * Browser preview, device end.
+ *
+ * The listener lives on the phone's own loopback and the relay only forwards
+ * frames, so the preview URL is `http://127.0.0.1:<port>/`: a secure context to
+ * the WebView, private to the device, and reachable no matter how the relay is
+ * published. A relay-side ephemeral port cannot do that -- it is unreachable
+ * behind a tunnel that proxies 443 only, and plain HTTP across the internet
+ * where it is reachable.
+ */
+
+import TcpSocket from 'react-native-tcp-socket';
+import { decodePreviewFrame, encodePreviewFrame, PREVIEW_CLOSE, PREVIEW_DATA } from '@muxr/contract';
+
+export interface PreviewBridge {
+    port: number;
+    close: () => void;
+}
+
+export const previewBridgeAvailable = true;
+
+type Server = ReturnType<typeof TcpSocket.createServer>;
+type Connection = InstanceType<typeof TcpSocket.Socket>;
+
+function toBytes(data: string | Buffer): Uint8Array {
+    if (typeof data !== 'string') return new Uint8Array(data);
+    // The library hands text back as base64 only when asked; a string here is
+    // binary read as latin1, so map it back byte for byte.
+    const bytes = new Uint8Array(data.length);
+    for (let index = 0; index < data.length; index += 1) bytes[index] = data.charCodeAt(index) & 0xff;
+    return bytes;
+}
+
+export async function startPreviewBridge(socket: WebSocket): Promise<PreviewBridge> {
+    const connections = new Map<number, Connection>();
+    let nextConnId = 0;
+    let server: Server | undefined;
+
+    const send = (connId: number, flag: number, payload?: Uint8Array): void => {
+        if (socket.readyState === WebSocket.OPEN) socket.send(encodePreviewFrame(connId, flag, payload));
+    };
+
+    socket.onmessage = (event) => {
+        if (typeof event.data === 'string') return;
+        const frame = decodePreviewFrame(new Uint8Array(event.data as ArrayBuffer));
+        if (frame === undefined) return;
+        const connection = connections.get(frame.connId);
+        if (connection === undefined) return;
+        if (frame.flag === PREVIEW_CLOSE) {
+            connections.delete(frame.connId);
+            connection.destroy();
+            return;
+        }
+        if (frame.payload.length > 0) connection.write(Buffer.from(frame.payload));
+    };
+
+    const close = (): void => {
+        for (const connection of connections.values()) connection.destroy();
+        connections.clear();
+        server?.close();
+        if (socket.readyState === WebSocket.OPEN) socket.close();
+    };
+
+    const port = await new Promise<number>((resolve, reject) => {
+        server = TcpSocket.createServer((connection) => {
+            nextConnId += 1;
+            const connId = nextConnId;
+            connections.set(connId, connection);
+            connection.on('data', (data) => send(connId, PREVIEW_DATA, toBytes(data)));
+            connection.on('close', () => { connections.delete(connId); send(connId, PREVIEW_CLOSE); });
+            connection.on('error', () => { connections.delete(connId); send(connId, PREVIEW_CLOSE); });
+        });
+        server.on('error', (error: Error) => reject(error));
+        // Loopback only: nothing else on the network may reach the dev server.
+        server.listen({ port: 0, host: '127.0.0.1' }, () => {
+            const address = server?.address();
+            if (address === undefined || address === null || typeof address === 'string') {
+                reject(new Error('The preview listener did not report a port.'));
+                return;
+            }
+            resolve(address.port);
+        });
+    }).catch((error: unknown) => {
+        close();
+        throw error;
+    });
+
+    return { port, close };
+}

--- a/apps/mobile/sources/preview/previewBridge.web.ts
+++ b/apps/mobile/sources/preview/previewBridge.web.ts
@@ -1,0 +1,12 @@
+/** A browser tab cannot bind a listener, so web keeps the relay-side port. */
+
+export interface PreviewBridge {
+    port: number;
+    close: () => void;
+}
+
+export const previewBridgeAvailable = false;
+
+export function startPreviewBridge(_socket: WebSocket): Promise<PreviewBridge> {
+    return Promise.reject(new Error('Browser preview needs the muxr app on this platform.'));
+}

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -425,7 +425,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     </Pressable>
                 )}
                 <PluginSlot slot="session.header.trailing" context={{ sessionId: props.id, cwd: session?.metadata?.path }} />
-                <DeclarativeHeaderButtons cwd={session?.metadata?.path} />
+                <DeclarativeHeaderButtons cwd={session?.metadata?.path} sessionId={props.id} />
                 <DeclarativeChips slot="session.header.trailing" />
                 {(
                     <Pressable

--- a/apps/relay/src/preview.ts
+++ b/apps/relay/src/preview.ts
@@ -43,6 +43,39 @@ export class PreviewChannels {
     }
 
     /**
+     * Forwards frames between a client that runs its own listener and the host.
+     * The relay holds no socket of its own here, so the preview survives a relay
+     * published only on 443 -- a tunnel, or any TLS front door.
+     */
+    async bridgeClient(channel: string, socket: WebSocket): Promise<void> {
+        const upstream = await this.waitForUpstream(channel);
+        if (upstream === undefined) {
+            socket.close(1008, 'preview: no host on this channel');
+            return;
+        }
+        this.upstreams.delete(channel);
+
+        const copy = (from: WebSocket, to: WebSocket) => (data: RawData) => {
+            // Decoded, not relayed blind: a malformed frame is dropped here
+            // rather than handed to the other end.
+            if (decodePreviewFrame(new Uint8Array(data as Buffer)) === undefined) return;
+            if (to.readyState === to.OPEN) to.send(data as Buffer, { binary: true });
+        };
+        socket.on('message', copy(socket, upstream));
+        upstream.on('message', copy(upstream, socket));
+
+        const teardown = (): void => {
+            if (socket.readyState === socket.OPEN) socket.close();
+            if (upstream.readyState === upstream.OPEN) upstream.close();
+        };
+        socket.on('close', teardown);
+        socket.on('error', teardown);
+        upstream.on('close', teardown);
+        upstream.on('error', teardown);
+        socket.send(JSON.stringify({ type: 'preview.bridge' }));
+    }
+
+    /**
      * Opens the TCP listener this client will point a WebView at and reports the
      * port back over `socket`. Rejects when no host has joined the channel, so
      * the app can say so instead of showing a page that never loads.

--- a/apps/relay/src/relay.ts
+++ b/apps/relay/src/relay.ts
@@ -797,6 +797,8 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
             const key = `${accountId.length}:${accountId}${machineId.length}:${machineId}${channel}`;
             if (identity.role === 'machine') {
                 previews.joinMachine(key, socket);
+            } else if (url.searchParams.get('bridge') === '1') {
+                previews.bridgeClient(key, socket);
             } else {
                 // Same interface the relay itself is reachable on, so a preview
                 // reaches exactly as far as the session link does.

--- a/packages/contract/src/manifest.ts
+++ b/packages/contract/src/manifest.ts
@@ -65,6 +65,11 @@ function id(value: unknown): string {
     if (typeof value !== 'string' || !/^[a-z0-9][a-z0-9._-]{0,63}$/.test(value)) throw new Error('invalid plugin id');
     return value;
 }
+/** Screen params name RPC input fields, which are camelCase, not plugin ids. */
+function paramKey(value: unknown): string {
+    if (typeof value !== 'string' || !/^[a-z][a-zA-Z0-9_]{0,63}$/.test(value)) throw new Error('invalid plugin screen param');
+    return value;
+}
 function presentation(value: unknown): 'card' | 'sheet' {
     if (value !== 'card' && value !== 'sheet') throw new Error('invalid data-card presentation');
     return value;
@@ -259,6 +264,13 @@ function parseScreenNode(item: Record<string, unknown>, depth: number, budget: {
                 ...(item.title === undefined ? {} : { title: pluginText(item.title, 80) }),
                 ...(item.emptyText === undefined ? {} : { emptyText: pluginText(item.emptyText, 120) }),
             };
+        case 'tabs':
+            return {
+                type: 'tabs',
+                path: bindingPath(item.path),
+                selectedPath: bindingPath(item.selectedPath),
+                param: paramKey(item.param),
+            };
         case 'divider':
             return { type: 'divider' };
         case 'empty':
@@ -359,7 +371,7 @@ function actionInput(value: unknown): unknown {
 
 export function parsePluginScreenParams(value: unknown): Record<string, string> {
     if (!isRecord(value) || Object.keys(value).length > MAX_SCREEN_PARAMS) throw new Error('invalid plugin screen action params');
-    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [id(key), text(entry, MAX_TEXT)]));
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [paramKey(key), text(entry, MAX_TEXT)]));
 }
 
 /** Shared structural validator for manifest actions and untrusted RPC results. */

--- a/packages/contract/src/plugins.ts
+++ b/packages/contract/src/plugins.ts
@@ -473,6 +473,21 @@ export interface PluginScreenTreeNode {
     action?: PluginScreenRowAction;
 }
 
+/**
+ * Data-driven tab strip. Selecting a tab reloads the screen with `param` set to
+ * that tab's id, so a plugin serves one provider at a time instead of shipping
+ * every provider's detail in a single payload.
+ */
+export interface PluginScreenTabsNode {
+    type: 'tabs';
+    /** Runtime path to bounded `{ id, label }` entries. */
+    path: string;
+    /** Runtime path holding the id of the tab the payload belongs to. */
+    selectedPath: string;
+    /** Screen param set to the pressed tab's id. */
+    param: string;
+}
+
 export interface PluginScreenListNode {
     type: 'list';
     title?: PluginText;
@@ -501,6 +516,7 @@ export type PluginScreenNode =
     | PluginScreenButtonNode
     | PluginScreenSectionNode
     | PluginScreenListNode
+    | PluginScreenTabsNode
     | PluginScreenTreeNode;
 
 export interface PluginScreenContribution {

--- a/packages/contract/src/preview.ts
+++ b/packages/contract/src/preview.ts
@@ -53,7 +53,7 @@ export function newPreviewChannel(): string {
  */
 export function previewSocketUrl(
     relayUrl: string,
-    options: { machineId: string; channel: string; role: 'machine' | 'client'; token?: string },
+    options: { machineId: string; channel: string; role: 'machine' | 'client'; token?: string; bridge?: boolean },
 ): string {
     // Hand-built rather than URLSearchParams: this runs on React Native too,
     // where that polyfill is partial.
@@ -66,5 +66,9 @@ export function previewSocketUrl(
     if (options.token !== undefined && options.token !== '') {
         parts.push(`token=${encodeURIComponent(options.token)}`);
     }
+    // A bridging client holds its own listener, so the relay must not open one:
+    // an ephemeral relay port is unreachable behind a tunnel that only proxies
+    // 443, and it would be plain HTTP across the internet if it were.
+    if (options.bridge === true) parts.push('bridge=1');
     return `${base}/preview?${parts.join('&')}`;
 }

--- a/packages/contract/src/wsTickets.ts
+++ b/packages/contract/src/wsTickets.ts
@@ -41,7 +41,8 @@ export async function issueWsTicket(input: {
     return body.ticket;
 }
 
-export function ticketSocketUrl(relayUrl: string, ticket: string, transport: WsTransport): string {
+export function ticketSocketUrl(relayUrl: string, ticket: string, transport: WsTransport, bridge = false): string {
     const path = transport === 'relay' ? '' : `/${transport}`;
-    return `${stripTrailingSlashes(relayUrl)}${path}?ticket=${encodeURIComponent(ticket)}`;
+    const query = `ticket=${encodeURIComponent(ticket)}${bridge ? '&bridge=1' : ''}`;
+    return `${stripTrailingSlashes(relayUrl)}${path}?${query}`;
 }

--- a/plugins/code/files.mjs
+++ b/plugins/code/files.mjs
@@ -31,8 +31,22 @@ function repos() {
     return [...seen.values()].slice(0, 32);
 }
 
+/** The host injects the session's cwd; a caller can never choose it. */
+function sessionRoot() {
+    const cwd = String(input.cwd ?? '');
+    if (cwd === '' || cwd.includes('\0')) return undefined;
+    try { return exec('git', ['-C', cwd, 'rev-parse', '--show-toplevel'], 3000).trim() || undefined; }
+    catch { return undefined; }
+}
+
 function repoRoot(value) {
-    const found = repos().find((entry) => entry.root === String(value ?? ''));
+    const requested = String(value ?? '');
+    const session = sessionRoot();
+    if (requested === '' || requested === session) {
+        if (session === undefined) throw new Error('unknown repository');
+        return session;
+    }
+    const found = repos().find((entry) => entry.root === requested);
     if (found === undefined) throw new Error('unknown repository');
     return found.root;
 }

--- a/plugins/code/history.mjs
+++ b/plugins/code/history.mjs
@@ -23,7 +23,7 @@ if (method === 'log') {
     }
     const root = execFileSync('git', ['-C', repo(), 'rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 20000 }).trim();
     const commits = git(['log', '-25', '--date=short', '--pretty=%H%x1f%h%x1f%s%x1f%an%x1f%ad']).split('\n').filter(Boolean)
-        .map((line) => { const [sha, short, subject, author, date] = line.split('\x1f'); return { sha, short, subject, author, date, meta: `${short} · ${author} · ${date}`, cwd: repo() }; });
+        .map((line) => { const [sha, short, subject, author, date] = line.split('\x1f'); return { sha, short, subject, author, date, meta: `${short} · ${author} · ${date}`, sessionId: String(input.sessionId ?? '') }; });
     process.stdout.write(JSON.stringify({ title: root.split('/').pop(), count: `${commits.length} recent commits`, commits }));
 } else {
     const sha = String(input.sha ?? '');

--- a/plugins/code/muxr-ui.json
+++ b/plugins/code/muxr-ui.json
@@ -69,6 +69,14 @@
       ]
     },
     {
+      "slot": "session.header.trailing",
+      "id": "files.open",
+      "type": "screen-button",
+      "title": "Files",
+      "icon": "folder-outline",
+      "contentContributionId": "files"
+    },
+    {
       "slot": "navigation.content",
       "id": "files",
       "type": "screen",
@@ -202,7 +210,7 @@
                 "contributionId": "history.commit",
                 "params": {
                   "sha": "{{item.sha}}",
-                  "cwd": "{{item.cwd}}"
+                  "sessionId": "{{item.sessionId}}"
                 }
               }
             }

--- a/plugins/status/muxr-ui.json
+++ b/plugins/status/muxr-ui.json
@@ -45,46 +45,81 @@
       },
       "children": [
         {
+          "type": "tabs",
+          "path": "data.providers",
+          "selectedPath": "data.provider",
+          "param": "provider"
+        },
+        {
           "type": "section",
           "title": "Today",
           "columns": 2,
           "children": [
             {
               "type": "metric",
-              "label": "Tokens today",
-              "value": "{{data.summary.totalTokens}}"
+              "label": "Tokens",
+              "value": "{{data.todayTokens}}"
             },
             {
               "type": "metric",
-              "label": "Active agents",
-              "value": "{{data.summary.measured}}"
+              "label": "Cost",
+              "value": "{{data.todayCost}}"
+            }
+          ]
+        },
+        {
+          "type": "chart",
+          "variant": "ring",
+          "path": "data.limitRing",
+          "title": "Current limit",
+          "emptyText": "No published limit for this provider"
+        },
+        {
+          "type": "text",
+          "text": "{{data.limitLabel}}",
+          "tone": "secondary"
+        },
+        {
+          "type": "chart",
+          "variant": "bar",
+          "path": "data.modelSeries",
+          "title": "Models today",
+          "emptyText": "No measured activity today"
+        },
+        {
+          "type": "chart",
+          "variant": "bar",
+          "path": "data.weekSeries",
+          "title": "Last 7 days",
+          "emptyText": "No measured activity this week"
+        },
+        {
+          "type": "section",
+          "title": "This week",
+          "columns": 2,
+          "children": [
+            {
+              "type": "metric",
+              "label": "Tokens",
+              "value": "{{data.weekTokens}}"
+            },
+            {
+              "type": "metric",
+              "label": "Cost",
+              "value": "{{data.weekCost}}"
             }
           ]
         },
         {
           "type": "chart",
           "variant": "bar",
-          "path": "data.activitySeries",
-          "title": "Token activity",
-          "emptyText": "No measured activity today"
-        },
-        {
-          "type": "chart",
-          "variant": "ring",
-          "path": "data.codexRing",
-          "title": "Codex availability",
-          "emptyText": "Codex limits unavailable"
-        },
-        {
-          "type": "chart",
-          "variant": "bar",
-          "path": "data.codexSeries",
-          "title": "Codex limits",
-          "emptyText": "Codex limits unavailable"
+          "path": "data.limitSeries",
+          "title": "Rate limits",
+          "emptyText": "No published rate limits"
         },
         {
           "type": "text",
-          "text": "Local activity only. Costs, prompts, models, projects, and session details stay out.",
+          "text": "Read from local agent logs. Prompts and project details stay out.",
           "tone": "secondary"
         }
       ]

--- a/plugins/status/usage.mjs
+++ b/plugins/status/usage.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { constants, accessSync, chmodSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+
 import { createRequire } from 'node:module';
 import { delimiter, join } from 'node:path';
 
 const require = createRequire(import.meta.url);
+const input = JSON.parse(readFileSync(0, 'utf8') || 'null') ?? {};
+/** Which provider tab the screen asked for; empty means "pick the busiest". */
+const selected = String(input.provider ?? '').slice(0, 32);
 let ccusageFailure;
 const AGENTS = {
   claude: 'Anthropic Claude', codex: 'OpenAI Codex', opencode: 'OpenCode', amp: 'Amp', droid: 'Droid', codebuff: 'Codebuff',
@@ -71,12 +75,72 @@ function runJson(command, args, timeout = 8_000) {
   });
 }
 
-async function ccusageDaily() {
+const RANGE_DAYS = 7;
+
+function sinceArgument() {
+  const start = new Date(Date.now() - (RANGE_DAYS - 1) * 86_400_000);
+  return `${start.getFullYear()}${String(start.getMonth() + 1).padStart(2, '0')}${String(start.getDate()).padStart(2, '0')}`;
+}
+
+/**
+ * One report covers every provider and every day on screen. Asking per tab
+ * would re-read the same session logs once per provider.
+ */
+async function ccusageRange() {
   const binary = ccusageBinary();
   if (!binary) return undefined;
-  const result = await runJson(binary, ['daily', '--last', '1', '--by-agent', '--json', '--no-cost', '--offline'], 15_000);
+  const result = await runJson(binary, ['daily', '--by-agent', '--json', '--offline', '--since', sinceArgument()], 20_000);
   if (result === undefined && ccusageFailure === undefined) ccusageFailure = 'ccusage activity unavailable · reopen Usage in a minute';
   return result;
+}
+
+async function claudeBlock() {
+  const binary = ccusageBinary();
+  if (!binary) return undefined;
+  const result = await runJson(binary, ['blocks', '--active', '--json', '--offline'], 15_000);
+  return Array.isArray(result?.blocks) ? result.blocks.find((block) => block?.isActive) : undefined;
+}
+
+function money(value) {
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return value >= 100 ? `$${Math.round(value)}` : `$${value.toFixed(2)}`;
+}
+
+function dayLabel(period) {
+  const parsed = new Date(`${String(period ?? '')}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime())
+    ? String(period ?? '')
+    : ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][parsed.getUTCDay()];
+}
+
+/**
+ * agent -> one entry per day in the window, so every tab reads from one report.
+ * Days an agent sat idle stay in the series as zeroes; dropping them would slide
+ * an older day into today's slot and report stale totals as current.
+ */
+function byAgent(result) {
+  const days = Array.isArray(result?.daily) ? result.daily.slice(-RANGE_DAYS) : [];
+  const periods = days.map((day) => String(day?.period ?? ''));
+  const agents = new Map();
+  days.forEach((day, index) => {
+    for (const row of Array.isArray(day?.agents) ? day.agents.slice(0, 32) : []) {
+      if (!CCUSAGE_AGENTS.has(row?.agent) || !Number.isSafeInteger(row.totalTokens) || row.totalTokens < 0) continue;
+      const entry = agents.get(row.agent) ?? periods.map((period) => ({ period, row: undefined }));
+      entry[index] = { period: periods[index], row };
+      agents.set(row.agent, entry);
+    }
+  });
+  return agents;
+}
+
+function modelSeries(row) {
+  const breakdowns = Array.isArray(row?.modelBreakdowns) ? row.modelBreakdowns.slice(0, 8) : [];
+  return breakdowns.flatMap((model) => {
+    const total = (model.inputTokens ?? 0) + (model.outputTokens ?? 0) + (model.cacheCreationTokens ?? 0) + (model.cacheReadTokens ?? 0);
+    const label = String(model.modelName ?? '').replace(/[^\x20-\x7e]+/g, ' ').trim().slice(0, 40);
+    const valueLabel = tokens(total);
+    return label === '' || valueLabel === undefined ? [] : [{ label, value: total, valueLabel }];
+  }).sort((a, b) => b.value - a.value);
 }
 
 function tokens(value) {
@@ -87,13 +151,11 @@ function tokens(value) {
   return String(Math.round(value));
 }
 
-function ccusageItems(result) {
+function ccusageItems(agents) {
   const totals = new Map();
-  for (const day of Array.isArray(result?.daily) ? result.daily.slice(0, 1) : []) {
-    for (const row of Array.isArray(day?.agents) ? day.agents.slice(0, 32) : []) {
-      if (!CCUSAGE_AGENTS.has(row?.agent) || !Number.isSafeInteger(row.totalTokens) || row.totalTokens < 0) continue;
-      totals.set(row.agent, (totals.get(row.agent) ?? 0) + row.totalTokens);
-    }
+  for (const [agent, days] of agents) {
+    const today = days[days.length - 1]?.row;
+    if (today !== undefined) totals.set(agent, today.totalTokens);
   }
   const sorted = [...totals].sort((a, b) => b[1] - a[1]).slice(0, 16);
   const max = sorted.length === 0 ? 0 : sorted[0][1];
@@ -111,14 +173,18 @@ function ccusageItems(result) {
     return valueLabel === undefined ? [] : [{ label: AGENTS[agent], value: total, valueLabel }];
   });
   const totalTokens = [...totals.values()].reduce((sum, value) => sum + value, 0);
-  return { items, series, agents: new Set(totals.keys()), totalTokens };
+  return { items, series, agents: new Set(totals.keys()), totalTokens, totals };
+}
+
+function cacheName() {
+  return `usage-${selected === '' ? 'all' : selected}.json`;
 }
 
 function cachedOutput() {
   const state = process.env.MUXR_PLUGIN_STATE_DIR?.trim();
   if (!state) return undefined;
   try {
-    const saved = JSON.parse(readFileSync(join(state, 'usage.json'), 'utf8'));
+    const saved = JSON.parse(readFileSync(join(state, cacheName()), 'utf8'));
     const age = Date.now() - saved.at;
     if (age >= 0 && age < 60_000 && Array.isArray(saved.output?.items) && JSON.stringify(saved.output).length <= 16_384) return saved.output;
   } catch {}
@@ -128,7 +194,7 @@ function cachedOutput() {
 function saveOutput(output) {
   const state = process.env.MUXR_PLUGIN_STATE_DIR?.trim();
   if (!state) return;
-  const cache = join(state, 'usage.json');
+  const cache = join(state, cacheName());
   const temporary = `${cache}.${process.pid}.tmp`;
   try {
     writeFileSync(temporary, JSON.stringify({ at: Date.now(), output }), { mode: 0o600 });
@@ -230,18 +296,32 @@ const cached = cachedOutput();
 if (cached !== undefined) {
   process.stdout.write(JSON.stringify(cached));
 } else {
-  const [activity, codex] = await Promise.all([
-    ccusageDaily().then(ccusageItems),
-    codexUsage().then(codexItems),
-  ]);
+  // Codex limits load every time: the home card lists them whatever tab the
+  // details screen last showed.
+  const [range, codex] = await Promise.all([ccusageRange(), codexUsage().then(codexItems)]);
+  const agents = byAgent(range);
+  const activity = ccusageItems(agents);
+  const installed = Object.entries(AGENT_COMMANDS).filter(([, command]) => available(command));
+  // A provider earns a tab by having measured usage this week or a CLI on the
+  // host; an installed-but-idle agent still deserves a tab that says so.
+  const providerIds = [...new Set([...agents.keys(), ...installed.map(([agent]) => agent)])]
+    .sort((a, b) => (activity.totals.get(b) ?? 0) - (activity.totals.get(a) ?? 0) || AGENTS[a].localeCompare(AGENTS[b]))
+    .slice(0, 16);
+  const provider = providerIds.includes(selected) ? selected : providerIds[0] ?? '';
+  const days = agents.get(provider) ?? [];
+  const today = days[days.length - 1]?.row;
+  const weekTokens = days.reduce((sum, day) => sum + (day.row?.totalTokens ?? 0), 0);
+  const weekCost = days.reduce((sum, day) => sum + (day.row?.totalCost ?? 0), 0);
+  const block = provider === 'claude' ? await claudeBlock() : undefined;
+  const blockRemaining = block === undefined ? undefined
+    : Math.max(0, Math.min(100, Math.round(100 - (Date.now() - Date.parse(block.startTime)) / (Date.parse(block.endTime) - Date.parse(block.startTime)) * 100)));
   const items = [];
   if (ccusageFailure && activity.items.length === 0) items.push({
     id: 'ccusage-unavailable', title: 'Local activity unavailable', subtitle: ccusageFailure, icon: 'warning-outline', metadata: [],
   });
   const reported = new Set(activity.agents);
   if (codex.items.length) reported.add('codex');
-  const installedAgents = Object.entries(AGENT_COMMANDS).filter(([, command]) => available(command));
-  for (const [agent] of installedAgents) {
+  for (const [agent] of installed) {
     if (reported.has(agent)) continue;
     items.push({
       id: `available-${agent}`, title: AGENTS[agent], icon: 'terminal-outline', metadata: [],
@@ -259,12 +339,31 @@ if (cached !== undefined) {
       : {}),
     summary: {
       measured: String(activity.series.length),
-      installed: String(installedAgents.length),
+      installed: String(installed.length),
       totalTokens: totalTokens ?? '0',
     },
     activitySeries: activity.series,
-    codexSeries: codex.series,
-    codexRing: codex.ring,
+    providers: providerIds.map((agent) => ({ id: agent, label: AGENTS[agent] })),
+    provider,
+    providerName: AGENTS[provider] ?? 'Usage',
+    todayTokens: tokens(today?.totalTokens ?? 0) ?? '0',
+    todayCost: money(today?.totalCost) ?? '—',
+    modelSeries: modelSeries(today),
+    weekTokens: tokens(weekTokens) ?? '0',
+    weekCost: money(weekCost) ?? '—',
+    weekSeries: days.map(({ period, row }) => ({
+      label: dayLabel(period), value: row?.totalTokens ?? 0, valueLabel: tokens(row?.totalTokens ?? 0) ?? '0',
+    })),
+    limitSeries: provider === 'codex' ? codex.series : [],
+    limitRing: blockRemaining !== undefined
+      ? [
+          { label: 'Left', value: blockRemaining, valueLabel: `${blockRemaining}%`, tone: limitTone(blockRemaining) },
+          { label: 'Used', value: 100 - blockRemaining, valueLabel: `${100 - blockRemaining}%`, tone: 'secondary' },
+        ]
+      : provider === 'codex' ? codex.ring : [],
+    limitLabel: block !== undefined
+      ? `5-hour window · ${relativeReset(Date.parse(block.endTime) / 1000)} left · ${tokens(Math.round(block.burnRate?.tokensPerMinute ?? 0)) ?? '0'} tokens/min`
+      : provider === 'codex' ? codex.remainingLabel : '',
     codexRemaining: codex.remaining,
     codexRemainingLabel: codex.remainingLabel,
   };

--- a/plugins/status/usage.mjs
+++ b/plugins/status/usage.mjs
@@ -166,6 +166,8 @@ function ccusageItems(agents) {
       group: 'Active today',
       ...(max > 0 ? { progress: { value: total / max } } : {}),
       metadata: [{ value: `${value} tokens`, tone: 'primary' }],
+      // The card is a summary; the detail lives on one screen, wherever it opened from.
+      action: { type: 'screen', contributionId: 'usage.details', params: { provider: agent } },
     }];
   });
   const series = sorted.slice(0, 8).flatMap(([agent, total]) => {
@@ -327,13 +329,15 @@ if (cached !== undefined) {
       id: `available-${agent}`, title: AGENTS[agent], icon: 'terminal-outline', metadata: [],
       group: 'Idle today',
       ...(CCUSAGE_AGENTS.has(agent) ? {} : { subtitle: 'Totals unsupported by ccusage' }),
+      action: { type: 'screen', contributionId: 'usage.details', params: { provider: agent } },
     });
   }
   // Rate limits lead (they need attention), then today's activity, then idle.
   const ordered = [...codex.items, ...activity.items, ...items];
   const totalTokens = tokens(activity.totalTokens);
   const output = {
-    items: ordered.slice(0, 50), actions: [],
+    items: ordered.slice(0, 50),
+    actions: [{ id: 'details', label: 'Open full usage', icon: 'stats-chart-outline', action: { type: 'screen', contributionId: 'usage.details' } }],
     ...(activity.totalTokens > 0 && totalTokens !== undefined
       ? { badge: { value: `${totalTokens} tokens today` } }
       : {}),

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -280,12 +280,12 @@ try {
         const usagePlugin = join(installDir, 'node_modules', '@trymuxr', 'cli', 'plugins', 'status', 'usage.mjs');
         const usageResult = run(process.execPath, [usagePlugin], { cwd: installDir, env: { ...process.env, HOME: usageHome, PATH: binDir } });
         const usageOutput = JSON.parse(usageResult.stdout);
-        assert.ok(usageOutput.items.some((item) => item.id === 'activity-claude' && item.metadata[0]?.value === '2 tokens' && item.action === undefined), 'installed Usage did not return a read-only Claude activity item');
+        assert.ok(usageOutput.items.some((item) => item.id === 'activity-claude' && item.metadata[0]?.value === '2 tokens' && item.action?.type === 'screen'), 'installed Usage did not return a Claude activity item that opens its details');
         assert.notEqual(statSync(ccusageTarget).mode & 0o111, 0, 'packaged ccusage backend stayed non-executable');
         const resolveScript = `const {createRequire}=require('node:module');process.stdout.write(createRequire(${JSON.stringify(usagePlugin)}).resolve('@ccusage/ccusage-${process.platform}-${process.arch}/bin/ccusage'))`;
         const resolvedCcusage = run(process.execPath, ['-e', resolveScript], { cwd: installDir }).stdout;
         assert.equal(resolvedCcusage, ccusageTarget, 'Usage plugin did not resolve its installed native ccusage package');
-        const probe = run(resolvedCcusage, ['daily', '--last', '1', '--by-agent', '--json', '--no-cost', '--offline'], {
+        const probe = run(resolvedCcusage, ['daily', '--by-agent', '--json', '--offline'], {
             cwd: installDir,
             env: { ...process.env, HOME: usageHome, HTTPS_PROXY: 'http://127.0.0.1:1', HTTP_PROXY: 'http://127.0.0.1:1' },
         });

--- a/scripts/checkPreviewTunnel.mjs
+++ b/scripts/checkPreviewTunnel.mjs
@@ -6,7 +6,7 @@
 import { waitForRelay } from './waitForRelay.mjs';
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
-import { connect } from 'node:net';
+import { connect, createServer as createTcpServer } from 'node:net';
 import assert from 'node:assert/strict';
 import { setTimeout as delay } from 'node:timers/promises';
 import { mkdtempSync } from 'node:fs';
@@ -97,6 +97,7 @@ const send = (frame) => {
 };
 
 const CHANNEL = 'check-channel-1';
+const BRIDGE_CHANNEL = 'check-channel-2';
 
 session.on('open', () => send({ type: 'preview.probe', requestId: 'p1', params: { port: devPort } }));
 
@@ -116,8 +117,64 @@ session.on('message', (raw) => {
     if (frame.requestId === 'p2') {
         if (!frame.ok) done(1, `\nFAIL: preview.attach errored: ${frame.error}\n`);
         openTunnel();
+        return;
+    }
+
+    if (frame.requestId === 'p3') {
+        if (!frame.ok) done(1, `\nFAIL: bridge preview.attach errored: ${frame.error}\n`);
+        bridgeResolve();
     }
 });
+
+let bridgeResolve;
+const bridgeAttached = new Promise((resolve) => { bridgeResolve = resolve; });
+
+/**
+ * The device end of the bridge: the listener lives here, not on the relay, so
+ * the preview works against a relay published only on 443.
+ */
+async function runBridge() {
+    send({ type: 'preview.attach', requestId: 'p3', params: { channel: BRIDGE_CHANNEL, port: devPort } });
+    await bridgeAttached;
+
+    const control = new WebSocket(`${RELAY}/preview?role=client&machineId=${MACHINE}&channel=${BRIDGE_CHANNEL}&bridge=1`);
+    const connections = new Map();
+    let nextConnId = 0;
+
+    await new Promise((resolve, reject) => {
+        control.on('error', reject);
+        control.on('message', (raw, isBinary) => {
+            if (!isBinary) {
+                if (JSON.parse(String(raw)).type === 'preview.bridge') resolve();
+                return;
+            }
+            const frame = decodePreviewFrame(new Uint8Array(raw));
+            const socket = connections.get(frame.connId);
+            if (socket === undefined) return;
+            if (frame.payload.length > 0) socket.write(Buffer.from(frame.payload));
+        });
+        setTimeout(() => reject(new Error('relay never paired the bridge')), 10000);
+    });
+
+    const local = createTcpServer((socket) => {
+        nextConnId += 1;
+        const connId = nextConnId;
+        connections.set(connId, socket);
+        socket.on('data', (chunk) => control.send(encodePreviewFrame(connId, PREVIEW_DATA, new Uint8Array(chunk)), { binary: true }));
+        socket.on('close', () => connections.delete(connId));
+    });
+    await new Promise((resolve) => local.listen(0, '127.0.0.1', resolve));
+    const localPort = local.address().port;
+
+    const response = await fetch(`http://127.0.0.1:${localPort}/bridged`, { signal: AbortSignal.timeout(10000) });
+    const body = await response.text();
+    local.close();
+    control.close();
+    if (response.status !== 200 || !body.includes(MARKER) || !body.includes('/bridged')) {
+        done(1, `\nFAIL: bridged request got: ${response.status} ${body.slice(0, 300)}\n`);
+    }
+    return localPort;
+}
 
 function openTunnel() {
     const control = new WebSocket(`${RELAY}/preview?role=client&machineId=${MACHINE}&channel=${CHANNEL}`);
@@ -160,12 +217,15 @@ function openTunnel() {
                 done(1, '\nFAIL: preview port served a client it was not opened for\n');
             }
 
+            const bridgedPort = await runBridge();
+
             done(0, `\nPASS: browser preview through the relay\n`
                 + `      loopback port probed: application/json\n`
                 + `      loopback-bound dev server reached: yes\n`
                 + `      preview port: ${message.port}\n`
                 + `      concurrent connections muxed: yes\n`
                 + `      foreign source address refused: ${pinned === undefined ? 'skipped' : 'yes'}\n`
+                + `      device-side bridge port: ${bridgedPort}\n`
                 + `      body bytes: ${body.length}\n`);
         } catch (error) {
             done(1, `\nFAIL: request through preview port: ${error.message}\n`);

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -96,7 +96,14 @@ try {
     assert.deepEqual(cursor.modelSeries, []);
 
     assert.doesNotMatch(result.stdout, /hostile/);
-    assert.ok(output.items.every((item) => item.action === undefined), 'read-only Usage rows unexpectedly expose actions');
+    // Rows open the details screen and nothing else: the card is a summary of
+    // the same screen, not a second place that shows usage its own way.
+    assert.ok(
+        output.items.every((item) => item.action === undefined || item.action.type === 'screen' && item.action.contributionId === 'usage.details'),
+        'Usage rows reach past their own details screen',
+    );
+    assert.equal(output.items.find((item) => item.id === 'activity-kimi')?.action?.params?.provider, 'kimi');
+    assert.equal(output.actions[0]?.action?.contributionId, 'usage.details');
     assert.ok(existsSync(ccusageMarker), 'Usage plugin did not invoke its pinned ccusage backend');
     assert.ok(!existsSync(piMarker), 'Usage plugin invoked Pi and could enter a paid model path');
 

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -9,64 +9,114 @@ const piMarker = join(scratch, 'pi-ran');
 const ccusageMarker = join(scratch, 'ccusage-ran');
 const codexMarker = join(scratch, 'codex-ran');
 const ccusage = join(scratch, 'ccusage');
+const today = new Date();
+const day = (offset) => new Date(today.getTime() - offset * 86_400_000).toISOString().slice(0, 10);
+
+const report = {
+    daily: [
+        { period: day(1), agents: [{ agent: 'claude', totalTokens: 400_000, totalCost: 9.5 }, { agent: 'kimi', totalTokens: 60_000 }] },
+        {
+            period: day(0),
+            agents: [
+                {
+                    agent: 'claude',
+                    totalTokens: 1_250_000,
+                    inputTokens: 42,
+                    totalCost: 123.45,
+                    modelBreakdowns: [
+                        { modelName: 'claude-opus-5', inputTokens: 42, outputTokens: 1_000, cacheReadTokens: 1_248_958, cacheCreationTokens: 0 },
+                    ],
+                },
+                { agent: 'kimi', totalTokens: 2500 },
+                { agent: 'pi', totalTokens: 800 },
+                { agent: 'hostile\nname', totalTokens: 999999 },
+            ],
+        },
+    ],
+    totals: { totalTokens: 1_253_300, totalCost: 132.95 },
+};
+const activeBlock = {
+    blocks: [{
+        isActive: true,
+        startTime: new Date(today.getTime() - 3_600_000).toISOString(),
+        endTime: new Date(today.getTime() + 3 * 3_600_000).toISOString(),
+        burnRate: { tokensPerMinute: 12_000 },
+    }],
+};
+
+const run = (input, environment = {}) => spawnSync(process.execPath, ['plugins/status/usage.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    input: JSON.stringify(input),
+    env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch, ...environment },
+    timeout: 20_000,
+});
+
 try {
     writeFileSync(join(scratch, 'pi'), `#!/bin/sh\ntouch "${piMarker}"\nexit 99\n`, { mode: 0o755 });
-    writeFileSync(ccusage, `#!/bin/sh\n[ "$*" = "daily --last 1 --by-agent --json --no-cost --offline" ] || exit 77\nprintf x >> "${ccusageMarker}"\nprintf '%s' '${JSON.stringify({
-        daily: [{ date: '2026-08-17', agents: [
-            { agent: 'claude', totalTokens: 1_250_000, inputTokens: 42, totalCost: 123.45 },
-            { agent: 'kimi', totalTokens: 2500 },
-            { agent: 'pi', totalTokens: 800 },
-            { agent: 'hostile\\nname', totalTokens: 999999 },
-        ] }],
-        totals: { totalTokens: 1_253_300, totalCost: 123.45 },
-    })}'\n`, { mode: 0o755 });
+    writeFileSync(ccusage, `#!/bin/sh\ncase "$1 $2" in\n"daily --by-agent") printf x >> "${ccusageMarker}"; printf '%s' '${JSON.stringify(report)}';;\n"blocks --active") printf '%s' '${JSON.stringify(activeBlock)}';;\n*) exit 77;;\nesac\n`, { mode: 0o755 });
     writeFileSync(join(scratch, 'codex'), `#!/usr/bin/env node\nrequire('fs').appendFileSync(${JSON.stringify(codexMarker)}, 'x');let b='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>{b+=d;for(;;){const i=b.indexOf('\\n');if(i<0)break;const line=b.slice(0,i);b=b.slice(i+1);const m=JSON.parse(line);if(m.id===1)console.log(JSON.stringify({id:1,result:{}}));if(m.id===2)console.log(JSON.stringify({id:2,result:{rateLimitsByLimitId:{codex:{limitId:'codex',primary:{usedPercent:25,resetsAt:Math.floor(Date.now()/1000)+3600}}}}}));}});\n`, { mode: 0o755 });
     for (const command of ['claude', 'kimi', 'opencode', 'hermes', 'copilot', 'cursor-agent', 'omp', 'gemini', 'grok']) writeFileSync(join(scratch, command), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
-    const result = spawnSync(process.execPath, ['plugins/status/usage.mjs'], {
-        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch }, timeout: 20_000,
-    });
+
+    // Default tab: the busiest measured provider leads, and the card keeps its rows.
+    const result = run({});
     assert.equal(result.status, 0, result.stderr);
     const output = JSON.parse(result.stdout);
     const activity = Object.fromEntries(output.items.filter((item) => item.id.startsWith('activity-')).map((item) => [item.title, item.metadata[0]?.value]));
     assert.deepEqual(activity, { 'Anthropic Claude': '1.3M tokens', 'Kimi Code': '2.5K tokens', Pi: '800 tokens' });
     assert.ok(output.items.some((item) => item.id === 'limit-codex-0' && item.metadata[0]?.value === '75% left' && item.group === 'Rate limits'));
-    assert.ok(output.items.some((item) => item.id === 'activity-claude' && item.group === 'Active today' && item.progress?.value === 1));
     assert.equal(output.badge?.value, '1.3M tokens today');
-    assert.equal(output.summary?.totalTokens, '1.3M');
-    const installed = Object.fromEntries(output.items.filter((item) => item.id.startsWith('available-')).map((item) => [item.title, item]));
-    assert.equal(installed.OpenCode?.group, 'Idle today');
-    assert.equal(installed.OpenCode?.subtitle, undefined);
-    assert.equal(installed['Hermes Agent']?.subtitle, undefined);
-    assert.equal(installed['GitHub Copilot CLI']?.subtitle, undefined);
-    assert.equal(installed.Cursor?.subtitle, 'Totals unsupported by ccusage');
-    assert.equal(installed.OMP?.subtitle, 'Totals unsupported by ccusage');
-    assert.equal(installed['Gemini CLI']?.subtitle, undefined);
-    assert.equal(installed['xAI Grok']?.subtitle, undefined);
-    assert.doesNotMatch(result.stdout, /123\.45|totalCost|inputTokens|hostile/);
-    assert.ok(!output.items.some((item) => item.id === 'available-claude'));
+
+    // Every detected provider earns a tab, measured ones first.
+    assert.equal(output.provider, 'claude');
+    assert.equal(output.providers[0]?.label, 'Anthropic Claude');
+    const tabs = output.providers.map((tab) => tab.id);
+    for (const expected of ['claude', 'kimi', 'pi', 'codex', 'cursor']) assert.ok(tabs.includes(expected), `missing ${expected} tab`);
+
+    // Claude's tab carries today, its models, the week, and the live 5-hour window.
+    assert.equal(output.todayTokens, '1.3M');
+    assert.equal(output.todayCost, '$123');
+    assert.equal(output.modelSeries[0]?.label, 'claude-opus-5');
+    assert.equal(output.weekSeries.length, 2);
+    assert.equal(output.weekSeries[1]?.valueLabel, '1.3M');
+    assert.match(output.limitLabel, /5-hour window/);
+    assert.equal(output.limitRing[0]?.label, 'Left');
+
+    // A quiet provider reports zero today rather than its last active day.
+    const kimi = JSON.parse(run({ provider: 'kimi' }).stdout);
+    assert.equal(kimi.provider, 'kimi');
+    assert.equal(kimi.todayTokens, '2.5K');
+    assert.equal(kimi.weekSeries[0]?.valueLabel, '60.0K');
+    assert.equal(kimi.limitLabel, '');
+
+    // An installed but unmeasured provider still opens, empty and honest.
+    const cursor = JSON.parse(run({ provider: 'cursor' }).stdout);
+    assert.equal(cursor.provider, 'cursor');
+    assert.equal(cursor.todayTokens, '0');
+    assert.deepEqual(cursor.modelSeries, []);
+
+    assert.doesNotMatch(result.stdout, /hostile/);
     assert.ok(output.items.every((item) => item.action === undefined), 'read-only Usage rows unexpectedly expose actions');
     assert.ok(existsSync(ccusageMarker), 'Usage plugin did not invoke its pinned ccusage backend');
     assert.ok(!existsSync(piMarker), 'Usage plugin invoked Pi and could enter a paid model path');
-    const cached = spawnSync(process.execPath, ['plugins/status/usage.mjs'], {
-        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch }, timeout: 20_000,
-    });
-    assert.equal(cached.status, 0, cached.stderr);
-    assert.ok(JSON.parse(cached.stdout).items.some((item) => item.id === 'activity-claude'));
-    assert.equal(readFileSync(ccusageMarker, 'utf8'), 'x', 'one-minute cache did not prevent a duplicate ccusage scan');
-    assert.equal(readFileSync(codexMarker, 'utf8'), 'x', 'one-minute cache did not prevent a duplicate Codex app-server');
 
-    rmSync(join(scratch, 'usage.json'));
+    // One cache entry per tab, so reopening a tab does not rescan.
+    const cached = run({});
+    assert.equal(cached.status, 0, cached.stderr);
+    assert.equal(JSON.parse(cached.stdout).todayTokens, '1.3M');
+    assert.equal(readFileSync(ccusageMarker, 'utf8'), 'xxx', 'per-tab cache did not prevent a duplicate ccusage scan');
+    assert.equal(readFileSync(codexMarker, 'utf8'), 'xxx', 'per-tab cache did not prevent a duplicate Codex app-server');
+
+    rmSync(join(scratch, 'usage-all.json'));
     rmSync(join(scratch, 'codex'));
-    const fallback = spawnSync(process.execPath, ['plugins/status/usage.mjs'], {
-        cwd: process.cwd(), encoding: 'utf8', env: { ...process.env, PATH: scratch, MUXR_CCUSAGE_BIN: join(scratch, 'missing') }, timeout: 20_000,
-    });
+    const fallback = run({}, { PATH: scratch, MUXR_CCUSAGE_BIN: join(scratch, 'missing') });
     assert.equal(fallback.status, 0, fallback.stderr);
     const fallbackOutput = JSON.parse(fallback.stdout);
     assert.ok(fallbackOutput.items.some((item) => item.id === 'ccusage-unavailable'));
     assert.ok(fallbackOutput.items.some((item) => item.id === 'available-claude' && item.metadata.length === 0));
     assert.doesNotMatch(fallback.stdout, /OpenAI Codex current limit|Local activity today/);
     assert.ok(!existsSync(piMarker), 'Fallback Usage invoked Pi');
-    process.stdout.write('PASS e2e: bounded offline ccusage aggregation + safe live limits\n');
+    process.stdout.write('PASS e2e: per-provider ccusage tabs + safe live limits\n');
 } finally {
     rmSync(scratch, { recursive: true, force: true });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3734,6 +3734,14 @@ buffer@6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+buffer@^5.4.3:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -4853,6 +4861,11 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+eventemitter3@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 events@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -5670,7 +5683,7 @@ iconv-lite@0.6:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.2.1:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -7687,6 +7700,14 @@ react-native-svg@15.12.1:
     css-select "^5.1.0"
     css-tree "^1.1.3"
     warn-once "0.1.1"
+
+react-native-tcp-socket@6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-tcp-socket/-/react-native-tcp-socket-6.4.2.tgz#ddbd682910c5c21197b7d9155dd627f1047fb401"
+  integrity sha512-x3piN60BLaVA7or3n6HKhsa15QDpb1hu+X7Mh99ldV+ZXUGDVKymsLLyu7vzEybTzF3sC17ubpCEgjik5aXfcA==
+  dependencies:
+    buffer "^5.4.3"
+    eventemitter3 "^4.0.7"
 
 react-native-typography@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Five reported problems, one root cause each.

**Git history said "No repository for this session".** The host strips a caller-supplied `cwd` and re-injects the trusted one only when the payload carries `sessionId` (`herdrSessionSource.ts`). The header button sent `cwd` alone, so it always arrived empty — which is also why the Changes pill worked and history did not. History now travels by session id.

**Usage showed two providers.** It only ever read a single day (`daily --last 1`). Reading a week reveals Kimi and Codex too. The screen is now per-provider: a tab strip of every detected provider, and for the selected one — today's tokens and cost, model breakdown, a 7-day series, week totals, and the live limit (Claude's 5-hour window with burn rate, Codex's published rate limits).

**Tabs did not exist.** Added a `tabs` screen node: selecting a tab sets a screen param and reloads, so a plugin serves one provider per call instead of shipping every provider's detail at once. Screen param keys now validate as RPC field names rather than plugin ids, since that is what they are.

**The file tree looked generic and oversized.** Per-extension icons and language colours, tighter rows, and one provenance line instead of a stacked header block.

**Files were only reachable from home.** A Files button now sits in the session header beside Git history and opens the repository for the session's own directory; the host still chooses the path.

Verification: full suite 30/30. The usage flow test now covers tab selection, a quiet provider reporting zero today rather than its last active day, and per-tab caching.