### PR TITLE
Diff view drops git plumbing and tightens its type

### DIFF
--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -57,7 +57,7 @@ export default React.memo(function FileScreen() {
     const [isLoading, setIsLoading] = React.useState(!cached);
     const [error, setError] = React.useState<string | null>(null);
     const scrollViewRef = React.useRef<ScrollView | null>(null);
-    const [fontSize, setFontSize] = React.useState(13);
+    const [fontSize, setFontSize] = React.useState(12);
     // Pinch steps the size rather than scaling continuously: the code re-lays
     // out on every change, and a smooth scale would relayout every frame.
     const pinchStart = React.useRef(13);

--- a/apps/mobile/sources/components/diff/PierreDiffView.tsx
+++ b/apps/mobile/sources/components/diff/PierreDiffView.tsx
@@ -283,7 +283,7 @@ function PlainPatchView({
 }) {
     const { theme } = useUnistyles();
     const colors = theme.colors.diff;
-    const codeFontSize = fontSize ?? 13;
+    const codeFontSize = fontSize ?? 12;
     const lines = React.useMemo(() => patch.split('\n'), [patch]);
     const language = React.useMemo(() => syntaxLanguage(undefined, patchFileName(patch)), [patch]);
     const highlightSource = React.useMemo(() => boundText(lines.map((line) => isPatchCodeLine(line) ? line.slice(1) : '').join('\n'), 600, 64 * 1024).text, [lines]);
@@ -302,15 +302,23 @@ function PlainPatchView({
         <View style={{ flex: 1, overflow: 'hidden' }}>
             {lines.map((line, i) => {
                 const first = line.charAt(0);
-                const isFileHeader =
-                    line.startsWith('+++') ||
-                    line.startsWith('---') ||
+                // Plumbing says nothing the surrounding UI does not already say:
+                // the screen names the file, and `index`/`---`/`+++` are for
+                // `git apply`, not for a reader.
+                const isPlumbing =
+                    line.startsWith('+++ ') ||
+                    line.startsWith('--- ') ||
                     line.startsWith('diff ') ||
                     line.startsWith('index ') ||
+                    line.startsWith('similarity ') ||
+                    line.startsWith('dissimilarity ') ||
+                    line.startsWith('\\ No newline');
+                if (isPlumbing) return null;
+                // These carry real information; keep them as one quiet line each.
+                const isFileHeader =
                     line.startsWith('new file') ||
                     line.startsWith('deleted file') ||
                     line.startsWith('rename ') ||
-                    line.startsWith('similarity ') ||
                     line.startsWith('Binary files');
                 const isHunkHeader = line.startsWith('@@');
 
@@ -335,7 +343,7 @@ function PlainPatchView({
                                 style={{
                                     ...Typography.mono(),
                                     fontSize: codeFontSize - 2,
-                                    lineHeight: Math.round((codeFontSize - 2) * 1.45),
+                                    lineHeight: Math.round((codeFontSize - 2) * 1.4),
                                     color: colors.hunkHeaderText,
                                 }}
                             >
@@ -364,7 +372,7 @@ function PlainPatchView({
                         style={{
                             ...Typography.mono(),
                             fontSize: codeFontSize,
-                            lineHeight: Math.round(codeFontSize * 1.55),
+                            lineHeight: Math.round(codeFontSize * 1.45),
                             backgroundColor: bg,
                             color: fg,
                             paddingHorizontal: isFileHeader ? 12 : 8,


### PR DESCRIPTION
The mobile diff opened with five lines of `diff --git`/`index`/`---`/`+++` before any code — apply-plumbing, not reading material, and the screen header already names the file. Those lines and `\ No newline` no longer render; `new file`/`deleted file`/`rename`/`Binary files` stay as quiet metadata since they carry information.

Type tightens to Cursor density: default 12pt mono (pinch-zoom still works), line height 1.55 → 1.45.

Applies to both the session file viewer and the plugin diff node, which share PlainPatchView.

Verification: mobile typecheck clean; suite 30/30.