### PR TITLE
Encrypt native preview payloads

### DIFF
--- a/apps/host/src/host.ts
+++ b/apps/host/src/host.ts
@@ -48,6 +48,7 @@ export function startHost(options: HostOptions): Host {
         ...(options.terminals === undefined ? {} : { terminals: options.terminals }),
         ...(options.token === undefined ? {} : { token: options.token }),
         ...(options.hostedE2ee === undefined ? {} : {
+            requirePreviewEncryption: true,
             canMutateDevice: (deviceId: string) => options.hostedE2ee!.deviceKinds?.[deviceId] !== 'browser',
         }),
     });

--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -24,6 +24,8 @@ export interface RequestDispatcherOptions {
     hostVersion: string;
     /** Where to join preview channels. Absent means preview is unavailable. */
     relayUrl?: string;
+    /** Hosted E2EE never permits clear preview payloads from older clients. */
+    requirePreviewEncryption?: boolean;
     terminals?: TerminalManager;
     token?: string;
     /** Browser grants can observe but cannot mutate terminal/machine state. */
@@ -152,11 +154,15 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
             if (options.relayUrl === undefined) {
                 throw new Error('preview: host has no relay url');
             }
+            if (options.requirePreviewEncryption === true && params.key === undefined) {
+                throw new Error('preview: update the app to use encrypted preview');
+            }
             return attachPreview({
                 relayUrl: options.relayUrl,
                 machineId,
                 channel: params.channel,
                 port: params.port,
+                ...(params.key === undefined ? {} : { key: params.key }),
                 ...(options.token === undefined ? {} : { token: options.token }),
             });
         },

--- a/apps/host/src/requests/preview.ts
+++ b/apps/host/src/requests/preview.ts
@@ -11,6 +11,7 @@
 
 import { connect, type Socket } from 'node:net';
 import WebSocket from 'ws';
+import { deriveV2Key, openPreviewPayload, sealPreviewPayload } from '@muxr/crypto';
 import {
     decodePreviewFrame,
     encodePreviewFrame,
@@ -46,6 +47,7 @@ export interface AttachPreviewOptions {
     machineId: string;
     channel: string;
     port: number;
+    key?: string;
     token?: string;
 }
 
@@ -89,10 +91,15 @@ export async function attachPreview(options: AttachPreviewOptions): Promise<null
     });
 
     const connections = new Map<number, Socket>();
+    const hostToClientKey = options.key === undefined ? undefined : deriveV2Key(options.key, 'host->client');
+    const clientToHostKey = options.key === undefined ? undefined : deriveV2Key(options.key, 'client->host');
 
     const send = (connId: number, flag: number, payload?: Uint8Array): void => {
         if (socket.readyState === WebSocket.OPEN) {
-            socket.send(encodePreviewFrame(connId, flag, payload));
+            const body = payload === undefined || hostToClientKey === undefined
+                ? payload
+                : sealPreviewPayload(payload, hostToClientKey);
+            socket.send(encodePreviewFrame(connId, flag, body));
         }
     };
 
@@ -130,7 +137,16 @@ export async function attachPreview(options: AttachPreviewOptions): Promise<null
                 send(frame.connId, PREVIEW_CLOSE);
             });
         }
-        if (frame.payload.length > 0) upstream.write(frame.payload);
+        if (frame.payload.length > 0) {
+            try {
+                upstream.write(clientToHostKey === undefined
+                    ? frame.payload
+                    : openPreviewPayload(frame.payload, clientToHostKey));
+            } catch {
+                drop(frame.connId);
+                send(frame.connId, PREVIEW_CLOSE);
+            }
+        }
     });
 
     // The relay closes this side when the device goes away. Without the sweep

--- a/apps/mobile/sources/preview/openPreview.ts
+++ b/apps/mobile/sources/preview/openPreview.ts
@@ -9,6 +9,7 @@
  * a listener -- is the only caller left on that path.
  */
 
+import { newPreviewKey } from '@muxr/crypto';
 import { issueWsTicket, newPreviewChannel, previewSocketUrl, ticketSocketUrl } from '@muxr/contract';
 import { getCachedConnectionSettings } from '@/state/connectionSettings';
 import { sync } from '@/sync/sync';
@@ -67,8 +68,10 @@ export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> 
     }
 
     const channel = newPreviewChannel();
-    // The host has to be on the channel before the relay will open a listener.
-    await sync.request('preview.attach', { channel, port });
+    const key = previewBridgeAvailable ? newPreviewKey() : undefined;
+    // The per-preview key crosses inside the existing E2EE request. The relay
+    // sees connection ids for multiplexing, never the frontend bytes.
+    await sync.request('preview.attach', { channel, port, ...(key === undefined ? {} : { key }) });
 
     const socketUrl = settings.token === '' || settings.token.startsWith('acctok_')
         ? previewSocketUrl(settings.relayUrl, {
@@ -91,7 +94,8 @@ export async function attachPreviewTunnel(port: number): Promise<PreviewTunnel> 
     if (previewBridgeAvailable) {
         socket.binaryType = 'arraybuffer';
         await waitForRelay(socket, 'preview.bridge');
-        const bridge = await startPreviewBridge(socket);
+        if (key === undefined) throw new Error('Encrypted preview key unavailable.');
+        const bridge = await startPreviewBridge(socket, key);
         return { hostname: '127.0.0.1', port: bridge.port, close: bridge.close };
     }
 

--- a/apps/mobile/sources/preview/previewBridge.ts
+++ b/apps/mobile/sources/preview/previewBridge.ts
@@ -10,6 +10,7 @@
  */
 
 import TcpSocket from 'react-native-tcp-socket';
+import { deriveV2Key, openPreviewPayload, sealPreviewPayload } from '@muxr/crypto';
 import { decodePreviewFrame, encodePreviewFrame, PREVIEW_CLOSE, PREVIEW_DATA } from '@muxr/contract';
 
 export interface PreviewBridge {
@@ -31,13 +32,16 @@ function toBytes(data: string | Buffer): Uint8Array {
     return bytes;
 }
 
-export async function startPreviewBridge(socket: WebSocket): Promise<PreviewBridge> {
+export async function startPreviewBridge(socket: WebSocket, key: string): Promise<PreviewBridge> {
+    const clientToHostKey = deriveV2Key(key, 'client->host');
+    const hostToClientKey = deriveV2Key(key, 'host->client');
     const connections = new Map<number, Connection>();
     let nextConnId = 0;
     let server: Server | undefined;
 
     const send = (connId: number, flag: number, payload?: Uint8Array): void => {
-        if (socket.readyState === WebSocket.OPEN) socket.send(encodePreviewFrame(connId, flag, payload));
+        const body = payload === undefined ? undefined : sealPreviewPayload(payload, clientToHostKey);
+        if (socket.readyState === WebSocket.OPEN) socket.send(encodePreviewFrame(connId, flag, body));
     };
 
     socket.onmessage = (event) => {
@@ -51,7 +55,15 @@ export async function startPreviewBridge(socket: WebSocket): Promise<PreviewBrid
             connection.destroy();
             return;
         }
-        if (frame.payload.length > 0) connection.write(Buffer.from(frame.payload));
+        if (frame.payload.length > 0) {
+            try {
+                connection.write(Buffer.from(openPreviewPayload(frame.payload, hostToClientKey)));
+            } catch {
+                connections.delete(frame.connId);
+                connection.destroy();
+                send(frame.connId, PREVIEW_CLOSE);
+            }
+        }
     };
 
     const close = (): void => {

--- a/apps/mobile/sources/preview/previewBridge.web.ts
+++ b/apps/mobile/sources/preview/previewBridge.web.ts
@@ -7,6 +7,6 @@ export interface PreviewBridge {
 
 export const previewBridgeAvailable = false;
 
-export function startPreviewBridge(_socket: WebSocket): Promise<PreviewBridge> {
+export function startPreviewBridge(_socket: WebSocket, _key: string): Promise<PreviewBridge> {
     return Promise.reject(new Error('Browser preview needs the muxr app on this platform.'));
 }

--- a/apps/relay/src/preview.ts
+++ b/apps/relay/src/preview.ts
@@ -7,8 +7,8 @@
  * preview at a root path is the point: absolute asset paths, HMR websockets and
  * redirects all work without rewriting a single byte.
  *
- * The relay does not parse HTTP here. It moves bytes and tags them with a
- * connection id, because a browser opens several TCP connections per page.
+ * The relay does not parse HTTP here. It reads only the connection id and flag
+ * needed to multiplex sockets; native E2EE payloads remain ciphertext.
  *
  * Deliberately off `routeEnvelope` and out of `PeerTable`: preview traffic is
  * bulk, so recording it would evict real session events from a replay log sized

--- a/apps/relay/src/relay.ts
+++ b/apps/relay/src/relay.ts
@@ -465,10 +465,6 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                     return;
                 }
                 const body = (await readJsonBody(req).catch(() => undefined)) as Record<string, unknown> | undefined;
-                if (body?.transport === 'preview' && config.e2eeMode === 'on') {
-                    writeJsonError(res, 400, 'preview is unavailable with E2EE on');
-                    return;
-                }
                 const role = body?.role;
                 const machineSlug = (typeof body?.machineSlug === 'string' ? body.machineSlug
                     : typeof body?.machineId === 'string' ? body.machineId
@@ -793,8 +789,9 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
             socket.close(1008, 'ticket scope mismatch');
             return;
         }
-        if (config.e2eeMode === 'on' && transport === 'preview') {
-            socket.close(1008, 'preview requires cleartext framing and is unavailable with E2EE on');
+        if (config.e2eeMode === 'on' && transport === 'preview'
+            && identity.role === 'client' && url.searchParams.get('bridge') !== '1') {
+            socket.close(1008, 'encrypted preview requires the native bridge');
             return;
         }
         const authenticatedSocket = { socket, identity };

--- a/docs/specs/index.html
+++ b/docs/specs/index.html
@@ -14,11 +14,12 @@
   <div class="kicker">muxr engineering</div>
   <h1>Specification board</h1>
   <p>Durable plans, implementation status, and verification evidence.</p>
-  <div class="legend"><span>◐ In progress 0</span><span>◑ Implemented 3</span><span>● Tested 1</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
-  <section class="group"><h2>In progress</h2><p class="empty">No specifications currently in progress.</p></section>
+  <div class="legend"><span>◐ In progress 1</span><span>◑ Implemented 2</span><span>● Tested 1</span><span>○ Planned 1</span><span>⊘ Archived 0</span></div>
+  <section class="group"><h2>In progress</h2>
+    <a class="row" href="plugin-primitives.html"><span class="pip"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-20</span></a>
+  </section>
   <section class="group"><h2>Implemented</h2>
     <a class="row" href="remote-relay-enrollment.html"><span class="pip implemented"></span><span class="title">Shared Remote Relay Enrollment</span><span class="date">2026-08-20</span></a>
-    <a class="row" href="plugin-primitives.html"><span class="pip implemented"></span><span class="title">Plugins on primitives</span><span class="date">2026-08-20</span></a>
     <a class="row" href="pi-parity-extension-phase.html"><span class="pip implemented"></span><span class="title">Pi-Parity Extension Phase</span><span class="date">2026-08-15</span></a>
   </section>
   <section class="group"><h2>Tested</h2>

--- a/docs/specs/plugin-primitives.html
+++ b/docs/specs/plugin-primitives.html
@@ -13,7 +13,7 @@
 <body><main>
   <div class="kicker">muxr spec</div>
   <h1>Plugins on primitives</h1>
-  <span class="badge" style="background:var(--amber)">implemented</span>
+  <span class="badge" style="background:var(--accent)">in-progress</span>
   <p class="meta">plugin-primitives.md · created 2026-08-15 · updated 2026-08-19 · umer</p>
   <p class="lead">Primitives, slots, actions, capabilities, and runtime contracts are the public platform. Inbox, Voice, Preview, Changes, Attachments, and future product features are plugins composed entirely from it.</p>
   <div class="card"><h2>Decision</h2><p>Enabled Herdr plugins remain trusted and default-on. Enabling or linking is the user's trust decision. Explicit disable and revoke remain authoritative. This rework strengthens the platform without adding per-device hash reapproval.</p></div>
@@ -31,7 +31,7 @@
     <li>Hard-kill stuck RPCs, isolate concurrency, and stop repeated full catalog reparsing.</li>
     <li>Publish schemas and prove bundled plus adversarial third-party plugins on Android.</li>
   </ol></div>
-  <div class="card"><h2>Latest revision</h2><p>Usage becomes one plain pill beside Machine and opens provider tabs directly. Preview filters raw listeners down to real HTML frontends for the session project, removes the redundant Run server action, and carries the active paired relay URL through preview attach.</p></div>
+  <div class="card"><h2>Latest revision</h2><p>Native Preview encrypts frontend bytes with a per-preview key delivered through the existing E2EE control channel. The relay may multiplex bounded connection headers but cannot read the HTTP, WebSocket, or stream payload.</p></div>
   <div class="card"><h2>Verification</h2><ul class="check">
     <li>Automation passes 29/29; all 12 bundled plugins and adversarial combinations validate correctly.</li>
     <li>The v11 manifest/tokenization flow, mobile typecheck, web export, and Android production JS bundle pass.</li>

--- a/docs/specs/plugin-primitives.md
+++ b/docs/specs/plugin-primitives.md
@@ -1,7 +1,7 @@
 ---
 title: Plugins on primitives
 slug: plugin-primitives
-status: implemented
+status: in-progress
 created: 2026-08-15
 updated: 2026-08-19
 owner: umer
@@ -86,6 +86,7 @@ UI version 12 allows generic `item-list` rows to omit actions for read-only stat
 
 ## Revisions
 
+- 2026-08-20 — Encrypt each native Preview TCP payload with a per-preview key delivered through the existing E2EE control channel, allowing the relay to multiplex connection headers without reading frontend bytes.
 - 2026-08-20 — Collapse Usage to one plain navigation pill beside Machine that opens the provider-tab details screen directly. Preview lists only real HTML frontends for the session project, removes the redundant Run server action, and carries the paired relay URL through preview attach.
 - 2026-08-19 — Remove optional Assistant App Actions capability metadata after Google Play continued rejecting the signed release despite owner acceptance of both terms surfaces. Keep the same public `shortcuts` contribution, localized launcher shortcut, deep link, and live enabled-catalog guard. The signed versionCode 8 bundle then passed Play ingestion, internal testing, and closed-test release validation.
 - 2026-08-18 — Browser grants now admit only explicitly read-mode RPCs from package-owned bundled plugin roots; omitted modes and third-party self-declarations fail closed. Read-only session opens no longer acknowledge global attention. Terminal link extraction is stateful, control-safe, canonical, credential-free, latest-first, and bounded across sessions.

--- a/packages/contract/src/preview.ts
+++ b/packages/contract/src/preview.ts
@@ -4,14 +4,14 @@ import { stripTrailingSlashes } from './controlPlaneUrl.js';
  * Browser preview: the wire format for tunnelling a dev server to the device.
  *
  * The device binds a local TCP listener and the host dials the dev server on its
- * own loopback; the bytes in between are forwarded verbatim. Nothing on the path
- * parses HTTP, which is why websockets, SSE and streaming responses survive it --
- * and why a dev server bound to 127.0.0.1 works without rebinding.
+ * own loopback. Native endpoints encrypt each payload before the relay forwards
+ * it; the relay reads only the connection id and flag needed to multiplex TCP.
+ * Nothing on the path parses HTTP, so WebSockets, SSE, and streams survive.
  *
  * A browser opens several TCP connections per page, so frames are multiplexed
  * over one socket and tagged with a connection id.
  *
- * Layout: connId (uint32 BE) | flag (uint8) | payload
+ * Layout: connId (uint32 BE) | flag (uint8) | payload (opaque ciphertext on native E2EE)
  */
 
 export const PREVIEW_DATA = 0;

--- a/packages/contract/src/requests.ts
+++ b/packages/contract/src/requests.ts
@@ -307,10 +307,11 @@ export interface RequestMap {
      */
     'preview.probe': { params: { port: number }; result: { contentType: string | null } };
     /**
-     * Ask the host to join `channel` and forward it to `port`. The caller opens
-     * the matching side itself; the relay pairs them.
+     * Ask the host to join `channel` and forward it to `port`. Native callers
+     * send a per-preview key through this encrypted request; local legacy web
+     * preview may omit it because the browser cannot decrypt a raw TCP listener.
      */
-    'preview.attach': { params: { channel: string; port: number }; result: null };
+    'preview.attach': { params: { channel: string; port: number; key?: string }; result: null };
 
     // --- worktrees ----------------------------------------------------------
     /**

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -109,6 +109,29 @@ export function openPairingCodePayload(payload: string, code: string): string {
     return decodeUtf8(opened);
 }
 
+/** Per-preview root delivered inside the existing encrypted control channel. */
+export function newPreviewKey(): string {
+    return toBase64(nacl.randomBytes(nacl.secretbox.keyLength));
+}
+
+/** Encrypt one TCP payload; connection ids and close flags remain relay-routable. */
+export function sealPreviewPayload(payload: Uint8Array, key: string): Uint8Array {
+    const nonce = nacl.randomBytes(nacl.secretbox.nonceLength);
+    const ciphertext = nacl.secretbox(payload, nonce, toKeyBytes(key, 'preview key'));
+    return concatBytes(nonce, ciphertext);
+}
+
+export function openPreviewPayload(payload: Uint8Array, key: string): Uint8Array {
+    if (payload.length <= nacl.secretbox.nonceLength) throw new Error('preview payload is malformed');
+    const opened = nacl.secretbox.open(
+        payload.subarray(nacl.secretbox.nonceLength),
+        payload.subarray(0, nacl.secretbox.nonceLength),
+        toKeyBytes(key, 'preview key'),
+    );
+    if (opened === null) throw new Error('preview payload failed authentication');
+    return opened;
+}
+
 /**
  * Precompute the shared key once per peer instead of per frame.
  * Returns base64 so callers can hold it as a plain string.

--- a/packages/crypto/src/selfCheck.ts
+++ b/packages/crypto/src/selfCheck.ts
@@ -13,12 +13,15 @@ import {
     generateSigningKeyPair,
     isEncryptedPayload,
     isV2Envelope,
+    newPreviewKey,
     newV2ReplayTracker,
     newV2SenderState,
     openPairingCodePayload,
+    openPreviewPayload,
     openV2,
     pairingCodeHash,
     sealPairingCodePayload,
+    sealPreviewPayload,
     sealV2,
     signDetached,
     v2ReplayFromSnapshot,
@@ -73,6 +76,15 @@ assert.ok(!pairingCiphertext.includes('high-entropy-secret'), 'relay-stored code
 assert.ok(!pairingCodeHash(pairingCode).includes('7KDM4'), 'relay lookup does not contain the human code');
 assert.equal(openPairingCodePayload(pairingCiphertext, pairingCode), pairingPayload, 'pairing code opens its payload');
 assert.throws(() => openPairingCodePayload(pairingCiphertext, '8KDM4-QXP7N'), /authentication/, 'wrong pairing code fails closed');
+
+const previewRoot = newPreviewKey();
+const previewClientKey = deriveV2Key(previewRoot, 'client->host');
+const previewHostKey = deriveV2Key(previewRoot, 'host->client');
+const previewPlaintext = new TextEncoder().encode('GET /private HTTP/1.1');
+const previewCiphertext = sealPreviewPayload(previewPlaintext, previewClientKey);
+assert.notDeepEqual(previewCiphertext, previewPlaintext, 'relay cannot read preview TCP bytes');
+assert.deepEqual(openPreviewPayload(previewCiphertext, previewClientKey), previewPlaintext, 'host opens client preview bytes');
+assert.throws(() => openPreviewPayload(previewCiphertext, previewHostKey), /authentication/, 'preview directions cannot be reflected');
 
 // --- v2 strict envelope (hosted) --------------------------------------------
 

--- a/scripts/checkPreviewTunnel.mjs
+++ b/scripts/checkPreviewTunnel.mjs
@@ -13,6 +13,7 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
+import { deriveV2Key, newPreviewKey, openPreviewPayload, sealPreviewPayload } from '@muxr/crypto';
 import { decodePreviewFrame, encodePreviewFrame, PREVIEW_DATA } from '@muxr/contract';
 
 // A frame must survive a round trip with its payload byte-identical.
@@ -98,6 +99,9 @@ const send = (frame) => {
 
 const CHANNEL = 'check-channel-1';
 const BRIDGE_CHANNEL = 'check-channel-2';
+const BRIDGE_KEY = newPreviewKey();
+const BRIDGE_CLIENT_KEY = deriveV2Key(BRIDGE_KEY, 'client->host');
+const BRIDGE_HOST_KEY = deriveV2Key(BRIDGE_KEY, 'host->client');
 
 session.on('open', () => send({ type: 'preview.probe', requestId: 'p1', params: { port: devPort } }));
 
@@ -134,7 +138,7 @@ const bridgeAttached = new Promise((resolve) => { bridgeResolve = resolve; });
  * the preview works against a relay published only on 443.
  */
 async function runBridge() {
-    send({ type: 'preview.attach', requestId: 'p3', params: { channel: BRIDGE_CHANNEL, port: devPort } });
+    send({ type: 'preview.attach', requestId: 'p3', params: { channel: BRIDGE_CHANNEL, port: devPort, key: BRIDGE_KEY } });
     await bridgeAttached;
 
     const control = new WebSocket(`${RELAY}/preview?role=client&machineId=${MACHINE}&channel=${BRIDGE_CHANNEL}&bridge=1`);
@@ -151,7 +155,7 @@ async function runBridge() {
             const frame = decodePreviewFrame(new Uint8Array(raw));
             const socket = connections.get(frame.connId);
             if (socket === undefined) return;
-            if (frame.payload.length > 0) socket.write(Buffer.from(frame.payload));
+            if (frame.payload.length > 0) socket.write(Buffer.from(openPreviewPayload(frame.payload, BRIDGE_HOST_KEY)));
         });
         setTimeout(() => reject(new Error('relay never paired the bridge')), 10000);
     });
@@ -160,7 +164,7 @@ async function runBridge() {
         nextConnId += 1;
         const connId = nextConnId;
         connections.set(connId, socket);
-        socket.on('data', (chunk) => control.send(encodePreviewFrame(connId, PREVIEW_DATA, new Uint8Array(chunk)), { binary: true }));
+        socket.on('data', (chunk) => control.send(encodePreviewFrame(connId, PREVIEW_DATA, sealPreviewPayload(new Uint8Array(chunk), BRIDGE_CLIENT_KEY)), { binary: true }));
         socket.on('close', () => connections.delete(connId));
     });
     await new Promise((resolve) => local.listen(0, '127.0.0.1', resolve));


### PR DESCRIPTION
## Fix
Native Preview was still blanket-rejected by the E2EE relay. This adds a per-preview root sent through the existing encrypted control request, derives separate host/client direction keys, and encrypts every TCP payload while leaving only connection ids and close flags relay-routable. Hosted hosts reject old clear-preview clients; relay-side TCP listeners remain unavailable under E2EE.

## Verification
- full suite 30/30
- crypto self-check proves ciphertext, authentication, and reflection rejection
- preview tunnel flow proves encrypted device bridge plus HTTP body round-trip