### PR TITLE
Deploy the relay through Coolify

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,0 +1,57 @@
+name: deploy relay
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - package.json
+      - yarn.lock
+      - apps/relay/**
+      - packages/contract/**
+      - packages/crypto/**
+      - .github/workflows/deploy-relay.yml
+  workflow_dispatch:
+
+concurrency:
+  group: production-relay
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Deploy through Coolify
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_URL: ${{ vars.COOLIFY_URL }}
+          APPLICATION_UUID: ${{ vars.COOLIFY_RELAY_APP_UUID }}
+        run: |
+          response=$(curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            "${COOLIFY_URL}/api/v1/deploy?uuid=${APPLICATION_UUID}&force=true")
+          deployment=$(jq -er '.deployments[0].deployment_uuid' <<<"${response}")
+
+          for _ in {1..180}; do
+            status=$(curl --fail --silent --show-error \
+              --header "Authorization: Bearer ${COOLIFY_TOKEN}" \
+              "${COOLIFY_URL}/api/v1/deployments/${deployment}" | jq -er '.status')
+            case "${status}" in
+              finished) exit 0 ;;
+              failed|cancelled) echo "Coolify deployment ${status}" >&2; exit 1 ;;
+            esac
+            sleep 5
+          done
+
+          echo "Coolify deployment timed out" >&2
+          exit 1
+
+      - name: Verify relay readiness
+        env:
+          HEALTH_URL: ${{ vars.COOLIFY_RELAY_HEALTH_URL }}
+        run: curl --fail --silent --show-error --retry 10 --retry-delay 3 --retry-all-errors "${HEALTH_URL}"


### PR DESCRIPTION
Deploy the production relay from the shared Hetzner/Coolify platform whenever its Docker runtime or relay dependencies change. The workflow waits for Coolify to finish and then verifies the public readiness endpoint.

Repository configuration now contains the Coolify URL, relay application selector, health URL, and a secret API token.