### PR TITLE
Fix standalone relay Docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "@types/ws": "^8.5.13",
         "esbuild": "^0.28.1",
         "patch-package": "^8.0.1",
-        "typescript": "^5.7.2"
+        "typescript": "^5.7.2",
+        "vitest": "3.2.6"
     },
     "dependencies": {
         "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
The relay Docker context intentionally excludes mobile and wire workspaces, but its TypeScript build still type-checks Vitest-backed specs. Declare Vitest at the root so the supported standalone Dockerfile does not depend on unrelated workspace manifests.

## Verification

- `docker build --tag muxr-relay:test .`