### PR TITLE
Add relay container health probe dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY --from=build /app/packages ./packages
 COPY --from=build /app/apps/relay ./apps/relay
 VOLUME /data
 EXPOSE 8792
-RUN mkdir -p /data && chown node:node /data
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /data \
+    && chown node:node /data
 USER node
 CMD ["node", "apps/relay/dist/main.js"]


### PR DESCRIPTION
Coolify and other Docker orchestrators execute the configured readiness probe inside the runtime image. Install curl in the slim relay image so `/ready` can gate deployment instead of reporting a healthy relay as unhealthy.

## Verification

- `docker build --tag muxr-relay:healthcheck .`
- started the image and fetched `http://127.0.0.1:18792/ready` successfully