### PR TITLE
Retry an Android build that Maven Central rate-limited

### DIFF
--- a/.github/workflows/mobile-internal.yml
+++ b/.github/workflows/mobile-internal.yml
@@ -117,7 +117,19 @@ jobs:
         working-directory: apps/mobile
         run: |
           set -o pipefail
-          npx eas-cli@22.0.0 build --platform android --profile production --local --non-interactive --output "$RUNNER_TEMP/muxr.aab" 2>&1 | tee "$RUNNER_TEMP/android-eas.log"
+          # Maven Central answers 429 often enough to fail a release on its own.
+          # One retry costs a rebuild; a lost release costs the run.
+          for attempt in 1 2; do
+            if npx eas-cli@22.0.0 build --platform android --profile production --local --non-interactive --output "$RUNNER_TEMP/muxr.aab" 2>&1 | tee "$RUNNER_TEMP/android-eas.log"; then
+              exit 0
+            fi
+            if ! grep -q "Too Many Requests" "$RUNNER_TEMP/android-eas.log"; then
+              exit 1
+            fi
+            echo "::warning::Maven Central rate-limited the build; retrying once."
+            sleep 60
+          done
+          exit 1
       - name: Download pinned bundletool
         run: |
           curl -fsSL --retry 3 -o "$RUNNER_TEMP/bundletool.jar" https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar


### PR DESCRIPTION
The internal Android build failed on `Could not GET .../gson-2.9.1.pom. Received status code 429` — Maven Central rate-limiting the runner, nothing in the app.

Retry once, and only for that: any other failure still fails immediately, so a real break is never masked by a second attempt.

Verification: actionlint 1.7.12 clean.