### PR TITLE
Let the app choose its realtime voice provider

### DIFF
--- a/apps/host/src/fakeSessionSource.ts
+++ b/apps/host/src/fakeSessionSource.ts
@@ -123,7 +123,17 @@ export function createFakeSessionSource(): SessionSource {
             throw new Error('fake source has no plugins');
         },
 
+        async voiceProviderList() {
+            return [
+                { id: 'xai', name: 'Grok', available: true, selected: true },
+                { id: 'gemini', name: 'Gemini Live', available: true, selected: false },
+                { id: 'openai', name: 'OpenAI Realtime', available: true, selected: false },
+            ];
+        },
 
+        async voiceProviderSelect(provider) {
+            return (await this.voiceProviderList()).map((candidate) => ({ ...candidate, selected: candidate.id === provider }));
+        },
 
         async herdrLayout() {
             throw new Error('fake source has no panes');

--- a/apps/host/src/fakeSessionSource.ts
+++ b/apps/host/src/fakeSessionSource.ts
@@ -125,9 +125,9 @@ export function createFakeSessionSource(): SessionSource {
 
         async voiceProviderList() {
             return [
-                { id: 'xai', name: 'Grok', available: true, selected: true },
-                { id: 'gemini', name: 'Gemini Live', available: true, selected: false },
-                { id: 'openai', name: 'OpenAI Realtime', available: true, selected: false },
+                { id: 'xai', name: 'Grok', selected: true, source: { kind: 'local' as const }, hasBackend: true },
+                { id: 'gemini', name: 'Gemini Live', selected: false, source: { kind: 'local' as const }, hasBackend: true },
+                { id: 'openai', name: 'OpenAI Realtime', selected: false, source: { kind: 'local' as const }, hasBackend: true },
             ];
         },
 

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -968,15 +968,16 @@ export async function createHerdrSessionSource(
     }
 
     function voiceProviderOptions(): VoiceProviderOption[] {
-        return catalog.capabilityPlugins('voice.session').map(({ pluginId, name, enabled }) => ({
+        return catalog.capabilityPlugins('voice.session').map(({ pluginId, name, enabled, source, hasBackend }) => ({
             id: pluginId,
             name,
-            available: true,
             selected: enabled,
+            source,
+            hasBackend,
         }));
     }
 
-    async function selectVoiceProvider(providerId: string): Promise<VoiceProviderOption[]> {
+    async function selectVoiceProviderNow(providerId: string): Promise<VoiceProviderOption[]> {
         await refreshPlugins();
         const providers = catalog.capabilityPlugins('voice.session');
         const target = providers.find((candidate) => candidate.pluginId === providerId);
@@ -1004,6 +1005,13 @@ export async function createHerdrSessionSource(
             await refreshPlugins().catch(() => undefined);
             throw error;
         }
+    }
+
+    let voiceSwitch: Promise<void> = Promise.resolve();
+    function selectVoiceProvider(providerId: string): Promise<VoiceProviderOption[]> {
+        const run = voiceSwitch.then(() => selectVoiceProviderNow(providerId));
+        voiceSwitch = run.then(() => undefined, () => undefined);
+        return run;
     }
 
     void reconcilePlugins().catch(() => undefined);

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -996,6 +996,18 @@ export async function createHerdrSessionSource(
                 enabledTarget = true;
             }
             await refreshPlugins();
+            const latest = catalog.capabilityPlugins('voice.session');
+            let converged = false;
+            if (!latest.some((candidate) => candidate.pluginId === target.pluginId && candidate.enabled)) {
+                await client.call('plugin.enable', { plugin_id: target.pluginId });
+                converged = true;
+            }
+            for (const current of latest) {
+                if (!current.enabled || current.pluginId === target.pluginId) continue;
+                await client.call('plugin.disable', { plugin_id: current.pluginId });
+                converged = true;
+            }
+            if (converged) await refreshPlugins();
             return voiceProviderOptions();
         } catch (error) {
             if (enabledTarget) await client.call('plugin.disable', { plugin_id: target.pluginId }).catch(() => undefined);

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -1000,6 +1000,7 @@ export async function createHerdrSessionSource(
             let converged = false;
             if (!latest.some((candidate) => candidate.pluginId === target.pluginId && candidate.enabled)) {
                 await client.call('plugin.enable', { plugin_id: target.pluginId });
+                enabledTarget = true;
                 converged = true;
             }
             for (const current of latest) {

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -23,6 +23,7 @@ import type {
     SessionInfo,
     SessionSnapshot,
     SessionStatus,
+    VoiceProviderOption,
 } from '@muxr/contract';
 import { ATTENTION_REASONS, relayControlUrl } from '@muxr/contract';
 import { AttachmentWatcher } from './attachmentWatcher.js';
@@ -966,6 +967,45 @@ export async function createHerdrSessionSource(
         await reconcilePlugins(true);
     }
 
+    function voiceProviderOptions(): VoiceProviderOption[] {
+        return catalog.capabilityPlugins('voice.session').map(({ pluginId, name, enabled }) => ({
+            id: pluginId,
+            name,
+            available: true,
+            selected: enabled,
+        }));
+    }
+
+    async function selectVoiceProvider(providerId: string): Promise<VoiceProviderOption[]> {
+        await refreshPlugins();
+        const providers = catalog.capabilityPlugins('voice.session');
+        const target = providers.find((candidate) => candidate.pluginId === providerId);
+        if (target === undefined) throw new Error('realtime voice provider is not installed on this machine; update muxr first');
+        const previouslyEnabled = providers.filter(({ enabled }) => enabled);
+        const disabled: typeof previouslyEnabled = [];
+        let enabledTarget = false;
+        try {
+            for (const current of previouslyEnabled) {
+                if (current.pluginId === target.pluginId) continue;
+                await client.call('plugin.disable', { plugin_id: current.pluginId });
+                disabled.push(current);
+            }
+            if (!target.enabled) {
+                await client.call('plugin.enable', { plugin_id: target.pluginId });
+                enabledTarget = true;
+            }
+            await refreshPlugins();
+            return voiceProviderOptions();
+        } catch (error) {
+            if (enabledTarget) await client.call('plugin.disable', { plugin_id: target.pluginId }).catch(() => undefined);
+            for (const current of disabled.reverse()) {
+                await client.call('plugin.enable', { plugin_id: current.pluginId }).catch(() => undefined);
+            }
+            await refreshPlugins().catch(() => undefined);
+            throw error;
+        }
+    }
+
     void reconcilePlugins().catch(() => undefined);
     pluginPollTimer = setInterval(() => {
         if (machineListeners.size > 0) void reconcilePlugins().catch(() => undefined);
@@ -1100,6 +1140,15 @@ export async function createHerdrSessionSource(
             await refreshPlugins();
             if (approved) catalog.manifest(pluginId, manifestHash);
             await pluginApprovals.set(deviceId, pluginId, approved);
+        },
+
+        async voiceProviderList() {
+            await refreshPlugins();
+            return voiceProviderOptions();
+        },
+
+        async voiceProviderSelect(provider) {
+            return selectVoiceProvider(provider);
         },
 
         async pluginInvoke({ deviceId, pluginId, manifestHash, contributionId, sessionId, idempotencyKey }) {

--- a/apps/host/src/herdr/pluginCatalog.test.ts
+++ b/apps/host/src/herdr/pluginCatalog.test.ts
@@ -64,7 +64,9 @@ describe('plugin catalog flow', () => {
         const catalog = new PluginCatalog();
         await catalog.refresh([{ ...plugin(root), enabled: false }]);
         expect(catalog.list(() => true)).toEqual([]);
-        expect(catalog.capabilityPlugins('voice.session')).toEqual([{ pluginId: 'example.muxr-ui', name: 'Example muxr UI', enabled: false }]);
+        expect(catalog.capabilityPlugins('voice.session')).toEqual([{
+            pluginId: 'example.muxr-ui', name: 'Example muxr UI', enabled: false, source: { kind: 'local' }, hasBackend: true,
+        }]);
 
         await catalog.refresh([plugin(root)]);
         expect(catalog.capabilityPlugins('voice.session')[0]).toMatchObject({ enabled: true });

--- a/apps/host/src/herdr/pluginCatalog.test.ts
+++ b/apps/host/src/herdr/pluginCatalog.test.ts
@@ -53,6 +53,23 @@ describe('plugin catalog flow', () => {
         expect(pluginInvalidationFrame(baseline, many)).toMatchObject({ reason: 'linked', pluginIds: [] });
     });
 
+    it('discovers a disabled capability provider and tracks when it becomes active', async () => {
+        const root = await mkdtemp(join(tmpdir(), 'muxr-plugin-provider-'));
+        await writeFile(join(root, 'muxr-ui.json'), JSON.stringify({
+            schemaVersion: 1,
+            pluginId: 'example.muxr-ui',
+            capabilities: { 'voice.session': 'session' },
+            contributions: [{ slot: 'host.stream', id: 'session', type: 'stream', entry: 'stream.mjs' }],
+        }));
+        const catalog = new PluginCatalog();
+        await catalog.refresh([{ ...plugin(root), enabled: false }]);
+        expect(catalog.list(() => true)).toEqual([]);
+        expect(catalog.capabilityPlugins('voice.session')).toEqual([{ pluginId: 'example.muxr-ui', name: 'Example muxr UI', enabled: false }]);
+
+        await catalog.refresh([plugin(root)]);
+        expect(catalog.capabilityPlugins('voice.session')[0]).toMatchObject({ enabled: true });
+    });
+
     it('allow-lists and bounds public RPC context without internal ids', async () => {
         const root = await mkdtemp(join(tmpdir(), 'muxr-plugin-context-'));
         const manifestPath = join(root, 'muxr-ui.json');

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -151,11 +151,17 @@ export class PluginCatalog {
         return digests;
     }
 
-    capabilityPlugins(capability: string): Array<{ pluginId: string; name: string; enabled: boolean }> {
+    capabilityPlugins(capability: string): Array<{ pluginId: string; name: string; enabled: boolean; source: PluginSource; hasBackend: boolean }> {
         return [...this.installed].flatMap(([pluginId, { snapshot, enabled }]) =>
             snapshot.manifest.capabilities?.[capability] === undefined
                 ? []
-                : [{ pluginId, name: snapshot.summary.name, enabled }],
+                : [{
+                    pluginId,
+                    name: snapshot.summary.name,
+                    enabled,
+                    source: snapshot.summary.source,
+                    hasBackend: snapshot.summary.hasBackend || snapshot.manifest.contributions.some((item) => item.slot === 'host.rpc' || item.slot === 'host.stream'),
+                }],
         ).sort((left, right) => left.name.localeCompare(right.name));
     }
 

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -104,25 +104,24 @@ export function pluginInvalidationFrame(previous: PluginDigestSnapshot, next: Pl
 export class PluginCatalog {
     private snapshots = new Map<string, Snapshot>();
     private active = new Map<string, string>();
+    private installed = new Map<string, { snapshot: Snapshot; enabled: boolean }>();
     private parsedProjections = new Map<string, ParsedProjection>();
 
     /** Refresh from authoritative plugin.list and return stable per-plugin digests. */
     async refresh(plugins: HerdrPlugin[]): Promise<Map<string, string>> {
         const active = new Map<string, string>();
         const snapshots = new Map<string, Snapshot>();
+        const installed = new Map<string, { snapshot: Snapshot; enabled: boolean }>();
         const digests = new Map<string, string>();
         const usedProjectionKeys = new Set<string>();
         for (const plugin of plugins) {
-            // Disabled plugins still contribute visible/trust-relevant registry
-            // fields, but their UI file is not parsed on every bounded poll.
-            const loaded = plugin.enabled
-                ? await loadPlugin(plugin, this.parsedProjections, usedProjectionKeys).catch((error) => backendOnly(
-                    plugin,
-                    `muxr UI rejected: ${error instanceof Error ? error.message : String(error)}`,
-                ))
-                : undefined;
-            // loadPlugin already resolves source/provenance for enabled plugins.
-            const summary = loaded?.summary ?? summaryOf(plugin, undefined, {});
+            // Disabled manifests stay inert, but parsing their cached projection
+            // lets generic capability pickers show installed alternatives.
+            const loaded = await loadPlugin(plugin, this.parsedProjections, usedProjectionKeys).catch((error) => backendOnly(
+                plugin,
+                `muxr UI rejected: ${error instanceof Error ? error.message : String(error)}`,
+            ));
+            const summary = loaded.summary;
             digests.set(plugin.plugin_id, digest(stableJson({
                 pluginId: plugin.plugin_id,
                 name: summary.name,
@@ -138,7 +137,8 @@ export class PluginCatalog {
                 warnings: summary.warnings,
                 manifestHash: summary.manifestHash ?? null,
             })));
-            if (!plugin.enabled || loaded === undefined) continue;
+            installed.set(plugin.plugin_id, { snapshot: loaded, enabled: plugin.enabled });
+            if (!plugin.enabled) continue;
             snapshots.set(plugin.plugin_id, loaded);
             active.set(plugin.plugin_id, loaded.summary.manifestHash ?? '');
         }
@@ -147,7 +147,16 @@ export class PluginCatalog {
         }
         this.snapshots = snapshots;
         this.active = active;
+        this.installed = installed;
         return digests;
+    }
+
+    capabilityPlugins(capability: string): Array<{ pluginId: string; name: string; enabled: boolean }> {
+        return [...this.installed].flatMap(([pluginId, { snapshot, enabled }]) =>
+            snapshot.manifest.capabilities?.[capability] === undefined
+                ? []
+                : [{ pluginId, name: snapshot.summary.name, enabled }],
+        ).sort((left, right) => left.name.localeCompare(right.name));
     }
 
     list(isApproved: (pluginId: string, hash: string) => boolean): PluginSummary[] {

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -160,7 +160,7 @@ export class PluginCatalog {
                     name: snapshot.summary.name,
                     enabled,
                     source: snapshot.summary.source,
-                    hasBackend: snapshot.summary.hasBackend || snapshot.manifest.contributions.some((item) => item.slot === 'host.rpc' || item.slot === 'host.stream'),
+                    hasBackend: snapshot.summary.hasBackend,
                 }],
         ).sort((left, right) => left.name.localeCompare(right.name));
     }
@@ -296,7 +296,7 @@ async function loadPlugin(
         const authority = stableJson(authorityInput);
         const source = sourceOf(plugin.source, plugin, pluginRoot);
         const manifestHash = digest(`${APPROVAL_DOMAIN}\0${plugin.plugin_id}\0${sourceIdentity(source, pluginRoot)}\0${authority}\0${canonical}`);
-        return { pluginRoot, manifest, actions, calls, streams, summary: summaryOf(plugin, manifestHash, manifest.capabilities ?? {}, source) };
+        return { pluginRoot, manifest, actions, calls, streams, summary: summaryOf(plugin, manifestHash, manifest.capabilities ?? {}, source, manifest) };
     } finally {
         await handle.close();
     }
@@ -314,7 +314,7 @@ function backendOnly(plugin: HerdrPlugin, warning?: string, pluginRoot = plugin.
     };
 }
 
-function summaryOf(plugin: HerdrPlugin, manifestHash: string | undefined, capabilities: Record<string, string>, source = sourceOf(plugin.source, plugin)): Omit<PluginSummary, 'approved'> {
+function summaryOf(plugin: HerdrPlugin, manifestHash: string | undefined, capabilities: Record<string, string>, source = sourceOf(plugin.source, plugin), manifest?: PluginManifestV1): Omit<PluginSummary, 'approved'> {
     return {
         pluginId: plugin.plugin_id,
         name: safeText(plugin.name, 80)[0] ?? plugin.plugin_id,
@@ -323,7 +323,8 @@ function summaryOf(plugin: HerdrPlugin, manifestHash: string | undefined, capabi
         source,
         ...(manifestHash === undefined ? {} : { manifestHash }),
         capabilities,
-        hasBackend: [plugin.build, plugin.startup, plugin.actions, plugin.events, plugin.panes, plugin.link_handlers].some((value) => (value?.length ?? 0) > 0),
+        hasBackend: [plugin.build, plugin.startup, plugin.actions, plugin.events, plugin.panes, plugin.link_handlers].some((value) => (value?.length ?? 0) > 0)
+            || manifest?.contributions.some((item) => item.slot === 'host.rpc' || item.slot === 'host.stream') === true,
         warnings: (plugin.warnings ?? []).filter((warning): warning is string => typeof warning === 'string').slice(0, 4).flatMap((warning) => safeText(warning, MAX_TEXT)),
     };
 }

--- a/apps/host/src/requests/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/createRequestDispatcher.test.ts
@@ -87,8 +87,9 @@ describe('voice provider selection', () => {
         const providers = () => ['xai', 'gemini', 'openai'].map((id) => ({
             id,
             name: id,
-            available: true,
             selected: id === selected,
+            source: { kind: 'local' as const },
+            hasBackend: true,
         }));
         const source = {
             async voiceProviderList() { return providers(); },
@@ -107,7 +108,7 @@ describe('voice provider selection', () => {
         expect(await dispatch({ type: 'voice.provider.select', requestId: 'select', params: { providerId: 'gemini' } } as never, 'browser-1'))
             .toMatchObject({ ok: false, error: expect.stringContaining('read-only') });
         expect(await dispatch({ type: 'voice.provider.select', requestId: 'select', params: { providerId: 'gemini' } } as never, 'native-1'))
-            .toMatchObject({ ok: true, data: expect.arrayContaining([{ id: 'gemini', selected: true, available: true, name: 'gemini' }]) });
+            .toMatchObject({ ok: true, data: expect.arrayContaining([expect.objectContaining({ id: 'gemini', selected: true, name: 'gemini' })]) });
     });
 });
 

--- a/apps/host/src/requests/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/createRequestDispatcher.test.ts
@@ -81,6 +81,36 @@ describe('plugin device authority', () => {
     });
 });
 
+describe('voice provider selection', () => {
+    it('lists every provider but only lets a native device switch the active one', async () => {
+        let selected = 'xai';
+        const providers = () => ['xai', 'gemini', 'openai'].map((id) => ({
+            id,
+            name: id,
+            available: true,
+            selected: id === selected,
+        }));
+        const source = {
+            async voiceProviderList() { return providers(); },
+            async voiceProviderSelect(provider: string) { selected = provider; return providers(); },
+        } as unknown as SessionSource;
+        const { dispatch } = createRequestDispatcher({
+            source,
+            domain: {} as never,
+            machineId: 'm1',
+            hostVersion: '0.0.0',
+            canMutateDevice: (deviceId) => deviceId !== 'browser-1',
+        });
+
+        expect(await dispatch({ type: 'voice.provider.list', requestId: 'list', params: {} } as never, 'browser-1'))
+            .toMatchObject({ ok: true, data: [{ id: 'xai', selected: true }, { id: 'gemini' }, { id: 'openai' }] });
+        expect(await dispatch({ type: 'voice.provider.select', requestId: 'select', params: { providerId: 'gemini' } } as never, 'browser-1'))
+            .toMatchObject({ ok: false, error: expect.stringContaining('read-only') });
+        expect(await dispatch({ type: 'voice.provider.select', requestId: 'select', params: { providerId: 'gemini' } } as never, 'native-1'))
+            .toMatchObject({ ok: true, data: expect.arrayContaining([{ id: 'gemini', selected: true, available: true, name: 'gemini' }]) });
+    });
+});
+
 describe('unknown request type guard', () => {
     it('answers a stable host-contract-mismatch result instead of throwing', async () => {
         const { dispatch } = dispatcherWithSpy();

--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -63,6 +63,8 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
         'plugin.invoke': () => { throw new Error('authenticated device context required'); },
         'plugin.call': () => { throw new Error('authenticated device context required'); },
         'plugin.stream': () => { throw new Error('authenticated device context required'); },
+        'voice.provider.list': () => source.voiceProviderList(),
+        'voice.provider.select': (params) => source.voiceProviderSelect(params.providerId),
         'herdr.cli': async (params) => {
             const result = await runHerdrCli(params.args, params.timeoutMs);
             await source.refreshHerdr();
@@ -182,7 +184,7 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
             const readOnly = options.canMutateDevice?.(deviceId) === false;
             const readOnlyRequests = new Set<RequestType>([
                 'session.list', 'session.open', 'session.status',
-                'herdr.tree', 'herdr.agentKinds', 'herdr.layout', 'pane.read', 'plugin.list', 'plugin.manifest',
+                'herdr.tree', 'herdr.agentKinds', 'herdr.layout', 'pane.read', 'plugin.list', 'plugin.manifest', 'voice.provider.list',
                 'attachment.fetch', 'attachment.read', 'unread.catalog',
                 'attention.catalog', 'machines.list', 'terminal.attach',
             ]);

--- a/apps/host/src/sessionSource.ts
+++ b/apps/host/src/sessionSource.ts
@@ -17,6 +17,7 @@ import type {
     SessionStatus,
     StreamingBehavior,
     PluginsInvalidatedFrame,
+    VoiceProviderOption,
 } from '@muxr/contract';
 
 export interface SessionListOptions {
@@ -98,6 +99,8 @@ export interface SessionSource {
     /** Declared RPC mode for a catalog contribution, so read-only devices can be allowed through read paths only. */
     pluginRpcMode?(options: { pluginId: string; manifestHash: string; contributionId: string }): 'read' | 'write' | undefined;
     pluginStream(options: { deviceId: string; pluginId: string; manifestHash: string; contributionId: string; channel: string; sessionId?: string }): Promise<null>;
+    voiceProviderList(): Promise<VoiceProviderOption[]>;
+    voiceProviderSelect(providerId: string): Promise<VoiceProviderOption[]>;
     /** Split layout of one tab (rects in terminal cells) for grid views. */
     herdrLayout(tabId: string): Promise<{
         tabId: string;

--- a/apps/mobile/sources/app/(app)/_layout.tsx
+++ b/apps/mobile/sources/app/(app)/_layout.tsx
@@ -130,6 +130,12 @@ export default function RootLayout() {
                 }}
             />
             <Stack.Screen
+                name="settings/voice"
+                options={{
+                    headerTitle: 'Realtime voice',
+                }}
+            />
+            <Stack.Screen
                 name="restore/index"
                 options={{
                     headerShown: true,

--- a/apps/mobile/sources/app/(app)/settings/voice.tsx
+++ b/apps/mobile/sources/app/(app)/settings/voice.tsx
@@ -6,6 +6,7 @@ import { Item } from '@/components/Item';
 import { ItemGroup } from '@/components/ItemGroup';
 import { ItemList } from '@/components/ItemList';
 import { Modal } from '@/modal';
+import { sourceLabel } from '@/plugins/pluginActions';
 import { pluginHref } from '@/plugins/pluginHref';
 import { pluginCatalogSnapshot, refreshPlugins } from '@/plugins/pluginStore';
 import { sync } from '@/sync/sync';
@@ -19,71 +20,92 @@ export default function VoiceProviderScreen() {
     const { status } = useSocketStatus();
     const [providers, setProviders] = React.useState<VoiceProviderOption[]>([]);
     const [busy, setBusy] = React.useState<string>();
+    const [loaded, setLoaded] = React.useState(false);
     const [error, setError] = React.useState<string>();
+    const busyRef = React.useRef(false);
 
     const load = React.useCallback(async () => {
-        if (status !== 'connected') return;
+        if (status !== 'connected') { setLoaded(true); return; }
+        setLoaded(false);
         try {
             setProviders(await sync.request('voice.provider.list', {}));
             setError(undefined);
         } catch (cause) {
             setError(cause instanceof Error ? cause.message : String(cause));
+        } finally {
+            setLoaded(true);
         }
     }, [status]);
 
     React.useEffect(() => { void load(); }, [load]);
 
+    const approveProvider = React.useCallback(async (providerId: string) => {
+        await refreshPlugins();
+        let plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === providerId);
+        if (plugin?.summary.manifestHash !== undefined && !plugin.summary.approved) {
+            await sync.request('plugin.approve', {
+                pluginId: plugin.summary.pluginId,
+                manifestHash: plugin.summary.manifestHash,
+                approved: true,
+            });
+            await refreshPlugins();
+            plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === providerId);
+        }
+        return plugin;
+    }, []);
+
     const select = React.useCallback(async (provider: VoiceProviderOption) => {
-        if ((provider.selected && providers.filter((candidate) => candidate.selected).length === 1) || busy !== undefined) return;
+        if ((provider.selected && providers.filter((candidate) => candidate.selected).length === 1) || busyRef.current) return;
+        busyRef.current = true;
         setBusy(provider.id);
+        let switched = false;
         try {
             const next = await sync.request('voice.provider.select', { providerId: provider.id });
+            switched = true;
             setProviders(next);
-            await refreshPlugins();
-            const plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === provider.id);
-            if (plugin?.summary.manifestHash !== undefined && !plugin.summary.approved) {
-                await sync.request('plugin.approve', {
-                    pluginId: plugin.summary.pluginId,
-                    manifestHash: plugin.summary.manifestHash,
-                    approved: true,
-                });
-                await refreshPlugins();
-            }
+            await approveProvider(provider.id);
             setError(undefined);
         } catch (cause) {
             const message = cause instanceof Error ? cause.message : String(cause);
             setError(message);
-            Modal.alert('Could not switch voice provider', message);
+            Modal.alert(switched ? 'Provider selected, but setup failed' : 'Could not switch voice provider', message);
             await load();
         } finally {
+            busyRef.current = false;
             setBusy(undefined);
         }
-    }, [busy, load, providers]);
+    }, [approveProvider, load, providers]);
 
     const selected = providers.find((provider) => provider.selected);
-    const configure = React.useCallback(() => {
-        if (selected === undefined) return;
-        const plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === selected.id && summary.approved);
-        const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'settings.items' && contribution.type === 'settings-item');
-        if (settings?.action.type !== 'screen') {
-            Modal.alert('Provider settings unavailable', 'Reconnect to this machine and try again.');
-            return;
+    const configure = React.useCallback(async () => {
+        if (selected === undefined || busyRef.current) return;
+        busyRef.current = true;
+        setBusy(selected.id);
+        try {
+            const plugin = await approveProvider(selected.id);
+            const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'settings.items' && contribution.type === 'settings-item');
+            if (settings?.action.type !== 'screen') throw new Error('Open Settings → Plugins and enable this provider, then try again.');
+            router.push(pluginHref(selected.id, settings.action.contributionId) as any);
+        } catch (cause) {
+            Modal.alert('Provider settings unavailable', cause instanceof Error ? cause.message : String(cause));
+        } finally {
+            busyRef.current = false;
+            setBusy(undefined);
         }
-        router.push(pluginHref(selected.id, settings.action.contributionId) as any);
-    }, [router, selected]);
+    }, [approveProvider, router, selected]);
 
-    if (status === 'connected' && providers.length === 0 && error === undefined) return <ActivityIndicator style={{ flex: 1 }} />;
+    if (status === 'connected' && !loaded) return <ActivityIndicator style={{ flex: 1 }} />;
 
     return (
         <ItemList>
-            <ItemGroup title="Provider" footer={error ?? (status === 'connected' ? 'Exactly one realtime speech-to-speech provider runs on this machine.' : 'Connect to a machine to choose its voice provider.')}>
+            <ItemGroup title="Provider" footer={error ?? (status === 'connected' ? 'Exactly one provider runs on this machine. Only installed providers are shown.' : 'Connect to a machine to choose its voice provider.')}>
                 {providers.map((provider) => (
                     <Item
                         key={provider.id}
                         title={provider.name}
-                        subtitle={provider.available ? (provider.selected ? 'Selected' : 'Tap to use on this machine') : 'Not installed — update muxr on this machine'}
+                        subtitle={`${provider.selected ? 'Selected' : 'Tap to use on this machine'} · ${sourceLabel(provider.source)} · ${provider.hasBackend ? 'Runs code on this machine' : 'UI only'}`}
+                        subtitleLines={2}
                         selected={provider.selected}
-                        disabled={!provider.available}
                         loading={busy === provider.id}
                         showChevron={false}
                         onPress={() => void select(provider)}
@@ -97,7 +119,8 @@ export default function VoiceProviderScreen() {
                         title={`Configure ${selected.name}`}
                         subtitle="Set or replace its API key on the connected machine"
                         icon={<Ionicons name="key-outline" size={28} color={theme.colors.textSecondary} />}
-                        onPress={configure}
+                        loading={busy === selected.id}
+                        onPress={() => void configure()}
                     />
                 </ItemGroup>
             )}

--- a/apps/mobile/sources/app/(app)/settings/voice.tsx
+++ b/apps/mobile/sources/app/(app)/settings/voice.tsx
@@ -84,7 +84,7 @@ export default function VoiceProviderScreen() {
         try {
             const plugin = await approveProvider(selected.id);
             const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'settings.items' && contribution.type === 'settings-item');
-            if (settings?.action.type !== 'screen') throw new Error('Open Settings → Plugins and enable this provider, then try again.');
+            if (settings?.action.type !== 'screen') throw new Error('This provider has no configuration screen.');
             router.push(pluginHref(selected.id, settings.action.contributionId) as any);
         } catch (cause) {
             Modal.alert('Provider settings unavailable', cause instanceof Error ? cause.message : String(cause));

--- a/apps/mobile/sources/app/(app)/settings/voice.tsx
+++ b/apps/mobile/sources/app/(app)/settings/voice.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import type { VoiceProviderOption } from '@muxr/contract';
+import { Item } from '@/components/Item';
+import { ItemGroup } from '@/components/ItemGroup';
+import { ItemList } from '@/components/ItemList';
+import { Modal } from '@/modal';
+import { pluginHref } from '@/plugins/pluginHref';
+import { pluginCatalogSnapshot, refreshPlugins } from '@/plugins/pluginStore';
+import { sync } from '@/sync/sync';
+import { useSocketStatus } from '@/sync/storage';
+import { useRouter } from 'expo-router';
+import { useUnistyles } from 'react-native-unistyles';
+
+export default function VoiceProviderScreen() {
+    const router = useRouter();
+    const { theme } = useUnistyles();
+    const { status } = useSocketStatus();
+    const [providers, setProviders] = React.useState<VoiceProviderOption[]>([]);
+    const [busy, setBusy] = React.useState<string>();
+    const [error, setError] = React.useState<string>();
+
+    const load = React.useCallback(async () => {
+        if (status !== 'connected') return;
+        try {
+            setProviders(await sync.request('voice.provider.list', {}));
+            setError(undefined);
+        } catch (cause) {
+            setError(cause instanceof Error ? cause.message : String(cause));
+        }
+    }, [status]);
+
+    React.useEffect(() => { void load(); }, [load]);
+
+    const select = React.useCallback(async (provider: VoiceProviderOption) => {
+        if ((provider.selected && providers.filter((candidate) => candidate.selected).length === 1) || busy !== undefined) return;
+        setBusy(provider.id);
+        try {
+            const next = await sync.request('voice.provider.select', { providerId: provider.id });
+            setProviders(next);
+            await refreshPlugins();
+            const plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === provider.id);
+            if (plugin?.summary.manifestHash !== undefined && !plugin.summary.approved) {
+                await sync.request('plugin.approve', {
+                    pluginId: plugin.summary.pluginId,
+                    manifestHash: plugin.summary.manifestHash,
+                    approved: true,
+                });
+                await refreshPlugins();
+            }
+            setError(undefined);
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : String(cause);
+            setError(message);
+            Modal.alert('Could not switch voice provider', message);
+            await load();
+        } finally {
+            setBusy(undefined);
+        }
+    }, [busy, load, providers]);
+
+    const selected = providers.find((provider) => provider.selected);
+    const configure = React.useCallback(() => {
+        if (selected === undefined) return;
+        const plugin = pluginCatalogSnapshot().find(({ summary }) => summary.pluginId === selected.id && summary.approved);
+        const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'settings.items' && contribution.type === 'settings-item');
+        if (settings?.action.type !== 'screen') {
+            Modal.alert('Provider settings unavailable', 'Reconnect to this machine and try again.');
+            return;
+        }
+        router.push(pluginHref(selected.id, settings.action.contributionId) as any);
+    }, [router, selected]);
+
+    if (status === 'connected' && providers.length === 0 && error === undefined) return <ActivityIndicator style={{ flex: 1 }} />;
+
+    return (
+        <ItemList>
+            <ItemGroup title="Provider" footer={error ?? (status === 'connected' ? 'Exactly one realtime speech-to-speech provider runs on this machine.' : 'Connect to a machine to choose its voice provider.')}>
+                {providers.map((provider) => (
+                    <Item
+                        key={provider.id}
+                        title={provider.name}
+                        subtitle={provider.available ? (provider.selected ? 'Selected' : 'Tap to use on this machine') : 'Not installed — update muxr on this machine'}
+                        selected={provider.selected}
+                        disabled={!provider.available}
+                        loading={busy === provider.id}
+                        showChevron={false}
+                        onPress={() => void select(provider)}
+                        rightElement={provider.selected ? <Ionicons name="checkmark-circle" size={24} color={theme.colors.textLink} /> : undefined}
+                    />
+                ))}
+            </ItemGroup>
+            {selected !== undefined && (
+                <ItemGroup title="Setup">
+                    <Item
+                        title={`Configure ${selected.name}`}
+                        subtitle="Set or replace its API key on the connected machine"
+                        icon={<Ionicons name="key-outline" size={28} color={theme.colors.textSecondary} />}
+                        onPress={configure}
+                    />
+                </ItemGroup>
+            )}
+        </ItemList>
+    );
+}

--- a/apps/mobile/sources/components/SettingsView.tsx
+++ b/apps/mobile/sources/components/SettingsView.tsx
@@ -357,6 +357,12 @@ export const SettingsView = React.memo(function SettingsView({
                     onPress={() => router.push('/settings/connection' as any)}
                 />
                 <Item
+                    title="Realtime voice"
+                    subtitle="Choose Grok, Gemini Live, or OpenAI Realtime"
+                    icon={<Ionicons name="pulse-outline" size={29} color="#34C759" />}
+                    onPress={() => router.push('/settings/voice' as any)}
+                />
+                <Item
                     title="Plugins"
                     subtitle="Native UI and capabilities installed through Herdr"
                     icon={<Ionicons name="extension-puzzle-outline" size={29} color="#5856D6" />}

--- a/apps/mobile/sources/components/SettingsView.tsx
+++ b/apps/mobile/sources/components/SettingsView.tsx
@@ -358,7 +358,7 @@ export const SettingsView = React.memo(function SettingsView({
                 />
                 <Item
                     title="Realtime voice"
-                    subtitle="Choose Grok, Gemini Live, or OpenAI Realtime"
+                    subtitle="Choose which provider runs on this machine"
                     icon={<Ionicons name="pulse-outline" size={29} color="#34C759" />}
                     onPress={() => router.push('/settings/voice' as any)}
                 />

--- a/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
+++ b/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
@@ -265,7 +265,7 @@ export function DeclarativePhoneNavRow({ onSelect }: { onSelect: (pluginId: stri
 export function DeclarativeSettingsItems() {
     const router = useRouter();
     useSlotContributions('settings.items');
-    return <>{pluginSnapshot().filter(({ manifest }) => manifest.capabilities?.['voice.session'] === undefined).flatMap(({ summary, manifest }) => manifest.contributions.flatMap((contribution) => 'type' in contribution && contribution.type === 'settings-item' ? [<Item key={`${summary.pluginId}:${contribution.id}`} title={resolvePluginText(contribution.label)} subtitle={contribution.subtitle === undefined ? undefined : resolvePluginText(contribution.subtitle)} icon={<Ionicons name={contribution.icon as any} size={29} color="#666" />} onPress={() => {
+    return <>{pluginSnapshot().flatMap(({ summary, manifest }) => manifest.contributions.flatMap((contribution) => 'type' in contribution && contribution.type === 'settings-item' ? [<Item key={`${summary.pluginId}:${contribution.id}`} title={resolvePluginText(contribution.label)} subtitle={contribution.subtitle === undefined ? undefined : resolvePluginText(contribution.subtitle)} icon={<Ionicons name={contribution.icon as any} size={29} color="#666" />} onPress={() => {
         void dispatchPluginAction(contribution.action, { router, pluginId: summary.pluginId, manifestHash: summary.manifestHash, manifest })
             .catch((error: unknown) => Modal.alert('Plugin action unavailable', error instanceof Error ? error.message : String(error)));
     }} />] : []))}</>;

--- a/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
+++ b/apps/mobile/sources/plugins/DeclarativePluginSlot.tsx
@@ -265,7 +265,7 @@ export function DeclarativePhoneNavRow({ onSelect }: { onSelect: (pluginId: stri
 export function DeclarativeSettingsItems() {
     const router = useRouter();
     useSlotContributions('settings.items');
-    return <>{pluginSnapshot().flatMap(({ summary, manifest }) => manifest.contributions.flatMap((contribution) => 'type' in contribution && contribution.type === 'settings-item' ? [<Item key={`${summary.pluginId}:${contribution.id}`} title={resolvePluginText(contribution.label)} subtitle={contribution.subtitle === undefined ? undefined : resolvePluginText(contribution.subtitle)} icon={<Ionicons name={contribution.icon as any} size={29} color="#666" />} onPress={() => {
+    return <>{pluginSnapshot().filter(({ manifest }) => manifest.capabilities?.['voice.session'] === undefined).flatMap(({ summary, manifest }) => manifest.contributions.flatMap((contribution) => 'type' in contribution && contribution.type === 'settings-item' ? [<Item key={`${summary.pluginId}:${contribution.id}`} title={resolvePluginText(contribution.label)} subtitle={contribution.subtitle === undefined ? undefined : resolvePluginText(contribution.subtitle)} icon={<Ionicons name={contribution.icon as any} size={29} color="#666" />} onPress={() => {
         void dispatchPluginAction(contribution.action, { router, pluginId: summary.pluginId, manifestHash: summary.manifestHash, manifest })
             .catch((error: unknown) => Modal.alert('Plugin action unavailable', error instanceof Error ? error.message : String(error)));
     }} />] : []))}</>;

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -533,7 +533,7 @@ validates shape; `plugin call` proves wiring.
 
 A stream process receives one private `realtime.open` line followed by bounded provider-neutral NDJSON frames. The phone sends PCM audio, mute/stop controls, or text to speak; the adapter returns ready/state/audio/clear/transcript/closed frames. It owns all provider credentials, models, prompts, tools, codecs, and protocol events. The host enforces approval revocation, per-device admission, idle/process-group cleanup, frame bounds, and encrypted relay transport. Adding another provider means adding another plugin adapter, not changing React Native.
 
-The package ships xAI (`plugins/voice`, default on), Gemini Live (`plugins/voice-gemini`, default off), and OpenAI Realtime (`plugins/voice-openai`, default off) as complete examples. All claim `voice.session`; the resolver rejects an ambiguous claim, so disable the active provider before enabling another. Setup defaults apply only on first install and never overwrite an existing enabled/disabled choice.
+The package ships xAI (`plugins/voice`, default on), Gemini Live (`plugins/voice-gemini`, default off), and OpenAI Realtime (`plugins/voice-openai`, default off) as complete examples. All claim `voice.session`; choose one under **Settings → Realtime voice**, where the host serializes the switch and keeps the capability unambiguous. Setup defaults apply only on first install and never overwrite an existing choice.
 
 Voice uses this without knowing any provider plugin id. Its one-shot semantic RPC aliases remain:
 

--- a/docs/VOICE-SETUP.md
+++ b/docs/VOICE-SETUP.md
@@ -12,14 +12,9 @@ All three adapters ship with `@trymuxr/cli`:
 | `muxr.voice-gemini` | Gemini Live | disabled | `~/.muxr/gemini.key` |
 | `muxr.voice-openai` | OpenAI Realtime | disabled | `~/.muxr/openai.key` |
 
-Exactly one provider may be enabled because all three claim `voice.session`. To switch, disable the current plugin before enabling another:
+Exactly one provider may be enabled because all three claim `voice.session`. In the app, open **Settings → Realtime voice**, choose Grok, Gemini Live, or OpenAI Realtime, then open **Configure** to paste that provider's API key. The host serializes each switch so concurrent devices still converge on one provider.
 
-```bash
-herdr plugin disable muxr.voice
-herdr plugin enable muxr.voice-gemini # or muxr.voice-openai
-```
-
-Open the enabled provider under **Settings → Plugins** and paste its API key. The attributed secure prompt sends the value once through authenticated E2EE to that plugin's write RPC; declarative UI never stores or displays it. Explicit enable/disable choices survive `npm` upgrades and subsequent `muxr setup` runs.
+The attributed secure prompt sends the value once through authenticated E2EE to that plugin's write RPC; declarative UI never stores or displays it. Provider and key choices survive `npm` upgrades and subsequent `muxr setup` runs.
 
 `MUXR_HOME` relocates the key directory. It is owner-only (`0700`); each key is owner-only (`0600`), written through a unique temporary file and atomic rename. Reads reject symlinks, non-regular files, and unsafe permissions.
 

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -39,6 +39,7 @@ export type {
     RequestResult,
     RequestType,
     StreamingBehavior,
+    VoiceProviderOption,
 } from './requests.js';
 export { MISSING_CWD_ERROR_PREFIX, normalizeRequestFailure, requestRequiresE2ee } from './requests.js';
 export type { LayoutSnapshot } from './requests.js';

--- a/packages/contract/src/requests.ts
+++ b/packages/contract/src/requests.ts
@@ -29,7 +29,7 @@ import type {
     SessionSnapshot,
     UnreadCatalog,
 } from './sessionDomain.js';
-import type { PluginManifestV1, PluginSummary } from './plugins.js';
+import type { PluginManifestV1, PluginSource, PluginSummary } from './plugins.js';
 import type { LandWorktreeResult } from './worktree.js';
 import type { AttentionCatalog, HerdrTreeWorkspace, SessionInfo, SessionShellOutcome, SessionStatus } from './sessionState.js';
 
@@ -41,7 +41,7 @@ export interface PromptAttachment {
 }
 
 export type StreamingBehavior = 'steer' | 'followUp';
-export type VoiceProviderOption = { id: string; name: string; available: boolean; selected: boolean };
+export type VoiceProviderOption = { id: string; name: string; selected: boolean; source: PluginSource; hasBackend: boolean };
 
 export interface RequestMap {
     // --- lifecycle ----------------------------------------------------------

--- a/packages/contract/src/requests.ts
+++ b/packages/contract/src/requests.ts
@@ -41,6 +41,7 @@ export interface PromptAttachment {
 }
 
 export type StreamingBehavior = 'steer' | 'followUp';
+export type VoiceProviderOption = { id: string; name: string; available: boolean; selected: boolean };
 
 export interface RequestMap {
     // --- lifecycle ----------------------------------------------------------
@@ -100,6 +101,16 @@ export interface RequestMap {
     'plugin.stream': {
         params: { pluginId: string; manifestHash: string; contributionId: string; channel: string; sessionId?: string };
         result: null;
+    };
+    /** Installed realtime providers and the one currently active on this machine. */
+    'voice.provider.list': {
+        params: Record<string, never>;
+        result: VoiceProviderOption[];
+    };
+    /** Switch the machine to exactly one installed realtime provider. */
+    'voice.provider.select': {
+        params: { providerId: string };
+        result: VoiceProviderOption[];
     };
     /**
      * Full herdr CLI for trusted clients such as the realtime voice agent.
@@ -367,7 +378,7 @@ export const MISSING_CWD_ERROR_PREFIX = 'cwd-does-not-exist:';
 
 /** Normalize both old-host crashes and current structured result errors. */
 export function requestRequiresE2ee(type: string): boolean {
-    return type === 'plugin.approve' || type === 'plugin.invoke' || type === 'plugin.call' || type === 'plugin.stream' || type === 'herdr.cli';
+    return type === 'plugin.approve' || type === 'plugin.invoke' || type === 'plugin.call' || type === 'plugin.stream' || type === 'voice.provider.select' || type === 'herdr.cli';
 }
 
 export function normalizeRequestFailure(

--- a/plugins/voice-gemini/README.md
+++ b/plugins/voice-gemini/README.md
@@ -4,5 +4,5 @@ A bundled, default-off Gemini Live speech-to-speech provider. It claims the same
 
 - **Host:** `rpc.mjs` owns `~/.muxr/gemini.key` (owner-only). `stream.mjs` owns the Gemini WebSocket, model, prompt, tools, and translation to muxr's generic realtime NDJSON frames.
 - **Phone:** only provider-neutral capture, playback, transcript, controls, and native plugin primitives. No Gemini URL, model, key, or event vocabulary reaches mobile code.
-- **Enable:** disable the current `voice.session` provider, then run `herdr plugin enable muxr.voice-gemini`. Configure its key from Settings → Plugins.
-- **Disable:** `herdr plugin disable muxr.voice-gemini`. The key remains until cleared from the plugin settings screen.
+- **Enable:** choose Gemini Live under Settings → Realtime voice, then open Configure to set its key.
+- **Disable:** choose another provider there. The Gemini key remains until cleared from its configuration screen.

--- a/plugins/voice-openai/README.md
+++ b/plugins/voice-openai/README.md
@@ -4,5 +4,5 @@ A bundled, default-off OpenAI Realtime speech-to-speech provider. It claims the 
 
 - **Host:** `rpc.mjs` owns `~/.muxr/openai.key` (owner-only). `stream.mjs` owns the OpenAI WebSocket, model, prompt, tools, and translation to muxr's generic realtime NDJSON frames.
 - **Phone:** only provider-neutral capture, playback, transcript, controls, and native plugin primitives. No OpenAI URL, model, key, or event vocabulary reaches mobile code.
-- **Enable:** disable the current `voice.session` provider, then run `herdr plugin enable muxr.voice-openai`. Configure its key from Settings → Plugins.
-- **Disable:** `herdr plugin disable muxr.voice-openai`. The key remains until cleared from the plugin settings screen.
+- **Enable:** choose OpenAI Realtime under Settings → Realtime voice, then open Configure to set its key.
+- **Disable:** choose another provider there. The OpenAI key remains until cleared from its configuration screen.

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -4,6 +4,6 @@ The bundled xAI Grok speech-to-speech provider plugin. It uses the same public p
 
 - **Host:** `rpc.mjs` owns the provider key (`~/.muxr/xai.key`, owner-only). `stream.mjs` is the persistent `host.stream` adapter: it holds the xAI WebSocket, auth, model (`grok-voice-think-fast-2.0`), prompt, and event translation, and speaks only the generic realtime NDJSON frames.
 - **Phone:** generic `icon-button` controls, a provider-neutral `realtime-session-overlay`, PCM capture/playback, and a retained generic WebRTC capability. No API key, model name, provider URL, or provider event vocabulary is stored or known on the phone.
-- **Settings:** the plugin contributes its own declarative settings screen. Secure prompt values go directly to its write RPC and are never persisted or rendered by declarative UI.
-- **Swap:** disable this plugin and enable another that declares the same `voice.session` host.stream capability. The compiled WebRTC capability remains available for a provider-neutral muxr signaling adapter; adding a provider never adds a React Native provider branch.
+- **Settings:** choose Grok under Settings → Realtime voice, then open Configure. Secure prompt values go directly to its write RPC and are never persisted or rendered by declarative UI.
+- **Swap:** the app asks the host to serialize the switch between plugins declaring `voice.session`. The compiled WebRTC capability remains available for a provider-neutral muxr signaling adapter; adding a provider never adds a React Native transport branch.
 - **Removal:** clear the key from the plugin-owned Settings row, then `herdr plugin unlink muxr.voice`.

--- a/plugins/voice/herdr-plugin.toml
+++ b/plugins/voice/herdr-plugin.toml
@@ -1,5 +1,5 @@
 id = "muxr.voice"
-name = "muxr Voice"
+name = "Grok"
 version = "0.1.0"
 min_herdr_version = "0.8.0"
 description = "xAI Grok speech-to-speech behind muxr's provider-neutral stream"

--- a/plugins/voice/herdr-plugin.toml
+++ b/plugins/voice/herdr-plugin.toml
@@ -7,6 +7,6 @@ platforms = ["linux", "macos"]
 
 [[panes]]
 id = "setup"
-title = "muxr Voice setup"
+title = "Grok setup"
 placement = "overlay"
 command = ["node", "./setup.mjs"]


### PR DESCRIPTION
## What changed

- adds **Settings → Realtime voice** with the installed Grok, Gemini Live, and OpenAI Realtime providers
- switches the connected machine to exactly one provider and keeps provider credentials/configuration inside each backend plugin
- serializes concurrent device switches, converges after out-of-band Herdr changes, and rolls back partial failures
- discloses plugin source/code authority before the app grants access to the selected provider
- keeps the existing declarative provider Settings row as a staggered-upgrade fallback for older hosts
- blocks read-only browser grants from changing the provider

No provider URLs, models, credentials, or event vocabulary moved into the mobile realtime transport. The app discovers providers through the generic `voice.session` capability.

## Native Android

### Settings entry

![Settings entry](https://github.com/user-attachments/assets/21ca8e42-786d-4a0a-828a-114d8d1e9535)

### Gemini Live selected

![Gemini Live selected](https://github.com/user-attachments/assets/13181c35-1a8d-4a73-9bfb-288e67328045)

### OpenAI Realtime selected

![OpenAI Realtime selected](https://github.com/user-attachments/assets/c37333ca-6c50-4954-8f16-9803bcebf66f)

### Provider-owned key configuration

![Gemini configuration](https://github.com/user-attachments/assets/ff3c53a1-ac06-4eaa-b84d-300864d58f0f)

## Verification

- `yarn run check`: **30/30 passed** on final head
- focused host/provider flows: **23/23 passed**
- bundled plugin manifest/caste policy: passed
- workspace, host, and mobile TypeScript: passed
- independent Claude Opus review: **PASS — no actionable findings**
- API 36 x86_64 release APK built, v2 signature verified, and installed APK matched the build byte-for-byte (`26931e3c…`)
- paired the release APK to an isolated source-built self-host stack
- verified all three providers were listed, switched Gemini Live → OpenAI Realtime → Gemini Live, and confirmed exactly one remained enabled
- verified first-use Configure approved the selected provider and opened its plugin-owned key screen
- Android crash buffer and relevant app error scan were empty

The live machine was restored to **Gemini Live enabled**, with Grok and OpenAI Realtime disabled.
