### PR TITLE
Use the dedicated production relay domain

### DIFF
--- a/.github/workflows/mobile-internal.yml
+++ b/.github/workflows/mobile-internal.yml
@@ -23,7 +23,7 @@ env:
   MUXR_PUBLIC_BASE_URL: https://trymuxr.com
   MUXR_DISTRIBUTION: store
   EXPO_PUBLIC_MUXR_MODE: hosted
-  EXPO_PUBLIC_MUXR_RELAY_URL: wss://trymuxr.com
+  EXPO_PUBLIC_MUXR_RELAY_URL: wss://relay.trymuxr.com
 
 jobs:
   verify:

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -25,7 +25,7 @@
                 "MUXR_PUBLIC_BASE_URL": "https://trymuxr.com",
                 "MUXR_DISTRIBUTION": "store",
                 "EXPO_PUBLIC_MUXR_MODE": "hosted",
-                "EXPO_PUBLIC_MUXR_RELAY_URL": "wss://trymuxr.com",
+                "EXPO_PUBLIC_MUXR_RELAY_URL": "wss://relay.trymuxr.com",
                 "ORG_GRADLE_PROJECT_reactNativeArchitectures": "arm64-v8a"
             }
         },


### PR DESCRIPTION
Point internal and production mobile builds at `wss://relay.trymuxr.com` instead of the marketing origin. This matches the new Coolify relay deployment and keeps the website and WebSocket service on separate hostnames.

Validated with `node scripts/checkMobileCommerceBuilds.mjs`, JSON parsing, and `git diff --check`.