### PR TITLE
Refresh attachment lists when pane files change

### DIFF
--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -318,8 +318,10 @@ export async function createHerdrSessionSource(
     /** Agent-dropped artifacts in the pane's dump dir. Listed on demand through the attachments plugin. */
     const attachmentsDir = options.attachmentsDir ?? join(homedir(), '.muxr', 'attachments', 'pane');
     const attachments = new AttachmentWatcher(attachmentsDir, () => {
-        // Listed on demand through the attachments plugin RPC. Pushing the
-        // catalog onto the phone froze the JS thread on large files.
+        // Bytes stay pull-only, but the phone must discard its cached count
+        // when the directory changes or a newly written file stays at 0 until reconnect.
+        const frame: PluginsInvalidatedFrame = { type: 'plugins.invalidated', reason: 'changed', pluginIds: ['muxr.attachments'] };
+        for (const listener of machineListeners) listener(frame);
     });
     attachments.start();
 

--- a/apps/host/src/herdr/herdrSessionSource.ts
+++ b/apps/host/src/herdr/herdrSessionSource.ts
@@ -320,7 +320,7 @@ export async function createHerdrSessionSource(
     const attachments = new AttachmentWatcher(attachmentsDir, () => {
         // Bytes stay pull-only, but the phone must discard its cached count
         // when the directory changes or a newly written file stays at 0 until reconnect.
-        const frame: PluginsInvalidatedFrame = { type: 'plugins.invalidated', reason: 'changed', pluginIds: ['muxr.attachments'] };
+        const frame: PluginsInvalidatedFrame = { type: 'plugins.invalidated', reason: 'changed', pluginIds: [] };
         for (const listener of machineListeners) listener(frame);
     });
     attachments.start();


### PR DESCRIPTION
## Root cause

The host detected new files but intentionally emitted no catalog data, while the mobile item-list cached its initial empty response indefinitely. The attachment therefore stayed at `0` until a reconnect.

## Fix

Send the existing provider-neutral plugin invalidation frame when the watched pane directory changes. Attachment bytes remain pull-only; only the tiny cache-invalidation signal is pushed.

Validated with `yarn build` and `git diff --check`.