### PR TITLE
Plugin surfaces agree on tone, and keep their place

### DIFF
--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -17,7 +17,8 @@ import { SyntaxHighlightedCode } from '@/components/code/SyntaxHighlightedCode';
 import { sync } from '@/sync/sync';
 import { pluginSnapshot } from './pluginStore';
 import { dispatchPluginAction } from './pluginActions';
-import { subscribePluginDataInvalidation } from './pluginDataInvalidation';
+import { clearPluginCache, registerPluginDataCacheInvalidator, subscribePluginDataInvalidation } from './pluginDataInvalidation';
+import { toneColor } from './pluginTone';
 import { bindText, initialFieldValues, loadScreenData, resolvePath, runScreenButton, sharedPluginWriteKeys, shouldReloadAfterAction, type ScreenFieldValues } from './screenModel';
 import { resolvePluginText } from './pluginText';
 import { asScreenTree, type RuntimeTreeItem } from './screenTreeModel';
@@ -27,25 +28,16 @@ import { t } from '@/text';
 import { boundText } from '@/utils/boundedText';
 import { Typography } from '@/constants/Typography';
 
-function toneColor(theme: Theme, tone: string | undefined): string {
-    switch (tone) {
-        case 'positive': return theme.colors.success;
-        case 'warning': return theme.colors.box.warning.text;
-        case 'danger': return theme.colors.box.error.text;
-        case 'secondary': return theme.colors.textSecondary;
-        default: return theme.colors.text;
-    }
-}
+/** Screen payloads survive a close: reopening renders at once, then refreshes. */
+const screenCache = new Map<string, unknown>();
+registerPluginDataCacheInvalidator((pluginIds) => {
+    if (pluginIds === undefined) screenCache.clear();
+    else for (const pluginId of pluginIds) clearPluginCache(screenCache, pluginId);
+});
 
 /** Chart fills: untoned series get the accent, never a per-index rainbow. */
 function chartFill(theme: Theme, tone: PluginScreenTone | undefined): string {
-    switch (tone) {
-        case 'positive': return theme.colors.success;
-        case 'warning': return theme.colors.box.warning.text;
-        case 'danger': return theme.colors.box.error.text;
-        case 'secondary': return theme.colors.textSecondary;
-        default: return theme.colors.accent;
-    }
+    return tone === undefined ? theme.colors.accent : toneColor(theme, tone);
 }
 
 function withAlpha(color: string, alpha: number): string {
@@ -511,7 +503,7 @@ function ScreenNode(props: {
     const bind = (value: PluginText) => bindText(resolvePluginText(value), data);
     switch (node.type) {
         case 'text':
-            return <Text style={{ color: toneColor(theme, node.tone), fontSize: 15, lineHeight: 21, marginBottom: 8 }}>{bind(node.text)}</Text>;
+            return <Text style={{ color: node.tone === undefined ? theme.colors.text : toneColor(theme, node.tone), fontSize: 15, lineHeight: 21, marginBottom: 8 }}>{bind(node.text)}</Text>;
         case 'row':
             return <ScreenRow row={node} data={data} onRowAction={props.onRowAction} insideCard={props.nested === true} style={{ paddingVertical: 10 }} />;
         case 'diff': {
@@ -536,7 +528,7 @@ function ScreenNode(props: {
         case 'badge':
             return (
                 <View style={{ alignSelf: 'flex-start', borderRadius: 999, paddingHorizontal: 10, paddingVertical: 4, marginBottom: 10, backgroundColor: theme.colors.surfaceHighest }}>
-                    <Text style={{ color: toneColor(theme, node.tone), fontSize: 12, fontWeight: '600', letterSpacing: 0.2 }}>{bind(node.label)}</Text>
+                    <Text style={{ color: node.tone === undefined ? theme.colors.text : toneColor(theme, node.tone), fontSize: 12, fontWeight: '600', letterSpacing: 0.2 }}>{bind(node.label)}</Text>
                 </View>
             );
         case 'progress': {
@@ -678,6 +670,11 @@ function ScreenNode(props: {
     }
 }
 
+/** Stable across key order so a tab revisit hits the same cache entry. */
+function paramsKey(params: Record<string, string> | undefined): string {
+    return params === undefined ? '' : JSON.stringify(Object.entries(params).sort(([a], [b]) => a.localeCompare(b)));
+}
+
 function sourceLabel(source: PluginSource): string {
     if (source.kind === 'github') {
         const owner = source.owner ?? 'unknown';
@@ -700,14 +697,7 @@ function ScreenBody(props: {
 }) {
     const { screen } = props;
     const router = useRouter();
-    const [data, setData] = React.useState<unknown>(undefined);
-    const [dataError, setDataError] = React.useState<string>();
-    const [fields, setFields] = React.useState<ScreenFieldValues>(() => initialFieldValues(screen));
-    const [running, setRunning] = React.useState(false);
-    const [status, setStatus] = React.useState<{ ok: boolean; text: string }>();
-    const [refreshNonce, setRefreshNonce] = React.useState(0);
-    const [loading, setLoading] = React.useState(screen.data?.contributionId !== undefined);
-    const [refreshing, setRefreshing] = React.useState(false);
+    const dataContributionId = screen.data?.contributionId;
     // A pressed tab is just another screen param, so one payload per tab keeps
     // the plugin's reply small instead of shipping every tab's detail at once.
     const [tabParams, setTabParams] = React.useState<Record<string, string>>({});
@@ -715,11 +705,22 @@ function ScreenBody(props: {
         const merged = { ...(props.params ?? {}), ...tabParams };
         return Object.keys(merged).length === 0 ? undefined : merged;
     }, [props.params, tabParams]);
+    const cacheKey = React.useMemo(() => dataContributionId === undefined
+        ? undefined
+        : `${props.pluginId}:${props.manifestHash}:${dataContributionId}:${paramsKey(callParams)}`,
+    [callParams, dataContributionId, props.manifestHash, props.pluginId]);
+    const [data, setData] = React.useState<unknown>(() => cacheKey === undefined ? undefined : screenCache.get(cacheKey));
+    const [dataError, setDataError] = React.useState<string>();
+    const [fields, setFields] = React.useState<ScreenFieldValues>(() => initialFieldValues(screen));
+    const [running, setRunning] = React.useState(false);
+    const [status, setStatus] = React.useState<{ ok: boolean; text: string }>();
+    const [refreshNonce, setRefreshNonce] = React.useState(0);
+    const [loading, setLoading] = React.useState(dataContributionId !== undefined);
+    const [refreshing, setRefreshing] = React.useState(false);
     const operationVersion = React.useRef(0);
     const dirtyFields = React.useRef(new Set<string>());
     const writeKeys = sharedPluginWriteKeys;
     const request = React.useCallback((type: 'plugin.call', params: RequestParams<'plugin.call'>): Promise<unknown> => sync.request(type, params, PLUGIN_CALL_CLIENT_TIMEOUT_MS), []);
-    const dataContributionId = screen.data?.contributionId;
     React.useEffect(() => {
         operationVersion.current += 1;
         dirtyFields.current.clear();
@@ -731,13 +732,17 @@ function ScreenBody(props: {
         if (dataContributionId !== undefined) setRefreshNonce((value) => value + 1);
     }), [dataContributionId, props.pluginId]);
     React.useEffect(() => {
-        if (dataContributionId === undefined) return;
+        if (dataContributionId === undefined || cacheKey === undefined) return;
         let cancelled = false;
+        // Stale first, fresh behind it: a reopened screen never starts blank.
+        const cached = screenCache.get(cacheKey);
+        if (cached !== undefined) setData(cached);
         setLoading(true);
         setDataError(undefined);
         void loadScreenData(dataContributionId, props.manifest, props.pluginId, props.manifestHash, request, callParams)
             .then((value) => {
                 if (cancelled) return;
+                screenCache.set(cacheKey, value);
                 setData(value);
                 const defaults = initialFieldValues(screen, value);
                 setFields((current) => Object.fromEntries(Object.entries(defaults).map(([id, initial]) =>
@@ -746,7 +751,7 @@ function ScreenBody(props: {
             .catch((error: unknown) => { if (!cancelled) setDataError(error instanceof Error ? error.message : String(error)); })
             .finally(() => { if (!cancelled) { setLoading(false); setRefreshing(false); } });
         return () => { cancelled = true; };
-    }, [dataContributionId, props.manifest, props.pluginId, props.manifestHash, callParams, request, refreshNonce]);
+    }, [cacheKey, dataContributionId, props.manifest, props.pluginId, props.manifestHash, callParams, request, refreshNonce]);
 
     const onRowAction = React.useCallback((action: PluginScreenRowAction, item: unknown) => {
         const bound = action.type === 'screen' && action.params !== undefined
@@ -822,9 +827,6 @@ function ScreenBody(props: {
                     onRefresh={() => { setRefreshing(true); setRefreshNonce((value) => value + 1); }} />
             )}>
             <LoadingHairline active={loading} />
-            {/* One provenance line, not a header block: the navigation bar already
-                names the plugin, and the screen's own title needs the room. */}
-            {props.source.kind !== 'local' && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 11, marginBottom: 6 }}>{`${props.pluginName} · ${sourceLabel(props.source)}`}</Text>}
             {screen.title !== undefined && <Text style={{ color: theme.colors.text, fontSize: 21, fontWeight: '700', marginBottom: 8 }}>{bindText(resolvePluginText(screen.title), data)}</Text>}
             {/* Show why, not just that: a plugin author debugging a screen has
                 nothing to go on otherwise. The host already bounds this text. */}
@@ -850,6 +852,9 @@ function ScreenBody(props: {
                     {status.text}
                 </Text>
             )}
+            {/* Provenance is a footnote, not a headline: the screen's own title
+                leads, and where the plugin came from waits at the bottom. */}
+            {props.source.kind !== 'local' && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 11, marginTop: 20 }}>{`${props.pluginName} · ${sourceLabel(props.source)}`}</Text>}
         </ScrollView>
     );
 }

--- a/apps/mobile/sources/plugins/pluginTone.ts
+++ b/apps/mobile/sources/plugins/pluginTone.ts
@@ -1,0 +1,17 @@
+import type { PluginScreenTone } from '@muxr/contract';
+import type { Theme } from '@/theme';
+
+/**
+ * One tone-to-colour mapping for every plugin surface. Four private copies had
+ * drifted far enough that `warning` was amber on a declarative screen and blue
+ * in the sheet rendering the same plugin's data.
+ */
+export function toneColor(theme: Theme, tone: PluginScreenTone | undefined): string {
+    switch (tone) {
+        case 'positive': return theme.colors.status.done;
+        case 'warning': return theme.colors.box.warning.text;
+        case 'danger': return theme.colors.status.error;
+        case 'primary': return theme.colors.accent;
+        default: return theme.colors.textSecondary;
+    }
+}

--- a/apps/mobile/sources/plugins/primitives/CollectionView.tsx
+++ b/apps/mobile/sources/plugins/primitives/CollectionView.tsx
@@ -11,13 +11,13 @@ import { ItemGroup } from '@/components/ItemGroup';
 import { StatusDot } from '@/components/StatusDot';
 import { Typography } from '@/constants/Typography';
 import { layout } from '@/components/layout';
-import type { Theme } from '@/theme';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
 import type { PrimitiveProps } from '../primitiveRegistry';
 import { asPluginCollection, type PluginCollectionGroup, type PluginCollectionItem } from '../collectionModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';
 import { clearPluginCache, registerPluginDataCacheInvalidator, subscribePluginDataInvalidation } from '../pluginDataInvalidation';
+import { toneColor } from '../pluginTone';
 import { resolvePluginText } from '../pluginText';
 import { t } from '@/text';
 
@@ -27,16 +27,6 @@ registerPluginDataCacheInvalidator((pluginIds) => {
     if (pluginIds === undefined) cache.clear();
     else for (const pluginId of pluginIds) clearPluginCache(cache, pluginId);
 });
-
-function statusColor(status: PluginCollectionItem['status'], theme: Theme): string {
-    switch (status) {
-        case 'positive': return theme.colors.status.done;
-        case 'warning': return theme.colors.status.working;
-        case 'danger': return theme.colors.status.error;
-        case 'primary': return theme.colors.accent;
-        default: return theme.colors.textSecondary;
-    }
-}
 
 function relativeTime(value: string): string {
     const seconds = Math.max(0, Math.floor((Date.now() - Date.parse(value)) / 1000));
@@ -181,6 +171,8 @@ export function CollectionView({ context, pluginId, manifestHash, contribution }
                             paddingHorizontal: 16,
                             paddingVertical: 14,
                             backgroundColor: theme.colors.surface,
+                            // Settled work steps back so the row still working keeps the contrast.
+                            opacity: item.status === 'positive' ? 0.75 : 1,
                             borderBottomWidth: itemIndex === group.items.length - 1 ? 0 : StyleSheet.hairlineWidth,
                             borderBottomColor: theme.colors.divider,
                         }, pressed && { backgroundColor: theme.colors.surfacePressed }]}
@@ -193,7 +185,7 @@ export function CollectionView({ context, pluginId, manifestHash, contribution }
                                 {[item.glyph, item.timestamp === undefined ? undefined : relativeTime(item.timestamp)].filter(Boolean).join(' · ')}
                             </Text>}
                         </View>
-                        {item.status !== undefined && <StatusDot color={statusColor(item.status, theme)} isPulsing={item.pulsing === true} size={8} style={{ marginLeft: 10 }} />}
+                        {item.status !== undefined && <StatusDot color={toneColor(theme, item.status)} isPulsing={item.pulsing === true} size={8} style={{ marginLeft: 10 }} />}
                     </Pressable>)}
                 </ItemGroup>)}
             </ScrollView>

--- a/apps/mobile/sources/plugins/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/primitives/ItemList.tsx
@@ -11,13 +11,12 @@ import { Modal } from '@/modal';
 import { sync } from '@/sync/sync';
 import { Typography } from '@/constants/Typography';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
-import type { Theme } from '@/theme';
-import type { PluginScreenTone } from '@muxr/contract';
 import type { PrimitiveProps } from '../primitiveRegistry';
 import { asPluginItemList, type PluginItemListAction, type PluginItemListItem, type PluginItemListModel } from '../itemListModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';
 import { clearPluginCache, registerPluginDataCacheInvalidator, subscribePluginDataInvalidation } from '../pluginDataInvalidation';
+import { toneColor } from '../pluginTone';
 import { resolvePluginText } from '../pluginText';
 import { t } from '@/text';
 
@@ -27,16 +26,6 @@ registerPluginDataCacheInvalidator((pluginIds) => {
     if (pluginIds === undefined) cache.clear();
     else for (const pluginId of pluginIds) clearPluginCache(cache, pluginId);
 });
-
-function toneColor(theme: Theme, tone: PluginScreenTone | undefined): string {
-    switch (tone) {
-        case 'positive': return theme.colors.status.done;
-        case 'warning': return theme.colors.status.working;
-        case 'danger': return theme.colors.status.error;
-        case 'primary': return theme.colors.accent;
-        default: return theme.colors.textSecondary;
-    }
-}
 
 function withAlpha(color: string, alpha: number): string {
     const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color)?.[1];
@@ -71,15 +60,17 @@ function SheetRow({ item, fallbackIcon, busy, index, onPress }: {
 }) {
     const { theme } = useUnistyles();
     const [primary, ...rest] = item.metadata;
-    const secondary = rest.map((entry) => `${entry.label === undefined ? '' : `${entry.label} `}${entry.value}`.trim()).join(' · ');
     const metadataLabel = item.metadata.map((entry) => `${entry.label === undefined ? '' : `${entry.label} `}${entry.value}`).join(', ');
     const label = [item.group, item.title, item.subtitle, metadataLabel].filter((part) => part !== undefined && part !== '').join(', ');
+    // Work that already landed steps back; anything working or in trouble keeps
+    // full contrast, so the eye goes to the row that still needs a person.
+    const settled = (item.progress?.tone ?? primary?.tone) === 'positive';
     // Untoned bars step back down the list: a column of identical full-strength
     // accent reads as decoration rather than ranking.
     const progressColor = item.progress?.tone === undefined
         ? withAlpha(theme.colors.accent, Math.max(0.4, 1 - index * 0.14))
         : toneColor(theme, item.progress.tone);
-    const content = <>
+    const content = <View style={{ opacity: settled ? 0.75 : 1 }}>
         <View style={styles.itemRow}>
             {busy
                 ? <ActivityIndicator size="small" color={theme.colors.textSecondary} style={styles.iconTile} />
@@ -94,11 +85,20 @@ function SheetRow({ item, fallbackIcon, busy, index, onPress }: {
                 <Text style={[styles.metadataValue, { color: primary.tone === undefined ? theme.colors.text : toneColor(theme, primary.tone) }]}>
                     {primary.label === undefined ? '' : `${primary.label} `}{primary.value}
                 </Text>
-                {secondary !== '' && <Text numberOfLines={1} style={[styles.metadataSecondary, { color: theme.colors.textSecondary }]}>{secondary}</Text>}
+                {/* Each entry keeps its own tone: a row reads "+26 −12 · repo"
+                    with the counts coloured, not one flat grey run-on. */}
+                {rest.length > 0 && <Text numberOfLines={1} style={[styles.metadataSecondary, { color: theme.colors.textSecondary }]}>
+                    {rest.flatMap((entry, entryIndex) => [
+                        ...(entryIndex === 0 ? [] : [<Text key={`separator-${entryIndex}`}>{' · '}</Text>]),
+                        <Text key={entryIndex} {...(entry.tone === undefined ? {} : { style: { color: toneColor(theme, entry.tone) } })}>
+                            {`${entry.label === undefined ? '' : `${entry.label} `}${entry.value}`}
+                        </Text>,
+                    ])}
+                </Text>}
             </View>}
         </View>
         {item.progress !== undefined && <RowProgress value={item.progress.value} color={progressColor} delay={index * 50} />}
-    </>;
+    </View>;
     if (onPress === undefined) return <View accessible accessibilityLabel={label}>{content}</View>;
     return (
         <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={label} accessibilityState={{ busy }}

--- a/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
+++ b/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
@@ -8,25 +8,15 @@ import { Modal } from '@/modal';
 import { sync } from '@/sync/sync';
 import { OptionSheet } from '@/components/OptionSheet';
 import { StatusDot } from '@/components/StatusDot';
-import type { Theme } from '@/theme';
 import type { PrimitiveProps } from '../primitiveRegistry';
 import type { PluginSlotContexts } from '../slotTypes';
 import { asPluginTree, type PluginTreeNode } from '../treeModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';
 import { subscribePluginDataInvalidation } from '../pluginDataInvalidation';
+import { toneColor } from '../pluginTone';
 import { resolvePluginText } from '../pluginText';
 import { t } from '@/text';
-
-function statusColor(status: PluginTreeNode['status'], theme: Theme): string {
-    switch (status) {
-        case 'positive': return theme.colors.status.done;
-        case 'warning': return theme.colors.status.working;
-        case 'danger': return theme.colors.status.error;
-        case 'primary': return theme.colors.accent;
-        default: return theme.colors.textSecondary;
-    }
-}
 
 function flatten(nodes: PluginTreeNode[], depth = 0): Array<{ node: PluginTreeNode; depth: number }> {
     return nodes.flatMap((node) => [{ node, depth }, ...flatten(node.children ?? [], depth + 1)]);
@@ -143,10 +133,10 @@ export function TreeSheet({ context, pluginId, manifestHash, contribution }: Pri
                     })}
                 >
                     {node.status !== undefined
-                        ? <StatusDot color={statusColor(node.status, theme)} isPulsing={node.pulsing === true} size={7} />
+                        ? <StatusDot color={toneColor(theme, node.status)} isPulsing={node.pulsing === true} size={7} />
                         : <Ionicons name={(node.icon ?? 'ellipse-outline') as never} size={12} color={theme.colors.textSecondary} />}
                     <View style={{ flex: 1, minWidth: 0 }}>
-                        <Text numberOfLines={1} style={{ color: node.current === true ? theme.colors.accent : theme.colors.textSecondary, fontSize: depth === 0 ? 14 : 13, fontWeight: node.current === true ? '600' : '400' }}>
+                        <Text numberOfLines={1} style={{ color: node.current === true ? theme.colors.accent : theme.colors.text, fontSize: depth === 0 ? 14 : 13, fontWeight: node.current === true ? '600' : '400' }}>
                             {node.title}
                         </Text>
                         {node.subtitle !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12 }}>{node.subtitle}</Text>}


### PR DESCRIPTION
## What changed

**One tone mapping.** `toneColor`/`statusColor` was copy-pasted into four files and had genuinely drifted apart — `DeclarativeScreen` mapped `warning` to amber (`box.warning.text`), while `ItemList`, `CollectionView` and `TreeSheet` mapped it to `status.working` (blue). The same plugin's `warning` therefore rendered two different colours depending on which surface drew it. New `plugins/pluginTone.ts` holds one mapping (warning amber, positive done-green, danger error, primary accent, otherwise textSecondary); all four copies are deleted. `chartFill` now delegates to it and only keeps its own untoned default (accent).

**Stale-while-revalidate for screen data.** `DeclarativeScreen` refetched from scratch on every open, so reopening a plugin screen meant a skeleton every time. It now uses the same module-level `Map` + `registerPluginDataCacheInvalidator` pattern that `primitives/ItemList.tsx` already used, keyed by `pluginId:manifestHash:contributionId:params` (params key is order-stable, so revisiting a tab hits the same entry). Cached payload paints immediately, the refresh lands behind it.

**Metadata keeps its tones.** `SheetRow` flattened every metadata entry after the first into one grey string, throwing away each entry's tone. Each entry is now its own `Text` span coloured by its tone and joined with ` · `, which is what makes a row like `2 Files  +26 −12 · repo` readable. No schema change — `tone` was already per entry. The accessibility label is still the flattened string.

**Bright present, dim past.** Tree row titles rendered `textSecondary`, so every row whispered; default titles now use `theme.colors.text` and the `current` row keeps its accent treatment. Rows whose tone/status is `positive` (settled work) drop to 0.75 opacity in `ItemList` and `CollectionView`; working and danger rows keep full contrast.

**Provenance demoted.** `pluginName · github:owner/repo` led the screen above its own title. It is now a quiet single line at the bottom of the scroll content, and the screen title is the first element.

## Notes

Theme tokens only, both themes. No new dependencies. Every existing accessibility label, role and state is preserved. No tests added — this is presentation-layer work with no new branch worth a flow test, per `AGENTS.md`.

## Verification

- `tsc --build --force` clean
- `tsc --noEmit --project apps/mobile/tsconfig.json` clean
- `vitest run --root .` — 42 files, 158 tests, all passing