### PR TITLE
Harden mobile store review links

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -93,6 +93,12 @@
         <data android:scheme="muxr"/>
         <data android:scheme="exp+muxr"/>
       </intent-filter>
+      <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="https" android:host="trymuxr.com" android:pathPrefix="/pair"/>
+      </intent-filter>
       <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts"/>
     </activity>
   </application>

--- a/apps/mobile/ios/muxr/Info.plist
+++ b/apps/mobile/ios/muxr/Info.plist
@@ -89,7 +89,7 @@
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your microphone for voice conversations.</string>
     <key>NSPhotoLibraryUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your photos</string>
+    <string>Allow $(PRODUCT_NAME) to attach a photo to an agent session.</string>
     <key>NSUserActivityTypes</key>
     <array>
       <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>

--- a/scripts/checkMobileCommerceBuilds.mjs
+++ b/scripts/checkMobileCommerceBuilds.mjs
@@ -37,6 +37,8 @@ const xcodeTargets = [...readFileSync(join(mobile, 'ios', 'muxr.xcodeproj', 'pro
 assert.equal(xcodeTargets.length, 4, 'expected four Xcode deployment-target settings');
 assert.ok(xcodeTargets.every((target) => target >= 16.4), 'Xcode target is below expo-libghostty minimum');
 assert.match(readFileSync(join(mobile, 'android', 'app', 'build.gradle'), 'utf8'), /applicationId 'com\.trymuxr\.app'/);
+const androidManifest = readFileSync(join(mobile, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), 'utf8');
+assert.match(androidManifest, /<intent-filter android:autoVerify="true">[\s\S]*?<data android:scheme="https" android:host="trymuxr\.com" android:pathPrefix="\/pair"\/>[\s\S]*?<\/intent-filter>/, 'production manifest lost verified pairing links');
 const voiceManifest = readFileSync(join(mobile, 'modules', 'voice-overlay', 'android', 'src', 'main', 'AndroidManifest.xml'), 'utf8');
 assert.match(voiceManifest, /FOREGROUND_SERVICE_DATA_SYNC/);
 assert.match(voiceManifest, /foregroundServiceType="microphone\|dataSync"/);


### PR DESCRIPTION
## Summary
- keep the production Android pairing App Link in the committed native manifest
- make the iOS photo attachment permission explanation specific
- fail the mobile release gate if verified pairing links drift again

## Verification
- node scripts/checkMobileCommerceBuilds.mjs
- yarn workspace @muxr/mobile typecheck
- git diff --check