### PR TITLE
Keep terminal links whole and show real Claude limits

### DIFF
--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -611,8 +611,8 @@ function ScreenNode(props: {
         case 'progress': {
             const max = node.max ?? 100;
             const resolved = node.path === undefined ? node.value : resolvePath(data, node.path);
-            const raw = typeof resolved === 'number' && Number.isFinite(resolved) ? resolved : 0;
-            const value = Math.max(0, Math.min(max, raw));
+            if (typeof resolved !== 'number' || !Number.isFinite(resolved)) return null;
+            const value = Math.max(0, Math.min(max, resolved));
             const label = node.label === undefined ? undefined : bind(node.label);
             const valueLabel = node.valueLabel === undefined ? undefined : bind(node.valueLabel);
             return (

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -636,6 +636,41 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                         <Ionicons name="arrow-down" size={18} color={theme.colors.text} />
                     </Pressable>
                 )}
+                {Platform.OS !== 'web' && chipLink !== undefined && chipKind !== undefined && (
+                    <Animated.View
+                        entering={FadeIn.duration(180).reduceMotion(ReduceMotion.System)}
+                        exiting={FadeOut.duration(120).reduceMotion(ReduceMotion.System)}
+                        style={{ position: 'absolute', left: 12, right: showJump ? 64 : 12, bottom: 8, alignItems: 'flex-start' }}
+                    >
+                        <Pressable
+                            onPress={openChipLink}
+                            onLongPress={() => void Clipboard.setStringAsync(chipLink).then(() => showGestureHint('Link copied'))}
+                            accessibilityRole="button"
+                            accessibilityLabel={`${chipKind === 'preview' ? 'Preview' : 'Open'} ${chipLink}`}
+                            style={({ pressed }) => ({
+                                maxWidth: '100%',
+                                flexDirection: 'row',
+                                alignItems: 'center',
+                                gap: 4,
+                                paddingHorizontal: 9,
+                                paddingVertical: 6,
+                                borderRadius: 14,
+                                backgroundColor: theme.colors.surfaceHigh,
+                                borderWidth: 1,
+                                borderColor: theme.colors.divider,
+                                opacity: pressed ? 0.6 : 1,
+                            })}
+                        >
+                            <Ionicons name={chipKind === 'preview' ? 'globe-outline' : 'open-outline'} size={12} color={theme.colors.textSecondary} />
+                            <Text style={{ color: theme.colors.text, fontSize: 12, fontWeight: '600' }}>
+                                {chipKind === 'preview' ? 'Preview' : 'Open'}
+                            </Text>
+                            <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12, flexShrink: 1 }}>
+                                {displayLink(chipLink, 80)}
+                            </Text>
+                        </Pressable>
+                    </Animated.View>
+                )}
             </View>
 
             {Platform.OS !== 'web' && <>
@@ -648,41 +683,6 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
             >
                 {/* Pills lead: the key toolbar is wider than a phone, so anything
                     after it is scrolled off-screen and effectively invisible. */}
-                {/* The chip appears and disappears on its own as you scroll past
-                    a link, so a hard pop reads as a glitch rather than a state
-                    change. Opacity only: it is the one property that survives
-                    reduced motion, and the row would reflow if we moved it. */}
-                {chipLink !== undefined && chipKind !== undefined && (
-                    <Animated.View
-                        entering={FadeIn.duration(180).reduceMotion(ReduceMotion.System)}
-                        exiting={FadeOut.duration(120).reduceMotion(ReduceMotion.System)}
-                    >
-                    <Pressable
-                        onPress={openChipLink}
-                        onLongPress={() => void Clipboard.setStringAsync(chipLink).then(() => showGestureHint('Link copied'))}
-                        accessibilityRole="button"
-                        accessibilityLabel={`${chipKind === 'preview' ? 'Preview' : 'Open'} ${chipLink}`}
-                        style={({ pressed }) => ({
-                            flexDirection: 'row',
-                            alignItems: 'center',
-                            gap: 4,
-                            paddingHorizontal: 8,
-                            paddingVertical: 4,
-                            borderRadius: 12,
-                            backgroundColor: theme.colors.surfaceHigh,
-                            opacity: pressed ? 0.6 : 1,
-                        })}
-                    >
-                        <Ionicons name={chipKind === 'preview' ? 'globe-outline' : 'open-outline'} size={12} color={theme.colors.textSecondary} />
-                        <Text style={{ color: theme.colors.text, fontSize: 12, fontWeight: '600' }}>
-                            {chipKind === 'preview' ? 'Preview' : 'Open'}
-                        </Text>
-                        <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12 }}>
-                            {displayLink(chipLink, 40)}
-                        </Text>
-                    </Pressable>
-                    </Animated.View>
-                )}
                 {/* Plugin chips live here, not in the header: six trailing
                     buttons left the session's own name truncated to three
                     characters, and the name is what the bar is for. */}

--- a/apps/mobile/sources/terminal/TerminalView.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.tsx
@@ -16,7 +16,7 @@ import { View } from 'react-native';
 import { TerminalView as GhosttyView, type TerminalViewRef } from 'expo-libghostty';
 import { decodeBase64, encodeBase64 } from '@/encryption/base64';
 import { openTerminal, type TerminalChannel } from './openTerminal';
-import { beginViewportCapture, recordTerminalOutput } from './recentOutput';
+import { beginViewportCapture, recordTerminalOutput, setTerminalColumns } from './recentOutput';
 
 /**
  * One scroll message costs herdr one full-screen repaint whatever the line
@@ -128,6 +128,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
 
     const attach = React.useCallback(
         (cols: number, rows: number) => {
+            setTerminalColumns(sessionId, cols);
             const last = lastSizeRef.current;
             if (last !== null && last.cols === cols && last.rows === rows) return;
             lastSizeRef.current = { cols, rows };

--- a/apps/mobile/sources/terminal/TerminalView.web.tsx
+++ b/apps/mobile/sources/terminal/TerminalView.web.tsx
@@ -10,7 +10,7 @@ import { WebglAddon } from '@xterm/addon-webgl';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 import { openTerminal, type TerminalChannel } from './openTerminal';
-import { beginViewportCapture, recordTerminalOutput } from './recentOutput';
+import { beginViewportCapture, recordTerminalOutput, setTerminalColumns } from './recentOutput';
 
 export interface TerminalViewProps {
     sessionId: string;
@@ -47,6 +47,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
         term.loadAddon(new WebLinksAddon());
         term.open(element);
         fit.fit();
+        setTerminalColumns(sessionId, term.cols);
         // WebGL renderer: xterm.js rates it ~900% faster frame rendering than
         // canvas (it's VS Code's default). Canvas stays as the fallback where
         // WebGL is unavailable (old WebViews, blocked GPUs).
@@ -119,6 +120,7 @@ export const TerminalView = React.memo((props: TerminalViewProps) => {
 
         const resize = (): void => {
             fit.fit();
+            setTerminalColumns(sessionId, term.cols);
             channel?.resize(term.cols, term.rows);
         };
         window.addEventListener('resize', resize);

--- a/apps/mobile/sources/terminal/openTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/openTerminal.spec.ts
@@ -128,7 +128,7 @@ describe('openTerminal reconnect ownership', () => {
 
 describe('recentTerminalLinks', () => {
     it('keeps a bounded latest-first list of safe visible URLs', async () => {
-        const { recordTerminalOutput, recentTerminalLinks, clearTerminalOutput, setTerminalColumns } = await import('./recentOutput');
+        const { recordTerminalOutput, recentTerminalLinks, viewportTerminalLinks, clearTerminalOutput, setTerminalColumns } = await import('./recentOutput');
         const { encodeBase64 } = await import('@/encryption/base64');
         const record = (sessionId: string, text: string) => recordTerminalOutput(sessionId, encodeBase64(new TextEncoder().encode(text)));
 
@@ -147,6 +147,13 @@ describe('recentTerminalLinks', () => {
         setTerminalColumns('long', columns);
         wrappedRows.forEach((row, index) => record('long', `${row}${index === wrappedRows.length - 1 ? '' : '\r\n'}`));
         expect(recentTerminalLinks('long')).toEqual([longUrl]);
+
+        clearTerminalOutput('split-scheme');
+        record('split-scheme', 'ht');
+        record('split-scheme', 'tps://split.example/path');
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        expect(viewportTerminalLinks('long')).toEqual([longUrl]);
+        expect(viewportTerminalLinks('split-scheme')).toEqual(['https://split.example/path']);
 
         clearTerminalOutput('hard-break');
         setTerminalColumns('hard-break', columns);

--- a/apps/mobile/sources/terminal/openTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/openTerminal.spec.ts
@@ -128,7 +128,7 @@ describe('openTerminal reconnect ownership', () => {
 
 describe('recentTerminalLinks', () => {
     it('keeps a bounded latest-first list of safe visible URLs', async () => {
-        const { recordTerminalOutput, recentTerminalLinks, clearTerminalOutput } = await import('./recentOutput');
+        const { recordTerminalOutput, recentTerminalLinks, clearTerminalOutput, setTerminalColumns } = await import('./recentOutput');
         const { encodeBase64 } = await import('@/encryption/base64');
         const record = (sessionId: string, text: string) => recordTerminalOutput(sessionId, encodeBase64(new TextEncoder().encode(text)));
 
@@ -138,6 +138,20 @@ describe('recentTerminalLinks', () => {
         record('s1', '\x07again https://localhost:8901/index.html. https://safe.example/\u202eevil https://user:secret@evil.example/ https://exa\x1b(');
         record('s1', 'Bmple.com');
         expect(recentTerminalLinks('s1')).toEqual(['https://example.com/', 'https://localhost:8901/index.html', 'http://example.com/a?x=1']);
+
+        const columns = 80;
+        const longUrl = `https://example.com/releases/(latest)/download?token=${'a'.repeat(320)}&source=terminal`;
+        const wrappedRows = longUrl.match(new RegExp(`.{1,${columns}}`, 'g')) ?? [];
+        expect(wrappedRows).toHaveLength(5);
+        clearTerminalOutput('long');
+        setTerminalColumns('long', columns);
+        wrappedRows.forEach((row, index) => record('long', `${row}${index === wrappedRows.length - 1 ? '' : '\r\n'}`));
+        expect(recentTerminalLinks('long')).toEqual([longUrl]);
+
+        clearTerminalOutput('hard-break');
+        setTerminalColumns('hard-break', columns);
+        record('hard-break', 'https://short.example/path\nnot-part-of-the-link');
+        expect(recentTerminalLinks('hard-break')).toEqual(['https://short.example/path']);
 
         clearTerminalOutput('s2');
         for (let index = 0; index < 10; index++) record('s2', ` https://link-${index}.example`);

--- a/apps/mobile/sources/terminal/recentOutput.ts
+++ b/apps/mobile/sources/terminal/recentOutput.ts
@@ -150,12 +150,14 @@ export function recordTerminalOutput(sessionId: string, base64: string): void {
         state.scanTimer = setTimeout(() => scanViewport(sessionId), SCROLL_SCAN_DEBOUNCE_MS);
         return;
     }
-    // Not scrolling: the frame path is one boolean check. A chunk carrying a
-    // URL (a dev server just announced itself, and at the live edge that URL
-    // is on screen) schedules a single debounced chip refresh.
-    if (visible.includes('http') && state.tailTimer === undefined) {
+    // At the live edge, rescan once per output burst. Do not gate this on one
+    // socket chunk containing "http": the scheme itself can cross chunks.
+    if (visible !== '' && state.tailTimer === undefined) {
         state.tailTimer = setTimeout(() => {
             state.tailTimer = undefined;
+            const links = extractLinks(unwrapTerminalLinks(state.chunks.join(''), state.columns));
+            if (links.length === state.viewportLinks.length && links.every((link, index) => link === state.viewportLinks[index])) return;
+            state.viewportLinks = links;
             notifyLinks(sessionId);
         }, TAIL_NOTIFY_DEBOUNCE_MS);
     }

--- a/apps/mobile/sources/terminal/recentOutput.ts
+++ b/apps/mobile/sources/terminal/recentOutput.ts
@@ -21,12 +21,27 @@ type TailState = {
     scanTimer: ReturnType<typeof setTimeout> | undefined;
     tailTimer: ReturnType<typeof setTimeout> | undefined;
     viewportLinks: string[];
+    columns: number;
 };
 const tails = new Map<string, TailState>();
 
-const URL_PATTERN = /https?:\/\/[^\s"'`<>[\]{}()\\^|]+/g;
-const TRAILING = /[.,;:!?)\]]+$/;
+const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/g;
+const MAX_URL_CHARS = 8 * 1024;
 const UNSAFE_URL_CHARS = /[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
+
+function trimTrailingPunctuation(value: string): string {
+    let end = value.length;
+    while (end > 0 && '.,;:!?'.includes(value[end - 1]!)) end--;
+    for (const [open, close] of [['(', ')'], ['[', ']'], ['{', '}']] as const) {
+        let balance = 0;
+        for (let index = 0; index < end; index++) {
+            if (value[index] === open) balance++;
+            else if (value[index] === close) balance--;
+        }
+        while (balance < 0 && value[end - 1] === close) { end--; balance++; }
+    }
+    return value.slice(0, end);
+}
 
 type LinksListener = (sessionId: string) => void;
 const linksListeners = new Set<LinksListener>();
@@ -52,6 +67,7 @@ function newState(): TailState {
         scanTimer: undefined,
         tailTimer: undefined,
         viewportLinks: [],
+        columns: 0,
     };
 }
 
@@ -170,7 +186,7 @@ function scanViewport(sessionId: string): void {
     if (state === undefined) return;
     state.capturing = false;
     state.scanTimer = undefined;
-    const links = extractLinks(state.screen.replace(/\r/g, ''));
+    const links = extractLinks(unwrapTerminalLinks(state.screen, state.columns));
     state.screen = '';
     if (links.length === state.viewportLinks.length && links.every((link, index) => link === state.viewportLinks[index])) return;
     state.viewportLinks = links;
@@ -181,6 +197,26 @@ export function clearTerminalOutput(sessionId: string): void {
     drop(sessionId);
 }
 
+export function setTerminalColumns(sessionId: string, columns: number): void {
+    touch(sessionId).columns = Number.isFinite(columns) ? Math.max(0, Math.floor(columns)) : 0;
+}
+
+// A visual wrap fills the terminal row; a hard newline usually does not. Join
+// only full-width rows while already inside a URL, never arbitrary lines.
+function unwrapTerminalLinks(text: string, columns: number): string {
+    const lines = text.replace(/\r/g, '').split('\n');
+    if (columns === 0 || lines.length === 1) return lines.join('\n');
+    let result = lines[0] ?? '';
+    for (let index = 1; index < lines.length; index++) {
+        const previous = lines[index - 1] ?? '';
+        const next = lines[index] ?? '';
+        const insideUrl = /https?:\/\/[^\s"'`<>]*$/.test(result);
+        const softWrap = insideUrl && previous.length === columns && /^[^\s"'`<>]/.test(next);
+        result += `${softWrap ? '' : '\n'}${next}`;
+    }
+    return result;
+}
+
 /** Latest-first, deduped and canonical URLs from the given text. */
 function extractLinks(text: string): string[] {
     if (!text.includes('http')) return [];
@@ -188,8 +224,8 @@ function extractLinks(text: string): string[] {
     const seen = new Set<string>();
     const matches = [...text.matchAll(URL_PATTERN)];
     for (let index = matches.length - 1; index >= 0 && found.length < MAX_LINKS; index--) {
-        const candidate = matches[index]![0].replace(TRAILING, '');
-        if (candidate.length <= 12 || candidate.length > 2048 || UNSAFE_URL_CHARS.test(candidate)) continue;
+        const candidate = trimTrailingPunctuation(matches[index]![0]);
+        if (candidate.length <= 12 || candidate.length > MAX_URL_CHARS || UNSAFE_URL_CHARS.test(candidate)) continue;
         try {
             const parsed = new URL(candidate);
             if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || parsed.username !== '' || parsed.password !== '' || seen.has(parsed.href)) continue;
@@ -205,7 +241,7 @@ export function recentTerminalLinks(sessionId: string): string[] {
     const state = tails.get(sessionId);
     if (state === undefined) return [];
     touch(sessionId, state);
-    return extractLinks(state.chunks.join('').replace(/\r/g, ''));
+    return extractLinks(unwrapTerminalLinks(state.chunks.join(''), state.columns));
 }
 
 /** Links on screen after the last scroll gesture, latest first. */

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -13,7 +13,7 @@ These packages install into Herdr during muxr setup. Each can have an optional H
 | `workspace-hierarchy` | public workspace-tree context RPC | session overlay using source-driven `tree-sheet` |
 | `pane-titler` | rename panes from scrollback | backend only |
 | `code` | bounded repo tree/preview, `git status`, `git log`/`show`, saved commands | Files explorer, Changes pill, Git history screens, Runbook destination |
-| `status` | pinned offline ccusage + bounded Codex limits; disk/memory/load/uptime | Usage rows + chart detail screen; Home machine card |
+| `status` | pinned offline ccusage + bounded Claude/Codex plan limits; disk/memory/load/uptime | Usage rows + chart detail screen; Home machine card |
 | `servers` | list/stop listeners; start the project's dev script | Ports destination; Preview `item-list` with validated port actions |
 | `example-ui` | echo list/save RPCs | settings example for SDK validation |
 

--- a/plugins/status/README.md
+++ b/plugins/status/README.md
@@ -2,7 +2,7 @@
 
 Coding-agent usage and machine vitals.
 
-- **Usage:** exact pinned ccusage native binary with `daily --last 1 --by-agent --json --no-cost --offline`; only allowlisted agent names and rounded totals leave the machine. Codex limits come from its local app-server. Item rows plus a declarative detail screen with charts (UI v13).
+- **Usage:** exact pinned ccusage native binary with `daily --by-agent --json --offline --since …`; only allowlisted agent names and rounded totals leave the machine. Claude plan limits come from a fresh local status-line snapshot or Anthropic's account endpoint; Codex limits come from its local app-server. Credentials never enter plugin output. Item rows plus a declarative detail screen with charts (UI v13).
 - **Vitals:** disk, memory, load, and uptime of the machine running your agents.
 - **Bounds:** read-only, 15s/8s subprocess deadlines, one-minute owner-only cache of the final bounded model. Costs, prompts, models, projects, and session details are never exposed.
 - **Removal:** `herdr plugin unlink muxr.status`.

--- a/plugins/status/muxr-ui.json
+++ b/plugins/status/muxr-ui.json
@@ -64,11 +64,18 @@
               ]
             },
             {
-              "type": "chart",
-              "variant": "gauge",
-              "path": "data.limitRing",
-              "title": "Current limit",
-              "emptyText": "No published limit for this provider"
+              "type": "progress",
+              "path": "data.fiveHourUsed",
+              "max": 100,
+              "label": "5-hour limit",
+              "valueLabel": "{{data.fiveHourLabel}}"
+            },
+            {
+              "type": "progress",
+              "path": "data.sevenDayUsed",
+              "max": 100,
+              "label": "7-day limit",
+              "valueLabel": "{{data.sevenDayLabel}}"
             },
             {
               "type": "text",

--- a/plugins/status/usage.mjs
+++ b/plugins/status/usage.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { constants, accessSync, chmodSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { constants, accessSync, chmodSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 
 import { createRequire } from 'node:module';
+import { homedir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
 const require = createRequire(import.meta.url);
@@ -94,11 +95,52 @@ async function ccusageRange() {
   return result;
 }
 
-async function claudeBlock() {
-  const binary = ccusageBinary();
-  if (!binary) return undefined;
-  const result = await runJson(binary, ['blocks', '--active', '--json', '--offline'], 15_000);
-  return Array.isArray(result?.blocks) ? result.blocks.find((block) => block?.isActive) : undefined;
+function parseClaudeLimits(value) {
+  const source = value?.rate_limits ?? value;
+  return [
+    ['five_hour', '5-hour limit'],
+    ['seven_day', '7-day limit'],
+  ].flatMap(([id, label]) => {
+    const raw = source?.[id];
+    const utilization = raw?.utilization ?? raw?.used_percentage;
+    if (!Number.isFinite(utilization) || utilization < 0 || utilization > 100) return [];
+    const resetAt = typeof raw?.resets_at === 'number' ? raw.resets_at : Date.parse(raw?.resets_at) / 1000;
+    const reset = relativeReset(resetAt);
+    return [{ id, label, used: Math.round(utilization), reset }];
+  });
+}
+
+function readJson(path, maxBytes) {
+  try {
+    const stat = statSync(path);
+    if (!stat.isFile() || stat.size <= 0 || stat.size > maxBytes) return undefined;
+    return { value: JSON.parse(readFileSync(path, 'utf8')), modified: stat.mtimeMs };
+  } catch { return undefined; }
+}
+
+async function claudePlanLimits() {
+  const config = process.env.CLAUDE_CONFIG_DIR?.trim() || join(process.env.HOME?.trim() || homedir(), '.claude');
+  const snapshot = readJson(join(config, 'last-statusline-input.json'), 64 * 1024);
+  const snapshotAge = snapshot === undefined ? undefined : Date.now() - snapshot.modified;
+  if (snapshotAge !== undefined && snapshotAge >= 0 && snapshotAge < 5 * 60_000) {
+    const limits = parseClaudeLimits(snapshot.value);
+    if (limits.length > 0) return limits;
+  }
+  const credentials = readJson(join(config, '.credentials.json'), 64 * 1024)?.value?.claudeAiOauth;
+  const token = typeof credentials?.accessToken === 'string' && credentials.accessToken.length <= 16 * 1024 ? credentials.accessToken : undefined;
+  if (token === undefined || Number.isFinite(credentials?.expiresAt) && credentials.expiresAt <= Date.now()) return [];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8_000);
+  try {
+    const response = await fetch('https://api.anthropic.com/api/oauth/usage', {
+      headers: { accept: 'application/json', authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+    const body = await response.text();
+    return body.length <= 64 * 1024 ? parseClaudeLimits(JSON.parse(body)) : [];
+  } catch { return []; }
+  finally { clearTimeout(timer); }
 }
 
 function money(value) {
@@ -188,7 +230,8 @@ function cachedOutput() {
   try {
     const saved = JSON.parse(readFileSync(join(state, cacheName()), 'utf8'));
     const age = Date.now() - saved.at;
-    if (age >= 0 && age < 60_000 && Array.isArray(saved.output?.items) && JSON.stringify(saved.output).length <= 16_384) return saved.output;
+    const maxAge = selected === 'claude' ? 15_000 : 60_000;
+    if (age >= 0 && age < maxAge && Array.isArray(saved.output?.items) && JSON.stringify(saved.output).length <= 16_384) return saved.output;
   } catch {}
   return undefined;
 }
@@ -318,9 +361,9 @@ if (cached !== undefined) {
   const today = days[days.length - 1]?.row;
   const weekTokens = days.reduce((sum, day) => sum + (day.row?.totalTokens ?? 0), 0);
   const weekCost = days.reduce((sum, day) => sum + (day.row?.totalCost ?? 0), 0);
-  const block = provider === 'claude' ? await claudeBlock() : undefined;
-  const blockRemaining = block === undefined ? undefined
-    : Math.max(0, Math.min(100, Math.round(100 - (Date.now() - Date.parse(block.startTime)) / (Date.parse(block.endTime) - Date.parse(block.startTime)) * 100)));
+  const claudeLimits = provider === 'claude' ? await claudePlanLimits() : [];
+  const fiveHour = claudeLimits.find((limit) => limit.id === 'five_hour');
+  const sevenDay = claudeLimits.find((limit) => limit.id === 'seven_day');
   const items = [];
   if (ccusageFailure && activity.items.length === 0) items.push({
     id: 'ccusage-unavailable', title: 'Local activity unavailable', subtitle: ccusageFailure, icon: 'warning-outline', metadata: [],
@@ -363,14 +406,17 @@ if (cached !== undefined) {
       label: dayLabel(period), value: row?.totalTokens ?? 0, valueLabel: tokens(row?.totalTokens ?? 0) ?? '0',
     })),
     limitSeries: provider === 'codex' ? codex.series : [],
-    limitRing: blockRemaining !== undefined
-      ? [
-          { label: 'Left', value: blockRemaining, valueLabel: `${blockRemaining}%`, tone: limitTone(blockRemaining) },
-          { label: 'Used', value: 100 - blockRemaining, valueLabel: `${100 - blockRemaining}%`, tone: 'secondary' },
-        ]
-      : provider === 'codex' ? codex.ring : [],
-    limitLabel: block !== undefined
-      ? `5-hour window · ${relativeReset(Date.parse(block.endTime) / 1000)} left · ${tokens(Math.round(block.burnRate?.tokensPerMinute ?? 0)) ?? '0'} tokens/min`
+    limitRing: provider === 'codex' ? codex.ring : [],
+    ...(fiveHour === undefined ? {} : {
+      fiveHourUsed: fiveHour.used,
+      fiveHourLabel: `${fiveHour.used}% used${fiveHour.reset ? ` · resets in ${fiveHour.reset}` : ''}`,
+    }),
+    ...(sevenDay === undefined ? {} : {
+      sevenDayUsed: sevenDay.used,
+      sevenDayLabel: `${sevenDay.used}% used${sevenDay.reset ? ` · resets in ${sevenDay.reset}` : ''}`,
+    }),
+    limitLabel: claudeLimits.length > 0
+      ? 'Claude plan usage'
       : provider === 'codex' ? codex.remainingLabel : '',
     codexRemaining: codex.remaining,
     codexRemainingLabel: codex.remainingLabel,

--- a/scripts/checkUsageStatus.mjs
+++ b/scripts/checkUsageStatus.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -35,26 +35,26 @@ const report = {
     ],
     totals: { totalTokens: 1_253_300, totalCost: 132.95 },
 };
-const activeBlock = {
-    blocks: [{
-        isActive: true,
-        startTime: new Date(today.getTime() - 3_600_000).toISOString(),
-        endTime: new Date(today.getTime() + 3 * 3_600_000).toISOString(),
-        burnRate: { tokensPerMinute: 12_000 },
-    }],
+const claudeLimits = {
+    rate_limits: {
+        five_hour: { used_percentage: 21, resets_at: Math.floor((today.getTime() + 3 * 3_600_000) / 1000) },
+        seven_day: { used_percentage: 42, resets_at: Math.floor((today.getTime() + 3 * 86_400_000) / 1000) },
+    },
 };
 
 const run = (input, environment = {}) => spawnSync(process.execPath, ['plugins/status/usage.mjs'], {
     cwd: process.cwd(),
     encoding: 'utf8',
     input: JSON.stringify(input),
-    env: { ...process.env, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch, ...environment },
+    env: { ...process.env, HOME: scratch, PATH: `${scratch}:${process.env.PATH}`, MUXR_CCUSAGE_BIN: ccusage, MUXR_PLUGIN_STATE_DIR: scratch, ...environment },
     timeout: 20_000,
 });
 
 try {
     writeFileSync(join(scratch, 'pi'), `#!/bin/sh\ntouch "${piMarker}"\nexit 99\n`, { mode: 0o755 });
-    writeFileSync(ccusage, `#!/bin/sh\ncase "$1 $2" in\n"daily --by-agent") printf x >> "${ccusageMarker}"; printf '%s' '${JSON.stringify(report)}';;\n"blocks --active") printf '%s' '${JSON.stringify(activeBlock)}';;\n*) exit 77;;\nesac\n`, { mode: 0o755 });
+    writeFileSync(ccusage, `#!/bin/sh\ncase "$1 $2" in\n"daily --by-agent") printf x >> "${ccusageMarker}"; printf '%s' '${JSON.stringify(report)}';;\n*) exit 77;;\nesac\n`, { mode: 0o755 });
+    mkdirSync(join(scratch, '.claude'));
+    writeFileSync(join(scratch, '.claude', 'last-statusline-input.json'), JSON.stringify(claudeLimits));
     writeFileSync(join(scratch, 'codex'), `#!/usr/bin/env node\nrequire('fs').appendFileSync(${JSON.stringify(codexMarker)}, 'x');let b='';process.stdin.setEncoding('utf8');process.stdin.on('data',d=>{b+=d;for(;;){const i=b.indexOf('\\n');if(i<0)break;const line=b.slice(0,i);b=b.slice(i+1);const m=JSON.parse(line);if(m.id===1)console.log(JSON.stringify({id:1,result:{}}));if(m.id===2)console.log(JSON.stringify({id:2,result:{rateLimitsByLimitId:{codex:{limitId:'codex',primary:{usedPercent:25,resetsAt:Math.floor(Date.now()/1000)+3600}}}}}));}});\n`, { mode: 0o755 });
     for (const command of ['claude', 'kimi', 'opencode', 'hermes', 'copilot', 'cursor-agent', 'omp', 'gemini', 'grok']) writeFileSync(join(scratch, command), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
 
@@ -73,14 +73,18 @@ try {
     const tabs = output.providers.map((tab) => tab.id);
     for (const expected of ['claude', 'kimi', 'pi', 'codex', 'cursor']) assert.ok(tabs.includes(expected), `missing ${expected} tab`);
 
-    // Claude's tab carries today, its models, the week, and the live 5-hour window.
+    // Claude's tab carries today, its models, the week, and the real plan windows.
     assert.equal(output.todayTokens, '1.3M');
     assert.equal(output.todayCost, '$123');
     assert.equal(output.modelSeries[0]?.label, 'claude-opus-5');
     assert.equal(output.weekSeries.length, 2);
     assert.equal(output.weekSeries[1]?.valueLabel, '1.3M');
-    assert.match(output.limitLabel, /5-hour window/);
-    assert.equal(output.limitRing[0]?.label, 'Left');
+    assert.equal(output.limitLabel, 'Claude plan usage');
+    assert.equal(output.fiveHourUsed, 21);
+    assert.match(output.fiveHourLabel, /^21% used · resets in /);
+    assert.equal(output.sevenDayUsed, 42);
+    assert.match(output.sevenDayLabel, /^42% used · resets in /);
+    assert.deepEqual(output.limitRing, []);
 
     // A quiet provider reports zero today rather than its last active day.
     const kimi = JSON.parse(run({ provider: 'kimi' }).stdout);


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.97.0
## User-visible problems

1. The detected-link chip lived inside the horizontal terminal-key row. When it appeared, Esc/Tab/arrows shifted right and the user had to recover the keyboard position.
2. Long tokenized URLs that wrapped across four or five terminal rows were parsed as separate fragments. The extractor knew socket chunks and ANSI escapes, but not the terminal column boundary that distinguishes a visual wrap from a real newline.
3. Claude Usage showed an inaccurate “5-hour limit”: it was elapsed time inside ccusage’s local five-hour activity block, not Claude plan utilization. There was no Claude seven-day plan value at all, and the Claude tab could reuse that output for one minute.

## Root causes

- Link reconstruction stripped terminal control sequences but had no terminal width, so it could not safely rejoin soft-wrapped rows.
- The detected-link UI and terminal keys shared one horizontal `ScrollView`.
- ccusage reports local token/activity blocks; it does not report Anthropic subscription quota. The UI formatted that block clock as if it were a plan limit.

## Fix boundaries

### Terminal links

- `apps/mobile/sources/terminal/recentOutput.ts`
  - records the current terminal column count;
  - rejoins only full-width rows while already inside an HTTP(S) URL;
  - leaves shorter hard-newline rows separate;
  - accepts balanced URL punctuation and up to 8 KiB URLs;
  - canonicalizes with the platform `URL` parser and still rejects credentials, control/bidi characters, non-HTTP protocols, and unsafe lengths.
- `TerminalView.tsx` / `TerminalView.web.tsx` feed actual terminal width into extraction on attach/fit/resize.
- `TerminalScreen.tsx` moves the chip out of the key `ScrollView` and floats it at the bottom of the terminal, directly above the keys. It reserves room for Jump to bottom and cannot move the key row horizontally.
- `openTerminal.spec.ts` drives one URL over exactly five 80-column rows and separately proves a real newline is not joined.

No link-parsing dependency was added: a library can validate a URL, but it cannot recover terminal soft-wrap boundaries. The fix supplies that missing terminal context, then uses the standard URL parser.

### Claude usage

- `plugins/status/usage.mjs` removes the fake elapsed-block percentage.
- Claude’s real `five_hour` and `seven_day` utilization now comes from:
  1. a bounded status-line snapshot only when it is under five minutes old; otherwise
  2. Anthropic’s account usage endpoint using the existing Claude OAuth access token.
- Only bounded percentages/reset clocks reach plugin output. Credentials are never logged, cached in plugin state, or returned to the client. Failed/missing auth produces no meter rather than a plausible zero.
- Claude-tab output cache is reduced from 60 seconds to 15 seconds; other local-activity tabs keep the one-minute ccusage cache.
- `plugins/status/muxr-ui.json` shows fixed 0–100 meters for both plan windows.
- Data-bound progress nodes now render nothing when the source value is absent instead of inventing 0%.
- Codex keeps its existing local app-server rate-limit path; local token/cost history still comes from pinned offline ccusage.

## Visual evidence

Both frames are direct, full-device Android emulator captures from the branch APK (`app.muxr.pr91`) paired to the real local host. They are not composites.

### Five-row URL; link action outside the key row

The current URL wraps across five terminal rows. Its `Open` action floats in the terminal above the unchanged globe/folder/git/Ctrl/Shift/Esc/Tab row.

![Five-row terminal URL with link action above the key row](https://github.com/user-attachments/assets/e9394587-8b93-4e1d-ae5b-51633478a630)

### Real Claude plan windows

The live Claude tab shows separate 5-hour and 7-day plan utilization and reset clocks.

![Claude 5-hour and 7-day plan usage](https://github.com/user-attachments/assets/8ea9085a-369f-410e-a6de-2da8ec30b261)

## Failures found and repaired while implementing

- The first URL check split a large URL across socket chunks and ANSI cursor commands. That did not reproduce the reported bug. It was replaced with the actual failure shape: five physical terminal rows plus a negative hard-newline case.
- The first real Claude snapshot check omitted reset text because status-line snapshots use epoch seconds while the account endpoint uses ISO timestamps. The parser now accepts both forms, and the flow fixture uses epoch seconds.
- Native screenshot verification then exposed a stale-chip path the non-visual checks missed: live output notified the UI without updating its viewport-link model, and a socket boundary could split the `http` scheme. The chip now refreshes once per complete output burst; the flow check covers a split scheme, and a rebuilt branch APK showed the chip tracking the latest five-row URL.
- Main CI’s earlier release run had a one-off remote-relay isolation mismatch; the rerun passed before this branch started. This branch’s full suite passes independently.
- Automated reviewer startup was unavailable because Bun does not implement `node:v8.createHook`; the diff was reviewed manually and all runnable checks below were used as the gate.

## Verification

Environment: Linux x64, Node `22.23.2`, Yarn `1.22.22`.

```bash
yarn workspace @muxr/mobile vitest run sources/terminal/openTerminal.spec.ts
```

```text
Test Files  1 passed (1)
Tests       4 passed (4)
```

```bash
node scripts/checkUsageStatus.mjs
```

```text
PASS e2e: per-provider ccusage tabs + safe live limits
```

Real local status-line snapshot, through the production plugin path:

```text
5-hour: 32% used · resets in 2h 10m
7-day:  43% used · resets in 3d 9h
```

The same values were fetched successfully through the OAuth account-endpoint fallback with the snapshot removed from an isolated config directory. With both snapshot and credential absent, both meter fields are omitted.

```bash
yarn workspace @muxr/mobile typecheck
git diff --check
yarn run check
```

```text
mobile typecheck: pass
31/31 passed in 91.8s
```

## Honest residuals

- The soft-wrap join is intentionally conservative: a continuation row must exactly fill the known terminal width. Ambiguous short lines remain separate instead of risking a forged URL.
- On a host where Claude stores OAuth only in an OS keychain and no fresh status-line snapshot exists, plan meters stay hidden; this branch does not add keychain scraping.
- The branch APK was rebuilt, installed, paired, and exercised on Android. No physical-device or iOS visual pass was run.
- No host/wire contract, dependency, release, or store changes.

