### PR TITLE
Voice session shows a spiral of agents, not an orb

### DIFF
--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -46,7 +46,23 @@ function chartFill(theme: Theme, tone: PluginScreenTone | undefined): string {
     }
 }
 
-const SLICE_PALETTE = (theme: Theme) => [theme.colors.accent, theme.colors.textLink, theme.colors.success, theme.colors.box.warning.text, theme.colors.box.error.text, theme.colors.textSecondary];
+function withAlpha(color: string, alpha: number): string {
+    const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color)?.[1];
+    if (hex === undefined) return color;
+    const full = hex.length === 3 ? hex.split('').map((part) => part + part).join('') : hex;
+    const value = Number.parseInt(full, 16);
+    return `rgba(${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}, ${alpha.toFixed(3)})`;
+}
+
+/**
+ * Rank by depth of one hue, never by a categorical rainbow: borrowing the
+ * status colours for slice three and four is what makes a chart look cheap, and
+ * it spends red on a series that is not in trouble.
+ */
+function rampFill(theme: Theme, index: number, count: number): string {
+    const step = count <= 1 ? 0 : index / (count - 1);
+    return withAlpha(theme.colors.accent, 1 - step * 0.62);
+}
 
 /** Track fill that sweeps in when its value first arrives; decorative only. */
 function AnimatedBarFill({ ratio, color, delay }: { ratio: number; color: string; delay: number }) {
@@ -56,7 +72,7 @@ function AnimatedBarFill({ ratio, color, delay }: { ratio: number; color: string
         width.value = reduceMotion ? ratio : withDelay(delay, withTiming(ratio, { duration: 400, easing: Easing.bezier(0.23, 1, 0.32, 1) }));
     }, [delay, ratio, reduceMotion, width]);
     const animated = useAnimatedStyle(() => ({ width: `${Math.max(0, Math.min(1, width.value)) * 100}%` }));
-    return <Animated.View style={[{ height: '100%', borderRadius: 3, backgroundColor: color }, animated]} />;
+    return <Animated.View style={[{ height: '100%', borderRadius: 2.5, backgroundColor: color }, animated]} />;
 }
 
 function chartValue(item: PluginChartItem): string {
@@ -208,13 +224,12 @@ function ScreenChart({ node, data }: { node: PluginScreenChartNode; data: unknow
     if (node.variant === 'ring') {
         // First slice is the hero: its value/label sit in the donut center.
         const hero = series[0]!;
-        const palette = SLICE_PALETTE(theme);
         const slices = series.map((item, index) => ({
             label: item.label,
             value: item.value,
             color: item.tone === 'secondary'
                 ? theme.colors.surfaceHighest
-                : item.tone !== undefined ? chartFill(theme, item.tone) : palette[index % palette.length]!,
+                : item.tone !== undefined ? chartFill(theme, item.tone) : rampFill(theme, index, series.length),
         }));
         return <View accessible accessibilityRole="image" accessibilityLabel={summary}
             style={{ marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 }}>
@@ -238,14 +253,15 @@ function ScreenChart({ node, data }: { node: PluginScreenChartNode; data: unknow
     return <View style={{ marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 }}
         accessible accessibilityRole="image" accessibilityLabel={summary}>
         {title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 12 }}>{title}</Text>}
-        <View style={{ gap: 14 }}>
+        <View style={{ gap: 12 }}>
             {series.map((item, index) => <View key={`${item.label}-${index}`}>
-                <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 6 }}>
-                    <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 13, fontWeight: '500', flex: 1, marginRight: 12 }}>{item.label}</Text>
-                    <Text style={{ color: theme.colors.textSecondary, fontSize: 13, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>
+                <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 5 }}>
+                    <Text numberOfLines={1} style={{ color: index === 0 ? theme.colors.text : theme.colors.textSecondary, fontSize: 13, fontWeight: index === 0 ? '600' : '500', flex: 1, marginRight: 12 }}>{item.label}</Text>
+                    <Text style={{ color: index === 0 ? theme.colors.text : theme.colors.textSecondary, fontSize: 12.5, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>
                 </View>
-                <View style={{ height: 6, borderRadius: 3, backgroundColor: theme.colors.surfaceHighest, overflow: 'hidden' }}>
-                    <AnimatedBarFill ratio={max === 0 ? 0 : item.value / max} color={chartFill(theme, item.tone)} delay={index * 50} />
+                <View style={{ height: 5, borderRadius: 2.5, backgroundColor: theme.colors.surfaceHighest, overflow: 'hidden' }}>
+                    <AnimatedBarFill ratio={max === 0 ? 0 : item.value / max}
+                        color={item.tone === undefined ? rampFill(theme, index, series.length) : chartFill(theme, item.tone)} delay={index * 45} />
                 </View>
             </View>)}
         </View>

--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -258,21 +258,25 @@ function ScreenTree(props: {
     </View>;
 }
 
-function ScreenChart({ node, data }: { node: PluginScreenChartNode; data: unknown }) {
+function ScreenChart({ node, data, nested }: { node: PluginScreenChartNode; data: unknown; nested: boolean }) {
     const { theme } = useUnistyles();
     const reduceMotion = useReducedMotion();
     const series = asChartSeries(resolvePath(data, node.path));
     const title = node.title === undefined ? undefined : bindText(resolvePluginText(node.title), data);
     const empty = node.emptyText === undefined ? t('plugins.nothingToShow') : bindText(resolvePluginText(node.emptyText), data);
-    if (series.length === 0) return <View style={{ marginBottom: 12 }}>
-        {title !== undefined && <Text style={{ color: theme.colors.text, fontSize: 15, fontWeight: '600', marginBottom: 8 }}>{title}</Text>}
-        <Text style={{ color: theme.colors.textSecondary, fontSize: 14 }}>{empty}</Text>
+    // Empty says so in one quiet line. A full card drawn around "nothing yet"
+    // spends the same space as real data.
+    if (series.length === 0) return <View style={{ marginBottom: nested ? 8 : 14 }}>
+        {title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 4, marginTop: nested ? 10 : 0 }}>{title}</Text>}
+        <Text style={{ color: theme.colors.textSecondary, fontSize: 13 }}>{empty}</Text>
     </View>;
     const total = series.reduce((sum, item) => sum + item.value, 0);
     const summary = `${title ?? 'Chart'}: ${series.map((item) => `${item.label} ${node.variant === 'ring' ? `${Math.round(item.value / total * 100)} percent` : chartValue(item)}`).join(', ')}`;
-    const card = { marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 } as const;
+    const card = nested
+        ? { marginBottom: 4 }
+        : { marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 } as const;
     const heading = title === undefined ? null : (
-        <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 12 }}>{title}</Text>
+        <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 12, marginTop: nested ? 10 : 0 }}>{title}</Text>
     );
 
     // One value against its ceiling. A two-slice donut says the same thing with
@@ -345,9 +349,8 @@ function ScreenChart({ node, data }: { node: PluginScreenChartNode; data: unknow
         </View>;
     }
     const max = Math.max(...series.map((item) => item.value));
-    return <View style={{ marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 }}
-        accessible accessibilityRole="image" accessibilityLabel={summary}>
-        {title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 12 }}>{title}</Text>}
+    return <View style={card} accessible accessibilityRole="image" accessibilityLabel={summary}>
+        {heading}
         <View style={{ gap: 12 }}>
             {series.map((item, index) => <View key={`${item.label}-${index}`}>
                 <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 5 }}>
@@ -374,6 +377,8 @@ function ScreenNode(props: {
     onTreeLoad: (node: PluginScreenTreeNode, path: string) => Promise<RuntimeTreeItem[]>;
     onTreeError: (error: unknown) => void;
     onSelectTab: (param: string, value: string) => void;
+    /** Inside a section, which already owns the card around this node. */
+    nested?: boolean;
 }) {
     const { theme } = useUnistyles();
     const { width } = useWindowDimensions();
@@ -430,7 +435,7 @@ function ScreenNode(props: {
             );
         }
         case 'chart':
-            return <ScreenChart node={node} data={data} />;
+            return <ScreenChart node={node} data={data} nested={props.nested === true} />;
         case 'divider':
             return <View style={{ height: 1, backgroundColor: theme.colors.divider, marginVertical: 8 }} />;
         case 'empty':
@@ -442,15 +447,24 @@ function ScreenNode(props: {
             );
         case 'section': {
             const columns = node.columns === 3 && width < 480 ? 2 : node.columns;
+            // A section inside a section is a group, not a second card: stacking
+            // panels inside panels is what turns a screen into a wall of boxes.
+            const body = (
+                <View style={props.nested
+                    ? (columns === undefined ? {} : { flexDirection: 'row', flexWrap: 'wrap', columnGap: 10 })
+                    : {
+                        backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, paddingHorizontal: 16, paddingVertical: 12,
+                        ...(columns === undefined ? {} : { flexDirection: 'row', flexWrap: 'wrap', columnGap: 10 }),
+                    }}>
+                    {node.children.map((child, index) => columns === undefined
+                        ? <ScreenNode key={index} {...props} node={child} nested />
+                        : <View key={index} style={{ flexBasis: `${100 / columns - 2}%`, flexGrow: 1, maxWidth: `${100 / columns}%` }}><ScreenNode {...props} node={child} nested /></View>)}
+                </View>
+            );
             return (
-                <View style={{ marginBottom: 8 }}>
-                    {node.title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 13, textTransform: 'uppercase', letterSpacing: 0.4, marginBottom: 6, marginTop: 12 }}>{bind(node.title)}</Text>}
-                    <View style={{ backgroundColor: theme.colors.surfaceHigh, borderRadius: 12, paddingHorizontal: 14, paddingVertical: 6,
-                        ...(columns === undefined ? {} : { flexDirection: 'row', flexWrap: 'wrap', columnGap: 10 }) }}>
-                        {node.children.map((child, index) => columns === undefined
-                            ? <ScreenNode key={index} {...props} node={child} />
-                            : <View key={index} style={{ flexBasis: `${100 / columns - 2}%`, flexGrow: 1, maxWidth: `${100 / columns}%` }}><ScreenNode {...props} node={child} /></View>)}
-                    </View>
+                <View style={{ marginBottom: props.nested ? 4 : 14 }}>
+                    {node.title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 10, marginTop: props.nested ? 10 : 0 }}>{bind(node.title)}</Text>}
+                    {body}
                 </View>
             );
         }

--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -4,7 +4,8 @@ import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { PolarChart, Pie } from 'victory-native';
-import Animated, { Easing, FadeInDown, useAnimatedStyle, useReducedMotion, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
+import { Canvas, Path, Skia } from '@shopify/react-native-skia';
+import Animated, { Easing, FadeInDown, useAnimatedStyle, useDerivedValue, useReducedMotion, useSharedValue, withDelay, withTiming } from 'react-native-reanimated';
 import { useUnistyles } from 'react-native-unistyles';
 import type { PluginManifestV1, PluginScreenButtonNode, PluginScreenChartNode, PluginScreenContribution, PluginScreenNode, PluginScreenRowAction, PluginScreenRowNode, PluginScreenTone, PluginScreenTreeNode, PluginSource, PluginText, RequestParams } from '@muxr/contract';
 import { MAX_SCREEN_LIST_ROWS, PLUGIN_CALL_CLIENT_TIMEOUT_MS, capUtf8Bytes, defaultPluginText, sanitizeDisplayText } from '@muxr/contract';
@@ -62,6 +63,54 @@ function withAlpha(color: string, alpha: number): string {
 function rampFill(theme: Theme, index: number, count: number): string {
     const step = count <= 1 ? 0 : index / (count - 1);
     return withAlpha(theme.colors.accent, 1 - step * 0.62);
+}
+
+/**
+ * Open-bottom arc, so the gap reads as the scale's start and end rather than as
+ * a slice that was left out of a pie.
+ */
+function GaugeArc({ ratio, size, color, track }: { ratio: number; size: number; color: string; track: string }) {
+    const reduceMotion = useReducedMotion();
+    const sweep = useSharedValue(reduceMotion ? ratio : 0);
+    React.useEffect(() => {
+        sweep.value = reduceMotion ? ratio : withTiming(ratio, { duration: 620, easing: Easing.bezier(0.23, 1, 0.32, 1) });
+    }, [ratio, reduceMotion, sweep]);
+    const stroke = size * 0.085;
+    const radius = (size - stroke) / 2;
+    const box = Skia.XYWHRect(stroke / 2, stroke / 2, radius * 2, radius * 2);
+    const START = 135;
+    const SPAN = 270;
+    const trackPath = React.useMemo(() => {
+        const path = Skia.Path.Make();
+        path.addArc(box, START, SPAN);
+        return path;
+    }, [box]);
+    const valuePath = useDerivedValue(() => {
+        const path = Skia.Path.Make();
+        path.addArc(box, START, Math.max(0.001, SPAN * sweep.value));
+        return path;
+    });
+    return (
+        <Canvas style={{ width: size, height: size }}>
+            <Path path={trackPath} color={track} style="stroke" strokeWidth={stroke} strokeCap="round" />
+            <Path path={valuePath} color={color} style="stroke" strokeWidth={stroke} strokeCap="round" />
+        </Canvas>
+    );
+}
+
+function AnimatedColumn({ ratio, color, track, delay }: { ratio: number; color: string; track: string; delay: number }) {
+    const reduceMotion = useReducedMotion();
+    const height = useSharedValue(reduceMotion ? ratio : 0);
+    React.useEffect(() => {
+        height.value = reduceMotion ? ratio : withDelay(delay, withTiming(ratio, { duration: 480, easing: Easing.bezier(0.23, 1, 0.32, 1) }));
+    }, [delay, ratio, reduceMotion, height]);
+    // Floored so an idle day stays a visible baseline instead of disappearing.
+    const animated = useAnimatedStyle(() => ({ height: `${Math.max(2, Math.min(1, height.value) * 100)}%` }));
+    return (
+        <View style={{ width: '100%', flex: 1, justifyContent: 'flex-end', backgroundColor: track, borderRadius: 5, overflow: 'hidden' }}>
+            <Animated.View style={[{ width: '100%', borderRadius: 5, backgroundColor: color }, animated]} />
+        </View>
+    );
 }
 
 /** Track fill that sweeps in when its value first arrives; decorative only. */
@@ -221,6 +270,52 @@ function ScreenChart({ node, data }: { node: PluginScreenChartNode; data: unknow
     </View>;
     const total = series.reduce((sum, item) => sum + item.value, 0);
     const summary = `${title ?? 'Chart'}: ${series.map((item) => `${item.label} ${node.variant === 'ring' ? `${Math.round(item.value / total * 100)} percent` : chartValue(item)}`).join(', ')}`;
+    const card = { marginBottom: 14, backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, padding: 16 } as const;
+    const heading = title === undefined ? null : (
+        <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 12 }}>{title}</Text>
+    );
+
+    // One value against its ceiling. A two-slice donut says the same thing with
+    // a second slice that carries no information of its own.
+    if (node.variant === 'gauge') {
+        const hero = series[0]!;
+        const ratio = Math.max(0, Math.min(1, total === 0 ? 0 : hero.value / total));
+        return <View accessible accessibilityRole="progressbar" accessibilityLabel={summary}
+            accessibilityValue={{ min: 0, max: 100, now: Math.round(ratio * 100) }} style={card}>
+            {heading}
+            <View style={{ alignItems: 'center' }}>
+                <GaugeArc ratio={ratio} size={148} color={hero.tone === undefined ? theme.colors.accent : chartFill(theme, hero.tone)} track={theme.colors.surfaceHighest} />
+                <View pointerEvents="none" style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, alignItems: 'center', justifyContent: 'center' }}>
+                    <Text style={{ color: theme.colors.text, fontSize: 30, fontWeight: '700', letterSpacing: -0.8 }}>{chartValue(hero)}</Text>
+                    <Text style={{ color: theme.colors.textSecondary, fontSize: 11, marginTop: 1 }}>{hero.label}</Text>
+                </View>
+            </View>
+        </View>;
+    }
+
+    // Time reads left to right. Ranking a series of days destroys the shape.
+    if (node.variant === 'column') {
+        const peak = Math.max(...series.map((item) => item.value));
+        const last = series.length - 1;
+        return <View accessible accessibilityRole="image" accessibilityLabel={summary} style={card}>
+            {heading}
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end', height: 108, gap: 6 }}>
+                {series.map((item, index) => (
+                    <View key={`${item.label}-${index}`} style={{ flex: 1, alignItems: 'center', justifyContent: 'flex-end', height: '100%' }}>
+                        {index === last && <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 11, marginBottom: 4, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>}
+                        <AnimatedColumn ratio={peak === 0 ? 0 : item.value / peak} delay={index * 45}
+                            color={index === last ? theme.colors.accent : withAlpha(theme.colors.accent, 0.45)} track={theme.colors.surfaceHighest} />
+                    </View>
+                ))}
+            </View>
+            <View style={{ flexDirection: 'row', gap: 6, marginTop: 8 }}>
+                {series.map((item, index) => (
+                    <Text key={`${item.label}-${index}-label`} numberOfLines={1}
+                        style={{ flex: 1, textAlign: 'center', color: index === last ? theme.colors.text : theme.colors.textSecondary, fontSize: 11 }}>{item.label}</Text>
+                ))}
+            </View>
+        </View>;
+    }
     if (node.variant === 'ring') {
         // First slice is the hero: its value/label sit in the donut center.
         const hero = series[0]!;

--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -199,9 +199,9 @@ function ScreenTree(props: {
     });
     flatten(items, 0);
     const title = props.node.title === undefined ? undefined : bindText(resolvePluginText(props.node.title), props.data);
-    return <View style={{ marginBottom: 8 }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 12, marginBottom: 6 }}>
-            {title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 13, textTransform: 'uppercase', letterSpacing: 0.4, flex: 1 }}>{title}</Text>}
+    return <View style={{ marginBottom: 14 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
+            {title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, flex: 1 }}>{title}</Text>}
             {folders.length > 0 && <>
                 <Pressable onPress={() => setExpanded(new Set(folders))} accessibilityRole="button" accessibilityLabel="Expand all folders" hitSlop={8}>
                     <Text style={{ color: theme.colors.textLink, fontSize: 12, paddingHorizontal: 8 }}>Expand all</Text>
@@ -211,8 +211,8 @@ function ScreenTree(props: {
                 </Pressable>
             </>}
         </View>
-        <View style={{ backgroundColor: theme.colors.surfaceHigh, borderRadius: 12, paddingVertical: 4 }}>
-            {rows.length === 0 ? <Text style={{ color: theme.colors.textSecondary, padding: 14 }}>
+        <View style={{ backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, paddingVertical: 6 }}>
+            {rows.length === 0 ? <Text style={{ color: theme.colors.textSecondary, fontSize: 13, padding: 14 }}>
                 {props.node.emptyText === undefined ? t('plugins.nothingToShow') : bindText(resolvePluginText(props.node.emptyText), props.data)}
             </Text> : rows.map(({ item, depth }) => {
                 const isFolder = item.kind === 'folder';
@@ -410,8 +410,8 @@ function ScreenNode(props: {
             );
         case 'badge':
             return (
-                <View style={{ alignSelf: 'flex-start', borderRadius: 999, paddingHorizontal: 10, paddingVertical: 3, marginBottom: 8, backgroundColor: theme.colors.surfaceHighest }}>
-                    <Text style={{ color: toneColor(theme, node.tone), fontSize: 13, fontWeight: '600' }}>{bind(node.label)}</Text>
+                <View style={{ alignSelf: 'flex-start', borderRadius: 999, paddingHorizontal: 10, paddingVertical: 4, marginBottom: 10, backgroundColor: theme.colors.surfaceHighest }}>
+                    <Text style={{ color: toneColor(theme, node.tone), fontSize: 12, fontWeight: '600', letterSpacing: 0.2 }}>{bind(node.label)}</Text>
                 </View>
             );
         case 'progress': {
@@ -437,7 +437,7 @@ function ScreenNode(props: {
         case 'chart':
             return <ScreenChart node={node} data={data} nested={props.nested === true} />;
         case 'divider':
-            return <View style={{ height: 1, backgroundColor: theme.colors.divider, marginVertical: 8 }} />;
+            return <View style={{ height: 1, backgroundColor: theme.colors.divider, marginVertical: 12 }} />;
         case 'empty':
             return (
                 <View style={{ paddingVertical: 24, alignItems: 'center' }}>
@@ -500,14 +500,14 @@ function ScreenNode(props: {
             })();
             const all = [...node.rows.map((row) => ({ row, item: undefined as unknown })), ...repeated];
             return (
-                <View style={{ marginBottom: 8 }}>
-                    {node.title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 13, textTransform: 'uppercase', letterSpacing: 0.4, marginBottom: 6, marginTop: 12 }}>{bind(node.title)}</Text>}
-                    <View style={{ backgroundColor: theme.colors.surfaceHigh, borderRadius: 12, paddingHorizontal: 14, paddingVertical: 6 }}>
+                <View style={{ marginBottom: props.nested ? 4 : 14 }}>
+                    {node.title !== undefined && <Text style={{ color: theme.colors.textSecondary, fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 10, marginTop: props.nested ? 10 : 0 }}>{bind(node.title)}</Text>}
+                    <View style={props.nested ? {} : { backgroundColor: theme.colors.surfaceHigh, borderRadius: 16, paddingHorizontal: 16, paddingVertical: 4 }}>
                         {all.length === 0
-                            ? <Text style={{ color: theme.colors.textSecondary, fontSize: 14, paddingVertical: 10 }}>{bind(node.emptyText ?? t('plugins.nothingToShow'))}</Text>
+                            ? <Text style={{ color: theme.colors.textSecondary, fontSize: 13, paddingVertical: 10 }}>{bind(node.emptyText ?? t('plugins.nothingToShow'))}</Text>
                             : all.map(({ row, item }, index) => (
                                 <ScreenRow key={index} row={row} data={data} item={item} onRowAction={props.onRowAction}
-                                    style={{ paddingVertical: 10, borderTopWidth: index === 0 ? 0 : 1, borderTopColor: theme.colors.divider }} />
+                                    style={{ paddingVertical: 11, borderTopWidth: index === 0 ? 0 : 1, borderTopColor: theme.colors.divider }} />
                             ))}
                     </View>
                 </View>

--- a/apps/mobile/sources/plugins/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/primitives/ItemList.tsx
@@ -37,6 +37,14 @@ function toneColor(theme: Theme, tone: PluginScreenTone | undefined): string {
     }
 }
 
+function withAlpha(color: string, alpha: number): string {
+    const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color)?.[1];
+    if (hex === undefined) return color;
+    const full = hex.length === 3 ? hex.split('').map((part) => part + part).join('') : hex;
+    const value = Number.parseInt(full, 16);
+    return `rgba(${(value >> 16) & 255}, ${(value >> 8) & 255}, ${value & 255}, ${alpha.toFixed(3)})`;
+}
+
 /** Thin fill bar that sweeps in once on mount; decorative, never blocks taps. */
 function RowProgress({ value, color, delay }: { value: number; color: string; delay: number }) {
     const { theme } = useUnistyles();
@@ -65,7 +73,11 @@ function SheetRow({ item, fallbackIcon, busy, index, onPress }: {
     const secondary = rest.map((entry) => `${entry.label === undefined ? '' : `${entry.label} `}${entry.value}`.trim()).join(' · ');
     const metadataLabel = item.metadata.map((entry) => `${entry.label === undefined ? '' : `${entry.label} `}${entry.value}`).join(', ');
     const label = [item.group, item.title, item.subtitle, metadataLabel].filter((part) => part !== undefined && part !== '').join(', ');
-    const progressColor = toneColor(theme, item.progress?.tone ?? 'primary');
+    // Untoned bars step back down the list: a column of identical full-strength
+    // accent reads as decoration rather than ranking.
+    const progressColor = item.progress?.tone === undefined
+        ? withAlpha(theme.colors.accent, Math.max(0.4, 1 - index * 0.14))
+        : toneColor(theme, item.progress.tone);
     const content = <>
         <View style={styles.itemRow}>
             {busy

--- a/apps/mobile/sources/plugins/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/primitives/ItemList.tsx
@@ -281,14 +281,17 @@ const styles = StyleSheet.create({
     count: { fontSize: 11, ...Typography.mono('semiBold') },
     sheetActions: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, paddingBottom: 4 },
     sheetAction: { minHeight: 44, borderRadius: 999, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center', gap: 6 },
-    groupLabel: { fontSize: 11, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.8, marginBottom: 6, marginLeft: 4 },
-    groupCard: { borderRadius: 14, overflow: 'hidden' },
+    // One label scale across plugin surfaces: 12/600/0.6 is the section voice
+    // on declarative screens, and a sheet that whispers at 11/0.8 reads as a
+    // different app.
+    groupLabel: { fontSize: 12, fontWeight: '600', textTransform: 'uppercase', letterSpacing: 0.6, marginBottom: 8, marginLeft: 4 },
+    groupCard: { borderRadius: 16, overflow: 'hidden' },
     rowDivider: { height: StyleSheet.hairlineWidth, marginLeft: 54 },
-    itemRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 12, paddingVertical: 10 },
-    iconTile: { width: 30, height: 30, borderRadius: 9, alignItems: 'center', justifyContent: 'center' },
+    itemRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingHorizontal: 14, paddingVertical: 11 },
+    iconTile: { width: 30, height: 30, borderRadius: 10, alignItems: 'center', justifyContent: 'center' },
     metadata: { alignItems: 'flex-end', gap: 2, marginLeft: 8 },
-    metadataValue: { fontSize: 14, ...Typography.mono('semiBold') },
+    metadataValue: { fontSize: 13, ...Typography.mono('semiBold') },
     metadataSecondary: { fontSize: 11 },
-    progressTrack: { height: 3, borderRadius: 1.5, marginLeft: 54, marginRight: 12, marginTop: -3, marginBottom: 10, overflow: 'hidden' },
-    progressFill: { height: '100%', borderRadius: 1.5 },
+    progressTrack: { height: 4, borderRadius: 2, marginLeft: 54, marginRight: 14, marginTop: -2, marginBottom: 11, overflow: 'hidden' },
+    progressFill: { height: '100%', borderRadius: 2 },
 });

--- a/apps/mobile/sources/realtime/RealtimeSessionVisual.tsx
+++ b/apps/mobile/sources/realtime/RealtimeSessionVisual.tsx
@@ -1,14 +1,111 @@
 import * as React from 'react';
-import { Canvas, Circle, RadialGradient, vec } from '@shopify/react-native-skia';
+import { Canvas, Circle, Group, Path, RadialGradient, Skia, vec } from '@shopify/react-native-skia';
 import Animated, {
     cancelAnimation,
+    Easing,
     useAnimatedStyle,
+    useDerivedValue,
     useReducedMotion,
     useSharedValue,
     withRepeat,
     withTiming,
 } from 'react-native-reanimated';
 import type { RealtimeSessionState } from './realtimeSessionState';
+
+/**
+ * The session as a barred spiral: a bulge for the conversation and two arms of
+ * agents sweeping around it. Drawn rather than played back from an animation
+ * file, because the same artwork answers for four states at two sizes and only
+ * geometry survives being shrunk to the 40pt pill.
+ *
+ * The arms turn rigidly. Real discs rotate differentially, which would shear
+ * them into a smear within a few laps -- correct, and useless as an indicator.
+ */
+
+const TWO_PI = Math.PI * 2;
+/** Enough tilt to read as depth without going edge-on. */
+const TILT = -0.34;
+const FLATTEN = 0.4;
+const ARMS = 2;
+/** How tightly the arms wind. Higher coils them in on themselves. */
+const WIND = 2.35;
+const R_MIN = 0.1;
+const R_MAX = 0.46;
+
+interface Star {
+    /** Fraction of the visual's size. */
+    radius: number;
+    angle: number;
+    /** Distance along the arm, 0 at the bulge. */
+    along: number;
+    dot: number;
+    streak: number;
+}
+
+/** Deterministic scatter: the arms look populated, not drawn with a compass. */
+function scatter(index: number): number {
+    return ((Math.sin((index + 1) * 12.9898) * 43758.5453) % 1 + 1) % 1;
+}
+
+function armAngle(radius: number, arm: number): number {
+    return arm * (TWO_PI / ARMS) + WIND * Math.log(radius / R_MIN);
+}
+
+function buildStars(count: number): Star[] {
+    const stars: Star[] = [];
+    for (let index = 0; index < count; index += 1) {
+        const along = (index + 0.5) / count;
+        const radius = R_MIN + (R_MAX - R_MIN) * Math.pow(along, 0.78);
+        const spread = (scatter(index) - 0.5) * 0.42 * (0.35 + along);
+        stars.push({
+            radius,
+            angle: armAngle(radius, index % ARMS) + spread,
+            along,
+            dot: 0.011 - along * 0.005,
+            streak: 0.1 + along * 0.16,
+        });
+    }
+    return stars;
+}
+
+const STARS = buildStars(46);
+const INNER = STARS.filter((star) => star.along < 0.45);
+const OUTER = STARS.filter((star) => star.along >= 0.45);
+/** Static backdrop; only the disc turns. */
+const FIELD = Array.from({ length: 26 }, (_, index) => ({
+    angle: scatter(index + 3) * TWO_PI,
+    radius: 0.3 + scatter(index + 9) * 0.19,
+    alpha: 0.4 + scatter(index + 3),
+}));
+
+function streakPath(stars: Star[], turns: number, half: number, size: number) {
+    'worklet';
+    const path = Skia.Path.Make();
+    const turn = turns * TWO_PI;
+    for (const star of stars) {
+        const angle = star.angle + turn;
+        const tail = angle + star.streak * 0.5;
+        path.moveTo(half + Math.cos(angle) * star.radius * size, half + Math.sin(angle) * star.radius * size * FLATTEN);
+        path.lineTo(half + Math.cos(tail) * star.radius * size, half + Math.sin(tail) * star.radius * size * FLATTEN);
+    }
+    return path;
+}
+
+function dotPath(stars: Star[], turns: number, half: number, size: number) {
+    'worklet';
+    const path = Skia.Path.Make();
+    const turn = turns * TWO_PI;
+    for (const star of stars) {
+        const angle = star.angle + turn;
+        path.addCircle(
+            half + Math.cos(angle) * star.radius * size,
+            half + Math.sin(angle) * star.radius * size * FLATTEN,
+            // Floored: at the pill an unclamped dot rounds away to nothing.
+            Math.max(0.5, star.dot * size),
+        );
+    }
+    return path;
+}
 
 export const RealtimeSessionVisual = React.memo(function RealtimeSessionVisual({
     size,
@@ -21,6 +118,10 @@ export const RealtimeSessionVisual = React.memo(function RealtimeSessionVisual({
 }) {
     const reduceMotion = useReducedMotion();
     const phase = useSharedValue(0.35);
+    const spin = useSharedValue(0);
+    const active = !muted && (state === 'speaking' || state === 'thinking' || state === 'connecting');
+    const half = size / 2;
+
     React.useEffect(() => {
         if (reduceMotion) {
             phase.value = 0.5;
@@ -29,16 +130,77 @@ export const RealtimeSessionVisual = React.memo(function RealtimeSessionVisual({
         phase.value = withRepeat(withTiming(1, { duration: state === 'speaking' ? 700 : 1800 }), -1, true);
         return () => cancelAnimation(phase);
     }, [phase, reduceMotion, state]);
-    const motion = useAnimatedStyle(() => ({
+
+    React.useEffect(() => {
+        if (reduceMotion) {
+            spin.value = 0.12;
+            return;
+        }
+        // Muted still turns, slowly: a frozen disc reads as a hung session.
+        const duration = muted ? 40_000
+            : state === 'speaking' ? 9_000
+            : state === 'thinking' || state === 'connecting' ? 15_000
+            : 26_000;
+        spin.value = 0;
+        spin.value = withRepeat(withTiming(1, { duration, easing: Easing.linear }), -1, false);
+        return () => cancelAnimation(spin);
+    }, [muted, reduceMotion, spin, state]);
+
+    const breathe = useAnimatedStyle(() => ({
         transform: reduceMotion ? [] : [{ scale: 0.97 + phase.value * 0.03 }],
     }));
-    const colors = muted
-        ? ['#17181b', '#75454d', '#d4a0a6']
+
+    // Tapered ribbons, built as filled outlines: a stroked path is one width for
+    // its whole length, and a lane that never thins reads as a painted stripe.
+    const dustPath = useDerivedValue(() => {
+        const path = Skia.Path.Make();
+        const turn = spin.value * TWO_PI;
+        for (let arm = 0; arm < ARMS; arm += 1) {
+            const left: number[] = [];
+            const right: number[] = [];
+            for (let step = 0; step <= 40; step += 1) {
+                const along = step / 40;
+                const radius = R_MIN + (R_MAX - R_MIN) * Math.pow(along, 0.78);
+                const angle = arm * (TWO_PI / ARMS) + WIND * Math.log(radius / R_MIN) + turn;
+                const width = size * (0.048 - along * 0.031);
+                const x = half + Math.cos(angle) * radius * size;
+                const y = half + Math.sin(angle) * radius * size * FLATTEN;
+                // Widen across the lane, not along it.
+                left.push(x, y - width);
+                right.push(x, y + width);
+            }
+            path.moveTo(left[0] as number, left[1] as number);
+            for (let index = 2; index < left.length; index += 2) path.lineTo(left[index] as number, left[index + 1] as number);
+            for (let index = right.length - 2; index >= 0; index -= 2) path.lineTo(right[index] as number, right[index + 1] as number);
+            path.close();
+        }
+        return path;
+    });
+
+    const innerStreaks = useDerivedValue(() => streakPath(INNER, spin.value, half, size));
+    const outerStreaks = useDerivedValue(() => streakPath(OUTER, spin.value, half, size));
+    const innerDots = useDerivedValue(() => dotPath(INNER, spin.value, half, size));
+    const outerDots = useDerivedValue(() => dotPath(OUTER, spin.value, half, size));
+
+    const fieldPath = React.useMemo(() => {
+        const path = Skia.Path.Make();
+        for (const star of FIELD) {
+            path.addCircle(
+                half + Math.cos(star.angle) * star.radius * size,
+                half + Math.sin(star.angle) * star.radius * size,
+                Math.max(0.4, size * 0.0045),
+            );
+        }
+        return path;
+    }, [half, size]);
+
+    const palette = muted
+        ? { field: '#1c1416', arm: '#7a4550', core: '#f0cdd2', star: '#e8b6bc' }
         : state === 'speaking'
-          ? ['#15181e', '#596783', '#dce2ec']
+          ? { field: '#0f1826', arm: '#4a76c8', core: '#eaf2ff', star: '#d8e8ff' }
           : state === 'thinking' || state === 'connecting'
-            ? ['#18171b', '#665f70', '#e2dee7']
-            : ['#131a19', '#4f756b', '#dce8e4'];
+            ? { field: '#151425', arm: '#5b57a8', core: '#efeaff', star: '#ddd6ff' }
+            : { field: '#0e1a17', arm: '#3f7d6c', core: '#e6fff5', star: '#d6f4e6' };
     const label = muted
         ? 'Realtime session indicator, microphone muted'
         : state === 'speaking'
@@ -46,6 +208,7 @@ export const RealtimeSessionVisual = React.memo(function RealtimeSessionVisual({
           : state === 'thinking' || state === 'connecting'
             ? 'Realtime session indicator, thinking'
             : 'Realtime session indicator, listening';
+    const bulge = size * (active ? 0.2 : 0.16);
 
     return (
         <Animated.View
@@ -58,22 +221,38 @@ export const RealtimeSessionVisual = React.memo(function RealtimeSessionVisual({
                     height: size,
                     borderRadius: size / 2,
                     overflow: 'hidden',
-                    backgroundColor: '#151619',
+                    backgroundColor: '#07080a',
                     elevation: Math.round(size * 0.05),
                 },
-                motion,
+                breathe,
             ]}
         >
             <Canvas style={{ width: size, height: size }}>
-                <Circle cx={size / 2} cy={size / 2} r={size * 0.49}>
-                    <RadialGradient c={vec(size * 0.34, size * 0.28)} r={size * 0.72} colors={colors} />
+                {/* Near-black field, so the arms stay the brightest thing in it. */}
+                <Circle cx={half} cy={half} r={size * 0.5}>
+                    <RadialGradient c={vec(half, half * 1.05)} r={size * 0.55} colors={[palette.field, '#080a0d', '#06070a']} />
                 </Circle>
-                <Circle cx={size * 0.58} cy={size * 0.64} r={size * 0.26} opacity={0.38}>
-                    <RadialGradient
-                        c={vec(size * 0.5, size * 0.55)}
-                        r={size * 0.38}
-                        colors={['rgba(255,255,255,0.5)', 'rgba(155,180,255,0.16)', 'rgba(20,24,38,0)']}
-                    />
+
+                <Path path={fieldPath} color="#ffffff" opacity={muted ? 0.1 : 0.22} />
+
+                <Group transform={[{ rotate: TILT }]} origin={vec(half, half)}>
+                    <Path path={dustPath} color={palette.arm} opacity={muted ? 0.1 : 0.22} />
+                    <Path path={outerStreaks} color={palette.star} style="stroke" strokeWidth={Math.max(0.6, size * 0.007)} strokeCap="round" opacity={muted ? 0.14 : 0.34} />
+                    <Path path={innerStreaks} color={palette.star} style="stroke" strokeWidth={Math.max(0.7, size * 0.011)} strokeCap="round" opacity={muted ? 0.2 : 0.48} />
+                    <Path path={outerDots} color={palette.star} opacity={muted ? 0.26 : 0.62} />
+                    <Path path={innerDots} color={palette.star} opacity={muted ? 0.35 : 0.95} />
+                </Group>
+
+                {/* Bulge, flattened with the disc rather than pasted on as a ball. */}
+                <Group transform={[{ rotate: TILT }, { scaleY: 0.62 }]} origin={vec(half, half)}>
+                    <Circle cx={half} cy={half} r={bulge} opacity={muted ? 0.75 : 1}>
+                        <RadialGradient c={vec(half, half)} r={bulge} colors={[palette.core, palette.arm, 'rgba(0,0,0,0)']} />
+                    </Circle>
+                </Group>
+
+                {/* Rim: puts the disc inside a sphere. */}
+                <Circle cx={half} cy={half} r={size * 0.49} style="stroke" strokeWidth={size * 0.012}>
+                    <RadialGradient c={vec(size * 0.3, size * 0.25)} r={size * 0.8} colors={['rgba(255,255,255,0.2)', 'rgba(255,255,255,0.03)']} />
                 </Circle>
             </Canvas>
         </Animated.View>

--- a/packages/contract/src/manifest.ts
+++ b/packages/contract/src/manifest.ts
@@ -258,7 +258,9 @@ function parseScreenNode(item: Record<string, unknown>, depth: number, budget: {
             };
         }
         case 'chart':
-            if (item.variant !== 'bar' && item.variant !== 'ring') throw new Error('invalid plugin screen chart variant');
+            if (item.variant !== 'bar' && item.variant !== 'column' && item.variant !== 'gauge' && item.variant !== 'ring') {
+                throw new Error('invalid plugin screen chart variant');
+            }
             return {
                 type: 'chart', variant: item.variant, path: bindingPath(item.path),
                 ...(item.title === undefined ? {} : { title: pluginText(item.title, 80) }),

--- a/packages/contract/src/plugins.ts
+++ b/packages/contract/src/plugins.ts
@@ -453,7 +453,11 @@ export interface PluginScreenSectionNode {
 }
 export interface PluginScreenChartNode {
     type: 'chart';
-    variant: 'bar' | 'ring';
+    /**
+     * bar ranks categories, column reads a series over time left to right,
+     * gauge carries one value against its ceiling, ring splits a whole.
+     */
+    variant: 'bar' | 'column' | 'gauge' | 'ring';
     /** Runtime path to bounded `{ label, value, valueLabel?, tone? }` entries. */
     path: string;
     title?: PluginText;

--- a/plugins/status/muxr-ui.json
+++ b/plugins/status/muxr-ui.json
@@ -69,7 +69,7 @@
         },
         {
           "type": "chart",
-          "variant": "ring",
+          "variant": "gauge",
           "path": "data.limitRing",
           "title": "Current limit",
           "emptyText": "No published limit for this provider"
@@ -112,7 +112,7 @@
         },
         {
           "type": "chart",
-          "variant": "bar",
+          "variant": "column",
           "path": "data.weekSeries",
           "emptyText": "No measured activity this week"
         },

--- a/plugins/status/muxr-ui.json
+++ b/plugins/status/muxr-ui.json
@@ -53,68 +53,83 @@
         {
           "type": "section",
           "title": "Today",
-          "columns": 2,
           "children": [
             {
-              "type": "metric",
-              "label": "Tokens",
-              "value": "{{data.todayTokens}}"
+              "type": "section",
+              "columns": 2,
+              "children": [
+                {
+                  "type": "metric",
+                  "label": "Tokens",
+                  "value": "{{data.todayTokens}}"
+                },
+                {
+                  "type": "metric",
+                  "label": "Cost",
+                  "value": "{{data.todayCost}}"
+                }
+              ]
             },
             {
-              "type": "metric",
-              "label": "Cost",
-              "value": "{{data.todayCost}}"
+              "type": "chart",
+              "variant": "gauge",
+              "path": "data.limitRing",
+              "title": "Current limit",
+              "emptyText": "No published limit for this provider"
+            },
+            {
+              "type": "text",
+              "text": "{{data.limitLabel}}",
+              "tone": "secondary"
             }
           ]
         },
         {
-          "type": "chart",
-          "variant": "gauge",
-          "path": "data.limitRing",
-          "title": "Current limit",
-          "emptyText": "No published limit for this provider"
-        },
-        {
-          "type": "text",
-          "text": "{{data.limitLabel}}",
-          "tone": "secondary"
-        },
-        {
-          "type": "chart",
-          "variant": "bar",
-          "path": "data.limitSeries",
-          "title": "Rate limits",
-          "emptyText": "No published rate limits"
-        },
-        {
-          "type": "chart",
-          "variant": "bar",
-          "path": "data.modelSeries",
+          "type": "section",
           "title": "Models today",
-          "emptyText": "No measured activity today"
+          "children": [
+            {
+              "type": "chart",
+              "variant": "bar",
+              "path": "data.modelSeries",
+              "emptyText": "No measured activity today"
+            },
+            {
+              "type": "chart",
+              "variant": "bar",
+              "path": "data.limitSeries",
+              "title": "Rate limits",
+              "emptyText": "No published rate limits"
+            }
+          ]
         },
         {
           "type": "section",
           "title": "Last 7 days",
-          "columns": 2,
           "children": [
             {
-              "type": "metric",
-              "label": "Tokens",
-              "value": "{{data.weekTokens}}"
+              "type": "section",
+              "columns": 2,
+              "children": [
+                {
+                  "type": "metric",
+                  "label": "Tokens",
+                  "value": "{{data.weekTokens}}"
+                },
+                {
+                  "type": "metric",
+                  "label": "Cost",
+                  "value": "{{data.weekCost}}"
+                }
+              ]
             },
             {
-              "type": "metric",
-              "label": "Cost",
-              "value": "{{data.weekCost}}"
+              "type": "chart",
+              "variant": "column",
+              "path": "data.weekSeries",
+              "emptyText": "No measured activity this week"
             }
           ]
-        },
-        {
-          "type": "chart",
-          "variant": "column",
-          "path": "data.weekSeries",
-          "emptyText": "No measured activity this week"
         },
         {
           "type": "text",

--- a/plugins/status/muxr-ui.json
+++ b/plugins/status/muxr-ui.json
@@ -82,20 +82,20 @@
         {
           "type": "chart",
           "variant": "bar",
+          "path": "data.limitSeries",
+          "title": "Rate limits",
+          "emptyText": "No published rate limits"
+        },
+        {
+          "type": "chart",
+          "variant": "bar",
           "path": "data.modelSeries",
           "title": "Models today",
           "emptyText": "No measured activity today"
         },
         {
-          "type": "chart",
-          "variant": "bar",
-          "path": "data.weekSeries",
-          "title": "Last 7 days",
-          "emptyText": "No measured activity this week"
-        },
-        {
           "type": "section",
-          "title": "This week",
+          "title": "Last 7 days",
           "columns": 2,
           "children": [
             {
@@ -113,9 +113,8 @@
         {
           "type": "chart",
           "variant": "bar",
-          "path": "data.limitSeries",
-          "title": "Rate limits",
-          "emptyText": "No published rate limits"
+          "path": "data.weekSeries",
+          "emptyText": "No measured activity this week"
         },
         {
           "type": "text",


### PR DESCRIPTION
The realtime indicator was a gradient sphere that breathed. It said "something is on" and nothing else.

It is now a barred spiral drawn in Skia: a bulge for the conversation, two tapering dust lanes, and 46 agent stars drawn as short tangential streaks so motion reads even in a still frame, over a static field of background stars.

State drives it rather than decorating it:
- listening green, thinking violet, speaking blue, muted rose
- the bulge grows and brightens while the session is working
- rotation runs from 9s per turn while speaking to 40s while muted, because a frozen disc reads as a hung session

Skia and Reanimated were already dependencies, so this adds none. No Lottie file either: the same artwork has to serve the 40pt pill and the 238pt conversation view, and only geometry survives that range.

The arms turn rigidly. A real disc rotates differentially, which shears the arms into a smear within a few laps: accurate, and useless as an indicator.

Verification: suite 30/30, mobile typecheck clean, and the geometry was rendered and iterated on in a canvas replica of the same maths. On-device Skia rendering is unverified until this build lands.