### PR TITLE
Keep watching agent completion after realtime voice sleeps

### DIFF
--- a/apps/mobile/sources/plugins/primitives/RealtimeSessionOverlay.tsx
+++ b/apps/mobile/sources/plugins/primitives/RealtimeSessionOverlay.tsx
@@ -23,6 +23,7 @@ import {
     useRealtimeConversationVisible,
     useRealtimeMuted,
     useRealtimeSessionState,
+    useRealtimeWatching,
     stopRealtimeSession,
 } from '@/realtime/realtimeSessionState';
 
@@ -39,8 +40,10 @@ export const RealtimeSessionOverlay = React.memo(function RealtimeSessionOverlay
     React.useEffect(() => mountPrimitive('realtime-session-overlay'), []);
     React.useEffect(() => () => stopRealtimeSession(), []);
     const muted = useRealtimeMuted();
+    const watching = useRealtimeWatching();
     const open = state !== 'disconnected';
     const failed = !open && detail !== undefined;
+    const sleeping = watching && !open && !failed;
     const sessionLabel = state === 'connecting'
         ? t('plugins.realtimeConnecting')
         : state === 'connected'
@@ -49,9 +52,11 @@ export const RealtimeSessionOverlay = React.memo(function RealtimeSessionOverlay
             ? t('plugins.realtimeThinking')
             : state === 'speaking'
               ? t('plugins.realtimeSpeaking')
-            : failed
-              ? t('plugins.realtimeError')
-              : t('plugins.realtimeOff');
+            : sleeping
+              ? 'Watching'
+              : failed
+                ? t('plugins.realtimeError')
+                : t('plugins.realtimeOff');
     const conversationVisible = useRealtimeConversationVisible();
 
     const { width, height } = useWindowDimensions();
@@ -98,11 +103,11 @@ export const RealtimeSessionOverlay = React.memo(function RealtimeSessionOverlay
         transform: [{ translateX: x.value }, { translateY: y.value }, { scale: press.value }],
     }));
 
-    if (!open && !conversationVisible && !failed) return null;
+    if (!open && !conversationVisible && !failed && !watching) return null;
 
     return (
         <>
-            {(open || failed) && (
+            {(open || failed || watching) && (
                 <View pointerEvents="box-none" style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
                     <GestureDetector gesture={Gesture.Race(drag, tap)}>
                         <Animated.View

--- a/apps/mobile/sources/realtime/RealtimeConversation.tsx
+++ b/apps/mobile/sources/realtime/RealtimeConversation.tsx
@@ -17,6 +17,7 @@ import {
     useRealtimeMuted,
     useRealtimeSessionState,
     useRealtimeTurns,
+    useRealtimeWatching,
 } from './realtimeSessionState';
 
 export const RealtimeConversation = React.memo(function RealtimeConversation({
@@ -30,6 +31,7 @@ export const RealtimeConversation = React.memo(function RealtimeConversation({
     const { state, detail } = useRealtimeSessionState();
     const turns = useRealtimeTurns();
     const muted = useRealtimeMuted();
+    const watching = useRealtimeWatching();
     const previousState = React.useRef(state);
     const transcript = React.useRef<ScrollView>(null);
     // The voice is attached to a working session; what that session is doing is
@@ -65,7 +67,7 @@ export const RealtimeConversation = React.memo(function RealtimeConversation({
     // 28pt it wrapped into four lines and took the screen, which is how a
     // hiccup ends up looking like a crash.
     const status = (state === 'disconnected'
-        ? 'Asleep — tap the mic to wake'
+        ? watching ? 'Asleep — watching agent' : 'Asleep — tap the mic to wake'
         : state === 'connecting'
           ? 'Connecting…'
           : state === 'thinking'

--- a/apps/mobile/sources/realtime/realtimeSessionState.ts
+++ b/apps/mobile/sources/realtime/realtimeSessionState.ts
@@ -29,6 +29,8 @@ let turnId = 0;
 let bound: string | null = null;
 let pendingSpeech: string | null = null;
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
+/** Local completion watch; unlike `session`, this owns no provider connection. */
+let watching = false;
 /** Last used pane for a notification Talk action. */
 let realtimeTarget: string | null = null;
 /** The one root-owned conversation sheet, shared by Terminal and Home. */
@@ -104,6 +106,10 @@ export function rememberedRealtimeSession(): string | null {
     return realtimeTarget;
 }
 
+export function realtimeWatchTarget(): string | null {
+    return watching ? realtimeTarget : null;
+}
+
 export function acknowledgeRealtimeError(): void {
     detail = undefined;
     notify();
@@ -142,7 +148,7 @@ function clearIdleTimer(): void {
 function keepAwake(epoch: number): void {
     clearIdleTimer();
     idleTimer = setTimeout(() => {
-        if (epoch === realtimeEpoch && session !== null) stopRealtimeSession();
+        if (epoch === realtimeEpoch && session !== null) sleepRealtimeSession();
     }, IDLE_HANGUP_MS);
 }
 
@@ -177,6 +183,7 @@ export function startRealtimeSession(sessionId: string): boolean {
     }
     const epoch = ++realtimeEpoch;
     realtimeTarget = sessionId;
+    watching = true;
     clearIdleTimer();
     session?.stop();
     if (session !== null || starting) stopVoiceService();
@@ -213,7 +220,7 @@ function startRealtimeAfterService(sessionId: string, epoch: number): void {
                 if (next === 'disconnected') {
                     clearLiveState();
                     state = 'disconnected';
-                    detail = why;
+                    detail = why === 'ended' ? undefined : why;
                     notify();
                     return;
                 }
@@ -248,7 +255,7 @@ function startRealtimeAfterService(sessionId: string, epoch: number): void {
     starting = false;
 }
 
-export function stopRealtimeSession(): void {
+function sleepRealtimeSession(): void {
     realtimeEpoch++;
     const active = session;
     clearLiveState();
@@ -256,6 +263,11 @@ export function stopRealtimeSession(): void {
     state = 'disconnected';
     detail = undefined;
     notify();
+}
+
+export function stopRealtimeSession(): void {
+    watching = false;
+    sleepRealtimeSession();
 }
 
 export function toggleRealtimeMuted(): void {
@@ -284,6 +296,10 @@ export function useRealtimeTurns(): RealtimeTurn[] {
 
 export function useRealtimeMuted(): boolean {
     return React.useSyncExternalStore(subscribe, () => muted);
+}
+
+export function useRealtimeWatching(): boolean {
+    return React.useSyncExternalStore(subscribe, () => watching);
 }
 
 export function openRealtimeConversation(): void {

--- a/apps/mobile/sources/realtime/realtimeSessionState.ts
+++ b/apps/mobile/sources/realtime/realtimeSessionState.ts
@@ -28,6 +28,8 @@ let muted = false;
 let turnId = 0;
 let bound: string | null = null;
 let pendingSpeech: string | null = null;
+let sleepAfterSpeech = false;
+let reportSpeechStarted = false;
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
 /** Local completion watch; unlike `session`, this owns no provider connection. */
 let watching = false;
@@ -121,11 +123,13 @@ export function speak(text: string): void {
 }
 
 /**
- * Say this once a session exists. Waking the agent takes a few seconds, so a
- * report that arrives while it is asleep would otherwise be spoken into a
- * session that is not listening yet, and lost.
+ * Say this once a session exists, then disconnect again after its reply so a
+ * completion report cannot leave a paid provider idling. Waking takes a few
+ * seconds, so a report arriving while asleep must also survive until ready.
  */
 export function speakWhenReady(text: string): void {
+    sleepAfterSpeech = true;
+    reportSpeechStarted = false;
     if (session !== null) return session.speak(text);
     pendingSpeech = text;
 }
@@ -161,6 +165,8 @@ function clearLiveState(): void {
     turns = [];
     muted = false;
     pendingSpeech = null;
+    sleepAfterSpeech = false;
+    reportSpeechStarted = false;
 }
 
 function failRealtimeStart(epoch: number, reason: string): void {
@@ -190,6 +196,8 @@ export function startRealtimeSession(sessionId: string): boolean {
     session = null;
     turns = [];
     muted = false;
+    sleepAfterSpeech = false;
+    reportSpeechStarted = false;
     bound = sessionId;
     starting = true;
     state = 'connecting';
@@ -225,6 +233,11 @@ function startRealtimeAfterService(sessionId: string, epoch: number): void {
                     return;
                 }
                 if (next === 'connected' || next === 'thinking' || next === 'speaking') keepAwake(liveEpoch);
+                if (next === 'speaking' && sleepAfterSpeech) reportSpeechStarted = true;
+                if (next === 'connected' && sleepAfterSpeech && reportSpeechStarted) {
+                    sleepRealtimeSession();
+                    return;
+                }
                 if (next === 'connected' && pendingSpeech !== null) {
                     handle.speak(pendingSpeech);
                     pendingSpeech = null;

--- a/apps/mobile/sources/utils/dictation.spec.ts
+++ b/apps/mobile/sources/utils/dictation.spec.ts
@@ -3,7 +3,8 @@ import React from 'react';
 import TestRenderer from 'react-test-renderer';
 import { useDictation } from './dictation';
 import { pcm16ChunksToArrayBuffer } from './transcription';
-import { micOwners, registerRealtimeNotificationStart, releaseDictation, resolveRealtimeTarget, startRealtimeSession, stopRealtimeSession } from '../realtime/realtimeSessionState';
+import { wakeAndReport } from '../voice/wakeAndReport';
+import { micOwners, realtimeWatchTarget, registerRealtimeNotificationStart, releaseDictation, resolveRealtimeTarget, startRealtimeSession, stopRealtimeSession } from '../realtime/realtimeSessionState';
 
 const mocks = vi.hoisted(() => ({
     sessions: {} as Record<string, { id: string; activeAt: number; updatedAt: number }>,
@@ -21,12 +22,14 @@ const mocks = vi.hoisted(() => ({
         return { remove: () => undefined };
     }),
     syncRequest: vi.fn(),
+    callPlugin: vi.fn(),
 }));
 
 vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
 vi.mock('react-native-live-audio-stream', () => ({ default: mocks.liveAudio }));
 vi.mock('@/utils/localTranscription', () => ({ transcribePcm16: mocks.transcribe }));
 vi.mock('@/sync/sync', () => ({ sync: { request: mocks.syncRequest } }));
+vi.mock('@/plugins/callPlugin', () => ({ callPlugin: mocks.callPlugin }));
 vi.mock('@/modal', () => ({ Modal: { alert: mocks.modalAlert } }));
 vi.mock('@/sync/storage', () => ({ storage: { getState: () => ({ sessions: mocks.sessions }) } }));
 vi.mock('@/utils/microphonePermissions', () => ({
@@ -80,6 +83,7 @@ beforeEach(() => {
         if (target !== null) startRealtimeSession(target);
     });
     mocks.syncRequest.mockResolvedValue({ text: 'unused' });
+    mocks.callPlugin.mockResolvedValue({ say: 'The agent finished.' });
     vi.clearAllMocks();
 });
 
@@ -137,6 +141,32 @@ describe('on-device dictation flow', () => {
 
         mocks.notificationAction?.('mute');
         expect(setMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('disconnects the sleeping provider, keeps watching locally, and wakes once to report completion', async () => {
+        const first = { stop: vi.fn(), setMuted: vi.fn(), speak: vi.fn() };
+        const woken = { stop: vi.fn(), setMuted: vi.fn(), speak: vi.fn() };
+        mocks.startRealtimeSession.mockReturnValueOnce(first).mockReturnValueOnce(woken);
+
+        startRealtimeSession('session-a');
+        expect(realtimeWatchTarget()).toBe('session-a');
+        const provider = mocks.startRealtimeSession.mock.calls[0]![0] as {
+            onStatus: (status: 'disconnected', detail?: string) => void;
+        };
+        provider.onStatus('disconnected', 'ended');
+
+        expect(micOwners()).toEqual([]);
+        expect(mocks.stopVoiceService).toHaveBeenCalledOnce();
+        expect(realtimeWatchTarget()).toBe('session-a');
+
+        await wakeAndReport({ sessionId: 'session-a', status: 'done', pane: 'finished cleanly' });
+        expect(mocks.startRealtimeSession).toHaveBeenCalledTimes(2);
+        expect(mocks.callPlugin).toHaveBeenCalledWith('voice.report', { status: 'done', pane: 'finished cleanly' });
+        expect(woken.speak).toHaveBeenCalledWith('The agent finished.');
+
+        stopRealtimeSession();
+        expect(woken.stop).toHaveBeenCalledOnce();
+        expect(realtimeWatchTarget()).toBeNull();
     });
 
     it('releases ownership when the native recorder cannot start', async () => {

--- a/apps/mobile/sources/utils/dictation.spec.ts
+++ b/apps/mobile/sources/utils/dictation.spec.ts
@@ -164,8 +164,17 @@ describe('on-device dictation flow', () => {
         expect(mocks.callPlugin).toHaveBeenCalledWith('voice.report', { status: 'done', pane: 'finished cleanly' });
         expect(woken.speak).toHaveBeenCalledWith('The agent finished.');
 
-        stopRealtimeSession();
+        const reportProvider = mocks.startRealtimeSession.mock.calls[1]![0] as {
+            onStatus: (status: 'connected' | 'speaking') => void;
+        };
+        reportProvider.onStatus('connected');
+        reportProvider.onStatus('speaking');
+        reportProvider.onStatus('connected');
         expect(woken.stop).toHaveBeenCalledOnce();
+        expect(micOwners()).toEqual([]);
+        expect(realtimeWatchTarget()).toBe('session-a');
+
+        stopRealtimeSession();
         expect(realtimeWatchTarget()).toBeNull();
     });
 

--- a/apps/mobile/sources/voice/wakeAndReport.ts
+++ b/apps/mobile/sources/voice/wakeAndReport.ts
@@ -1,5 +1,5 @@
 import { callPlugin } from '@/plugins/callPlugin';
-import { boundRealtimeSession, realtimeConversationVisible, rememberedRealtimeSession, speak, speakWhenReady, startRealtimeSession, realtimeSessionSnapshot } from '@/realtime/realtimeSessionState';
+import { realtimeWatchTarget, speak, speakWhenReady, startRealtimeSession, realtimeSessionSnapshot } from '@/realtime/realtimeSessionState';
 
 /**
  * Voice's `speech.wake` capability: speaking needs the WebRTC session this app
@@ -8,11 +8,9 @@ import { boundRealtimeSession, realtimeConversationVisible, rememberedRealtimeSe
  */
 export async function wakeAndReport(input: { sessionId: string; status: string; pane?: string }): Promise<void> {
     const live = realtimeSessionSnapshot().state !== 'disconnected';
-    // Only the pane this conversation is about, and only where the user can see
-    // it wake: a phone that starts talking from a background screen is a bug.
-    const mine = boundRealtimeSession() ?? (realtimeConversationVisible() ? rememberedRealtimeSession() : null);
-    if (mine !== input.sessionId) return;
-    if (!live && !realtimeConversationVisible()) return;
+    // “Go to sleep” closes the paid provider stream but leaves this local watch
+    // attached to one pane until the user explicitly ends the realtime UI.
+    if (realtimeWatchTarget() !== input.sessionId) return;
     if (!live && !startRealtimeSession(input.sessionId)) return;
 
     const report = await callPlugin<{ say: string }>('voice.report', { status: input.status, pane: input.pane ?? '' });


### PR DESCRIPTION
## Summary
- fully disconnect the realtime provider and microphone after “go to sleep” or the idle timeout, while retaining a zero-provider-cost local watch for the bound agent
- keep a minimized `Watching` pill visible and reconnect only when that agent transitions from working to idle, done, or blocked
- read the pane tail, ask the selected realtime provider for one short completion summary, then disconnect the provider again immediately after the reply
- cancel the local watch only when the user explicitly ends the realtime UI

## Verification
- `yarn workspace @muxr/wire build`
- `yarn tsc --build --force`
- `yarn workspace @muxr/mobile typecheck`
- `yarn vitest run apps/mobile/sources/utils/dictation.spec.ts apps/mobile/sources/voice/realtimeSession.spec.ts apps/mobile/sources/plugins/screenModel.spec.ts`
- flow test covers provider disconnect, microphone-service release, local watch retention, event-triggered reconnect/report, automatic post-report disconnect, and explicit cancellation
- `git diff --check`
