### PR TITLE
Fix choppy realtime voice and minimized pill crash

### DIFF
--- a/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/RealtimePcmPlayer.kt
+++ b/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/RealtimePcmPlayer.kt
@@ -4,7 +4,7 @@ import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
 import android.util.Base64
-import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
@@ -15,8 +15,10 @@ internal class RealtimePcmPlayer {
     1,
     0L,
     TimeUnit.MILLISECONDS,
-    ArrayBlockingQueue(8),
-    ThreadPoolExecutor.DiscardOldestPolicy(),
+    // Provider audio arrives in bursts. Dropping the oldest queued delta skips
+    // straight into later speech, which sounds like words overlap and get cut.
+    // ponytail: cap by buffered PCM duration only if a provider can outrun playback.
+    LinkedBlockingQueue(),
   )
   @Volatile private var track: AudioTrack? = null
 

--- a/apps/mobile/sources/plugins/primitives/RealtimeSessionOverlay.tsx
+++ b/apps/mobile/sources/plugins/primitives/RealtimeSessionOverlay.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dimensions, Platform, View } from 'react-native';
+import { Platform, useWindowDimensions, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text } from '@/components/StyledText';
@@ -54,23 +54,18 @@ export const RealtimeSessionOverlay = React.memo(function RealtimeSessionOverlay
               : t('plugins.realtimeOff');
     const conversationVisible = useRealtimeConversationVisible();
 
-    const window = Dimensions.get('window');
-    const x = useSharedValue(window.width - WIDTH - MARGIN);
-    const y = useSharedValue(window.height * 0.62);
+    const { width, height } = useWindowDimensions();
+    const x = useSharedValue(width - WIDTH - MARGIN);
+    const y = useSharedValue(height * 0.62);
     const startX = useSharedValue(0);
     const startY = useSharedValue(0);
 
     React.useEffect(() => {
-        const clamp = ({ width, height }: { width: number; height: number }) => {
-            const maxX = Math.max(MARGIN, width - WIDTH - MARGIN);
-            const maxY = Math.max(safeArea.top + MARGIN, height - HEIGHT - safeArea.bottom - MARGIN);
-            x.value = withSpring(Math.min(Math.max(x.value, MARGIN), maxX), { damping: 18 });
-            y.value = withSpring(Math.min(Math.max(y.value, safeArea.top + MARGIN), maxY), { damping: 18 });
-        };
-        clamp(Dimensions.get('window'));
-        const subscription = Dimensions.addEventListener('change', ({ window: nextWindow }) => clamp(nextWindow));
-        return () => subscription.remove();
-    }, [safeArea.bottom, safeArea.top, x, y]);
+        const maxX = Math.max(MARGIN, width - WIDTH - MARGIN);
+        const maxY = Math.max(safeArea.top + MARGIN, height - HEIGHT - safeArea.bottom - MARGIN);
+        x.value = withSpring(Math.min(Math.max(x.value, MARGIN), maxX), { damping: 18 });
+        y.value = withSpring(Math.min(Math.max(y.value, safeArea.top + MARGIN), maxY), { damping: 18 });
+    }, [height, safeArea.bottom, safeArea.top, width, x, y]);
 
     const drag = React.useMemo(
         () =>
@@ -84,13 +79,12 @@ export const RealtimeSessionOverlay = React.memo(function RealtimeSessionOverlay
                     y.value = startY.value + event.translationY;
                 })
                 .onEnd(() => {
-                    const { width, height } = Dimensions.get('window');
                     const toLeft = x.value + WIDTH / 2 < width / 2;
                     x.value = withSpring(toLeft ? MARGIN : Math.max(MARGIN, width - WIDTH - MARGIN), { damping: 18 });
                     const maxY = Math.max(safeArea.top + MARGIN, height - HEIGHT - safeArea.bottom - MARGIN);
                     y.value = withSpring(Math.min(Math.max(y.value, safeArea.top + MARGIN), maxY), { damping: 18 });
                 }),
-        [safeArea.bottom, safeArea.top, startX, startY, x, y],
+        [height, safeArea.bottom, safeArea.top, startX, startY, width, x, y],
     );
 
     const press = useSharedValue(1);

--- a/apps/mobile/sources/realtime/RealtimeConversation.tsx
+++ b/apps/mobile/sources/realtime/RealtimeConversation.tsx
@@ -104,7 +104,7 @@ export const RealtimeConversation = React.memo(function RealtimeConversation({
             </View>
 
             <View style={{ flex: 1, alignItems: 'center', paddingHorizontal: 24, paddingTop: 8, gap: 18 }}>
-                <RealtimeSessionVisual size={200} state={state} muted={muted} />
+                <RealtimeSessionVisual size={240} state={state} muted={muted} />
                 <Text style={{ color: '#f7f8fb', fontSize: 22, lineHeight: 28, textAlign: 'center', ...Typography.default('semiBold') }}>
                     {status}
                 </Text>

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -754,7 +754,9 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                         paddingVertical: 8,
                     }}
                 />
-                <PluginSlot slot="session.composer.trailing" context={{ sessionId: props.id, getText: () => draftRef.current, setText: setDraft }} />
+                <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                    <PluginSlot slot="session.composer.trailing" context={{ sessionId: props.id, getText: () => draftRef.current, setText: setDraft }} />
+                </View>
                 <Pressable onPress={sendPrompt} hitSlop={8} disabled={!canSend} accessibilityRole="button" accessibilityLabel="Send" accessibilityState={{ disabled: !canSend }} style={{ opacity: canSend ? 1 : 0.4 }}>
                     <Ionicons name="arrow-up-circle" size={30} color={theme.colors.text} />
                 </Pressable>


### PR DESCRIPTION
## Summary
- preserve all provider PCM deltas instead of dropping older chunks during bursty realtime playback
- keep window measurement out of the pill drag worklet, fixing the Android crash after minimizing and moving the realtime pill
- enlarge the realtime galaxy and visually group the dictation/realtime composer controls

## Verification
- reproduced the Android pill crash as `undefined is not a function` in `RealtimeSessionOverlay` after minimizing and dragging
- `yarn workspace @muxr/wire build`
- `yarn workspace @muxr/mobile typecheck`
- `yarn vitest run apps/mobile/sources/voice/realtimeSession.spec.ts`
- `./gradlew :voice-overlay:compileDebugKotlin --no-daemon`
- preview Android `app:assembleDebug` build
- `git diff --check`
