### PR TITLE
Fix multi-machine pairing handoff

### DIFF
--- a/apps/host/src/requests/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/createRequestDispatcher.test.ts
@@ -45,8 +45,8 @@ describe('session.start cwd guard', () => {
     });
 });
 
-describe('agent availability catalog', () => {
-    it('keeps the full Herdr catalog while reporting only launchable executables', async () => {
+describe('host capability catalog', () => {
+    it('reports launchable agents and the actual host platform', async () => {
         const source = {
             async agentKinds() { return ['pi', 'claude', 'codex']; },
             async installedAgentKinds() { return ['claude']; },
@@ -59,6 +59,11 @@ describe('agent availability catalog', () => {
         });
         await expect(dispatch({ type: 'herdr.agentKinds', requestId: 'catalog', params: {} } as never, 'device-1'))
             .resolves.toMatchObject({ ok: true, data: { kinds: ['pi', 'claude', 'codex'], installed: ['claude'] } });
+        await expect(dispatch({ type: 'machines.list', requestId: 'machines', params: {} } as never, 'device-1'))
+            .resolves.toMatchObject({
+                ok: true,
+                data: [{ platform: process.platform === 'darwin' ? 'macOS' : process.platform === 'win32' ? 'Windows' : process.platform === 'linux' ? 'Linux' : process.platform }],
+            });
     });
 });
 

--- a/apps/host/src/requests/createRequestDispatcher.ts
+++ b/apps/host/src/requests/createRequestDispatcher.ts
@@ -149,7 +149,13 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
         'unread.acknowledge': async (params) => domain.unread.acknowledge(params.sessionId, params.throughSeq),
         'attention.catalog': async () => domain.attention.catalog(),
         'machines.list': async () => [
-            { machineId, online: true, hostVersion, lastSeenAt: new Date().toISOString() },
+            {
+                machineId,
+                online: true,
+                hostVersion,
+                platform: process.platform === 'darwin' ? 'macOS' : process.platform === 'win32' ? 'Windows' : process.platform === 'linux' ? 'Linux' : process.platform,
+                lastSeenAt: new Date().toISOString(),
+            },
         ],
         'machine.shell': (params) => runMachineShell(params.command, params.cwd),
         'machine.listDir': (params) => listDir(params.path),

--- a/apps/mobile/sources/app/(app)/new-agent.tsx
+++ b/apps/mobile/sources/app/(app)/new-agent.tsx
@@ -34,13 +34,12 @@ import {
     saveConnectionSettings,
 } from '@/state/connectionSettings';
 
-import { FALLBACK_AGENT_KINDS } from '@/sync/agentKinds';
+import { FALLBACK_AGENT_KINDS, resolveAgentCatalog, type AgentCatalogOption } from '@/sync/agentKinds';
 import { getCachedHostedGrant } from '@/state/hostedE2ee';
 
 const MAX_SQUAD = 4;
 const MAX_RECENT_CHIPS = 6;
-type AgentAvailability = 'installed' | 'unavailable' | 'unknown';
-type AgentOption = { kind: string; availability: AgentAvailability };
+type AgentOption = AgentCatalogOption;
 const MAX_WORKSPACE_ROWS = 6;
 
 function basename(path: string): string {
@@ -241,22 +240,13 @@ export default function NewAgentScreen() {
             .request('herdr.agentKinds', {})
             .then((result) => {
                 if (!live) return;
-                const kinds = [...new Set((result.kinds ?? []).filter((kind) => /^[a-z][a-z0-9_-]{0,31}$/.test(kind)))].slice(0, 64);
-                if (kinds.length === 0) { setCatalogSource('fallback'); return; }
-                if (!Array.isArray(result.installed)) {
-                    setCatalog(kinds.map((kind) => ({ kind, availability: 'unknown' })));
-                    setCatalogSource('fallback');
-                    return;
+                const resolved = resolveAgentCatalog(result);
+                setCatalog(resolved.options);
+                setCatalogSource(resolved.authoritative ? 'host' : 'fallback');
+                if (resolved.authoritative) {
+                    const installed = new Set(resolved.options.filter((option) => option.availability === 'installed').map((option) => option.kind));
+                    setSelected((previous) => new Set([...previous].filter((kind) => installed.has(kind))));
                 }
-                const installed = new Set(result.installed.filter((kind) => kinds.includes(kind)));
-                const options = kinds.map((kind): AgentOption => ({
-                    kind,
-                    availability: installed.has(kind) ? 'installed' : 'unavailable',
-                })).sort((left, right) => Number(right.availability === 'installed') - Number(left.availability === 'installed')
-                    || left.kind.localeCompare(right.kind));
-                setCatalog(options);
-                setCatalogSource('host');
-                setSelected((previous) => new Set([...previous].filter((kind) => installed.has(kind))));
             })
             .catch(() => { if (live) setCatalogSource('fallback'); });
         return () => {

--- a/apps/mobile/sources/auth/accountSession.integration.spec.ts
+++ b/apps/mobile/sources/auth/accountSession.integration.spec.ts
@@ -15,6 +15,8 @@ const harness = vi.hoisted(() => ({
     socketStatus: 'disconnected',
     socketError: null as string | null,
     ready: false,
+    machineReplaceFlags: [] as boolean[],
+    sessionReplaceFlags: [] as boolean[],
 }));
 
 vi.mock('expo-crypto', () => ({ randomUUID: () => 'login-device' }));
@@ -75,8 +77,8 @@ vi.mock('../sync/storage', () => ({
             sessionsLoaded: false,
             setSocketStatus: (status: string) => { harness.socketStatus = status; },
             setSocketError: (message: string | null) => { harness.socketError = message; },
-            applyMachines: vi.fn(),
-            applySessions: vi.fn(),
+            applyMachines: (_machines: unknown[], replace = false) => { harness.machineReplaceFlags.push(replace); },
+            applySessions: (_sessions: unknown[], replace = false) => { harness.sessionReplaceFlags.push(replace); },
             applyHerdrTree: vi.fn(),
             markSessionsLoaded: vi.fn(),
             applyAttentionCatalog: vi.fn(),
@@ -111,6 +113,8 @@ describe('hosted account-only lifecycle', () => {
         harness.clientConnects = 0;
         harness.socketStatus = 'disconnected';
         harness.ready = false;
+        harness.machineReplaceFlags.length = 0;
+        harness.sessionReplaceFlags.length = 0;
     });
 
     afterEach(() => {
@@ -151,10 +155,16 @@ describe('hosted account-only lifecycle', () => {
         expect(authenticated).toBe(true);
         expect(harness.clientOptions).toHaveLength(0);
 
+        const machineReplacementsBeforePairing = harness.machineReplaceFlags.length;
+        const sessionReplacementsBeforePairing = harness.sessionReplaceFlags.length;
         harness.connection.machineId = 'machine-a';
         harness.grant = { machineId: 'machine-a', relayUrl: 'ws://relay.test', credential: 'stored-grant' };
         await syncCreate({ ...credentials, token: 'stale-login-token' });
         await vi.waitFor(() => expect(harness.clientConnects).toBe(1));
+        expect(harness.machineReplaceFlags.length).toBeGreaterThan(machineReplacementsBeforePairing);
+        expect(harness.sessionReplaceFlags.length).toBeGreaterThan(sessionReplacementsBeforePairing);
+        expect(harness.machineReplaceFlags.at(-1)).toBe(true);
+        expect(harness.sessionReplaceFlags.at(-1)).toBe(true);
         expect(harness.clientOptions).toHaveLength(1);
         expect(harness.clientOptions[0].token).toBe('stored-grant');
 

--- a/apps/mobile/sources/changelog/changelog.json
+++ b/apps/mobile/sources/changelog/changelog.json
@@ -2,8 +2,8 @@
   "entries": [
     {
       "title": "Pairing that stays paired",
-      "summary": "Settings gains QR scanning, browser links become short, and refresh no longer loses access.",
-      "markdown": "- Scan the computer QR directly from Settings → Pair another machine, with manual entry beside it.\n- Pair browsers from one short two-minute HTTPS link instead of copying an enormous payload.\n- Choose full browser control or explicit view-only access; both remain host-enforced and expire after eight hours.\n- Wait for browser storage to commit before setup reports success, recover interrupted grant indexes, and show an explicit recovery screen instead of silently appearing unpaired."
+      "summary": "QRs scan reliably, saved machines switch cleanly, and browser access survives refresh.",
+      "markdown": "- Scan a four-margin terminal QR directly from Settings → Pair another machine, with manual entry beside it.\n- See the active computer on Home and switch saved machines there; stale sessions and forgotten computers disappear immediately.\n- Show the host's real platform and only launchable agents in the Home composer.\n- Pair browsers from one short two-minute HTTPS link with host-enforced control or explicit view-only access.\n- Wait for browser storage to commit before setup reports success, recover interrupted grant indexes, and show an explicit recovery screen instead of silently appearing unpaired."
     },
     {
       "title": "One tap, one destination",

--- a/apps/mobile/sources/components/HomeDock.tsx
+++ b/apps/mobile/sources/components/HomeDock.tsx
@@ -24,7 +24,7 @@ import { layout } from './layout';
 import { t } from '@/text';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import { useAllMachines, useSessions } from '@/sync/storage';
+import { useAllMachines, useSessions, useSocketStatus } from '@/sync/storage';
 import { formatLastSeen, formatPathRelativeToHome } from '@/utils/sessionUtils';
 import { isMachineOnline } from '@/utils/machineUtils';
 import { resolveAbsolutePath } from '@/utils/pathUtils';
@@ -35,10 +35,13 @@ interface ModeOption {
     key: string;
     name: string;
     description?: string;
+    agentKind?: string;
 }
 import { AGENT_TYPES, type NewSessionAgentType } from '@/sync/persistence';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import { Modal } from '@/modal';
+import { sync } from '@/sync/sync';
+import { resolveAgentCatalog } from '@/sync/agentKinds';
 
 export const MOBILE_HOME_DOCK_CONTENT_INSET = 108;
 
@@ -60,6 +63,7 @@ const AGENT_NAMES: Partial<Record<NewSessionAgentType, string>> = {
 const AGENTS = AGENT_TYPES.map((key) => ({
     key,
     name: AGENT_NAMES[key] ?? key.replace(/(^|[-_])(\w)/g, (_, prefix, letter) => `${prefix ? ' ' : ''}${letter.toUpperCase()}`),
+    ...(key === 'shell' ? {} : { agentKind: key }),
 }));
 
 const styles = StyleSheet.create((theme) => ({
@@ -510,6 +514,8 @@ export const HomeDock = React.memo(({
     const setPath = useNewSessionDraft((state) => state.setPath);
     const setSessionType = useNewSessionDraft((state) => state.setSessionType);
     const setWorktreeKey = useNewSessionDraft((state) => state.setWorktreeKey);
+    const socketStatus = useSocketStatus();
+    const [hostAgentKinds, setHostAgentKinds] = React.useState<string[] | null>(null);
     const machines = useAllMachines({ includeOffline: true });
     const sessions = useSessions();
     const selectedMachine = React.useMemo(
@@ -617,8 +623,28 @@ export const HomeDock = React.memo(({
         return options;
     }, [agentType, existingWorktrees, supportsWorktree, worktreeKey]);
     const currentWorktree = resolveOption(worktreeOptions, [selectedWorktreeKey]);
-    const availableAgents = AGENTS;
-    const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0];
+    React.useEffect(() => {
+        let cancelled = false;
+        setHostAgentKinds(null);
+        if (socketStatus.status !== 'connected') return () => { cancelled = true; };
+        void sync.request('herdr.agentKinds', {}).then((result) => {
+            if (cancelled) return;
+            const resolved = resolveAgentCatalog(result);
+            const launchable = resolved.options
+                .filter((option) => option.availability !== 'unavailable')
+                .map((option) => option.kind);
+            setHostAgentKinds([...new Set(['shell', ...launchable])]);
+        }).catch(() => { if (!cancelled) setHostAgentKinds(null); });
+        return () => { cancelled = true; };
+    }, [socketStatus.status]);
+    const visibleAgentKeys = new Set(hostAgentKinds ?? ['shell', agentType]);
+    const availableAgents = AGENTS.filter((agent) => visibleAgentKeys.has(agent.key));
+    const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0] ?? AGENTS[0];
+    React.useEffect(() => {
+        if (hostAgentKinds !== null && !hostAgentKinds.includes(agentType)) {
+            setAgentType((hostAgentKinds.find((kind) => kind !== 'shell') ?? 'shell') as NewSessionAgentType);
+        }
+    }, [agentType, hostAgentKinds, setAgentType]);
     const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
     const keyboardStyle = useAnimatedStyle(() => ({

--- a/apps/mobile/sources/components/MainView.tsx
+++ b/apps/mobile/sources/components/MainView.tsx
@@ -36,7 +36,11 @@ import { MOBILE_GLASS_HEADER_HEIGHT } from './navigation/headerMetrics';
 import { MobileGlassSurface } from './MobileGlass';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import { useStartSessionFromDraft } from '@/hooks/useStartSessionFromDraft';
-import { currentDeviceAuthority } from '@/state/hostedE2ee';
+import { currentDeviceAuthority, listPairedGrants, type StoredHostedGrant } from '@/state/hostedE2ee';
+import { getCachedConnectionSettings, pairingTransport, saveConnectionSettings } from '@/state/connectionSettings';
+import { useAuth } from '@/auth/AuthContext';
+import { OptionSheet, type ModelMode } from './OptionSheet';
+import { Modal } from '@/modal';
 
 interface MainViewProps {
     variant: 'phone' | 'sidebar';
@@ -124,6 +128,12 @@ const styles = StyleSheet.create((theme) => ({
         fontWeight: '600',
         ...Typography.default('semiBold'),
     },
+    machineTitleButton: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 3,
+        maxWidth: '100%',
+    },
     statusContainer: {
         flexDirection: 'row',
         alignItems: 'center',
@@ -188,67 +198,116 @@ const TAB_TITLES = {
 // Active tabs
 type ActiveTabType = TabType;
 
-// Header title component with connection status
+// Header title component with connection status and the active saved pairing.
 const HeaderTitle = React.memo(({ activeTab, pluginTitle }: { activeTab: ActiveTabType; pluginTitle?: string }) => {
     const { theme } = useUnistyles();
     const socketStatus = useSocketStatus();
+    const auth = useAuth();
+    const [pairedGrants, setPairedGrants] = React.useState<StoredHostedGrant[]>([]);
+    const [activeMachineId, setActiveMachineId] = React.useState(getCachedConnectionSettings().machineId);
+    const [machinePickerOpen, setMachinePickerOpen] = React.useState(false);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        void listPairedGrants().then((grants) => {
+            if (cancelled) return;
+            setPairedGrants(grants);
+            setActiveMachineId(getCachedConnectionSettings().machineId);
+        });
+        return () => { cancelled = true; };
+    }, [socketStatus.status]);
+
+    const activeGrant = pairedGrants.find((grant) => grant.machineId === activeMachineId);
+    const homeTitle = activeGrant?.machineName || 'Paired computer';
+    const machineOptions = React.useMemo<ModelMode[]>(() => pairedGrants.map((grant) => ({
+        key: grant.machineId,
+        name: grant.machineName || 'Paired computer',
+        description: grant.machineId === activeMachineId ? 'Active' : pairingTransport(grant.relayUrl),
+    })), [activeMachineId, pairedGrants]);
+
+    const openMachinePicker = React.useCallback(async () => {
+        try {
+            const grants = await listPairedGrants();
+            setPairedGrants(grants);
+            setActiveMachineId(getCachedConnectionSettings().machineId);
+            setMachinePickerOpen(true);
+        } catch (cause) {
+            Modal.alert('Could not load machines', cause instanceof Error ? cause.message : String(cause));
+        }
+    }, []);
+
+    const switchMachine = React.useCallback(async (option: ModelMode) => {
+        if (option.key === activeMachineId) return;
+        const grant = pairedGrants.find((entry) => entry.machineId === option.key);
+        if (grant === undefined) return;
+        try {
+            await saveConnectionSettings({
+                ...getCachedConnectionSettings(),
+                mode: 'hosted',
+                relayUrl: grant.relayUrl,
+                machineId: grant.machineId,
+                token: '',
+                selfhost: grant.source === 'selfhost' ? true : undefined,
+            });
+            await auth.login(grant.credential, grant.deviceKey.secretKey);
+            setActiveMachineId(grant.machineId);
+        } catch (cause) {
+            Modal.alert('Could not switch machine', cause instanceof Error ? cause.message : String(cause));
+        }
+    }, [activeMachineId, auth, pairedGrants]);
 
     const connectionStatus = React.useMemo(() => {
         const { status } = socketStatus;
         switch (status) {
             case 'connected':
-                return {
-                    color: theme.colors.status.connected,
-                    isPulsing: false,
-                    text: t('status.connected'),
-                };
+                return { color: theme.colors.status.connected, isPulsing: false, text: t('status.connected') };
             case 'connecting':
-                return {
-                    color: theme.colors.status.connecting,
-                    isPulsing: true,
-                    text: t('status.connecting'),
-                };
+                return { color: theme.colors.status.connecting, isPulsing: true, text: t('status.connecting') };
             case 'disconnected':
-                return {
-                    color: theme.colors.status.disconnected,
-                    isPulsing: false,
-                    text: t('status.disconnected'),
-                };
+                return { color: theme.colors.status.disconnected, isPulsing: false, text: t('status.disconnected') };
             case 'error':
                 return {
                     color: theme.colors.status.error,
                     isPulsing: false,
-                    // socketError is only ever a permanent pairing failure — the
-                    // nav header gets the short label, connection.tsx the sentence.
                     text: socketStatus.error !== null ? t('status.pairingIssue') : t('status.error'),
                 };
             default:
-                return {
-                    color: theme.colors.status.default,
-                    isPulsing: false,
-                    text: '',
-                };
+                return { color: theme.colors.status.default, isPulsing: false, text: '' };
         }
     }, [socketStatus, theme]);
 
+    const isHome = activeTab === 'sessions';
+    const title = activeTab === 'plugin' ? pluginTitle : isHome && activeGrant ? homeTitle : t(TAB_TITLES[activeTab]);
+
     return (
         <View style={styles.titleContainer}>
-            <Text style={styles.titleText}>
-                {activeTab === 'plugin' ? pluginTitle : t(TAB_TITLES[activeTab])}
-            </Text>
+            {isHome && pairedGrants.length > 1 ? (
+                <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Switch machine, current ${homeTitle}`}
+                    onPress={() => { void openMachinePicker(); }}
+                    style={styles.machineTitleButton}
+                >
+                    <Text style={styles.titleText} numberOfLines={1}>{title}</Text>
+                    <Ionicons name="chevron-down" size={13} color={theme.colors.header.tint} />
+                </Pressable>
+            ) : (
+                <Text style={styles.titleText} numberOfLines={1}>{title}</Text>
+            )}
             {connectionStatus.text && (
                 <View style={styles.statusContainer}>
-                    <StatusDot
-                        color={connectionStatus.color}
-                        isPulsing={connectionStatus.isPulsing}
-                        size={6}
-                        style={{ marginRight: 4 }}
-                    />
-                    <Text numberOfLines={1} style={[styles.statusText, { color: connectionStatus.color }]}>
-                        {connectionStatus.text}
-                    </Text>
+                    <StatusDot color={connectionStatus.color} isPulsing={connectionStatus.isPulsing} size={6} style={{ marginRight: 4 }} />
+                    <Text numberOfLines={1} style={[styles.statusText, { color: connectionStatus.color }]}>{connectionStatus.text}</Text>
                 </View>
             )}
+            <OptionSheet
+                visible={machinePickerOpen}
+                title="Switch machine"
+                options={machineOptions}
+                selectedKey={activeMachineId}
+                onSelect={(option) => { void switchMachine(option); }}
+                onClose={() => setMachinePickerOpen(false)}
+            />
         </View>
     );
 });

--- a/apps/mobile/sources/components/OptionSheet.tsx
+++ b/apps/mobile/sources/components/OptionSheet.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { ProviderIcon } from './ProviderIcon';
+import { AgentGlyph } from './AgentGlyph';
 import { hapticsLight } from './haptics';
 import { t } from '@/text';
 export interface ModelMode {
@@ -26,6 +27,7 @@ export interface ModelMode {
     contextWindow?: number;
     providerName?: string;
     providerKind?: string;
+    agentKind?: string;
 }
 import { ALL_PROVIDERS, filterModels, groupByProvider } from '@/utils/optionSheet';
 
@@ -122,11 +124,15 @@ export function OptionSheet({
                     model.disabled && { opacity: 0.45 },
                 ]}
             >
-                <Ionicons
-                    name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
-                    size={20}
-                    color={isSelected ? theme.colors.textLink : theme.colors.textSecondary}
-                />
+                {model.agentKind ? (
+                    <AgentGlyph name={model.agentKind} size={26} selected={isSelected} />
+                ) : (
+                    <Ionicons
+                        name={isSelected ? 'checkmark-circle' : 'ellipse-outline'}
+                        size={20}
+                        color={isSelected ? theme.colors.textLink : theme.colors.textSecondary}
+                    />
+                )}
                 <View style={styles.rowCopy}>
                     <Text style={styles.rowTitle} numberOfLines={1}>{model.name}</Text>
                     {!!model.description && (
@@ -134,6 +140,7 @@ export function OptionSheet({
                     )}
                 </View>
                 {context && <Text style={styles.contextChip}>{context}</Text>}
+                {model.agentKind && isSelected && <Ionicons name="checkmark-circle" size={20} color={theme.colors.textLink} />}
             </Pressable>
         );
     };

--- a/apps/mobile/sources/components/SettingsView.tsx
+++ b/apps/mobile/sources/components/SettingsView.tsx
@@ -115,8 +115,10 @@ export const SettingsView = React.memo(function SettingsView({
     const machineRows = React.useMemo(() => {
         const rows: { id: string; live?: (typeof allMachinesWithOffline)[number] }[] = [];
         const listedIds = new Set<string>();
+        const pairedIds = new Set(pairedGrants.map((grant) => grant.machineId));
+        const hosted = getCachedConnectionSettings().mode === 'hosted';
         for (const machine of allMachinesWithOffline) {
-            if (!showOfflineMachines && !isMachineOnline(machine)) continue;
+            if ((hosted && !pairedIds.has(machine.id)) || (!showOfflineMachines && !isMachineOnline(machine))) continue;
             listedIds.add(machine.id);
             rows.push({ id: machine.id, live: machine });
         }
@@ -289,9 +291,8 @@ export const SettingsView = React.memo(function SettingsView({
                 </View>
             </View>
 
-            {/* Machines: union of the live list and the persisted pairing
-                grants. The live list alone is empty whenever the host is down —
-                exactly when switching and pairing must stay reachable. */}
+            {/* Hosted machines require a persisted grant; live transport rows
+                cannot resurrect a pairing the user just forgot. */}
             <ItemGroup title={t('settings.machines')}>
                 {machineRows.map(({ id, live: machine }) => {
                     const isOnline = machine !== undefined && isMachineOnline(machine);

--- a/apps/mobile/sources/sync/agentKinds.ts
+++ b/apps/mobile/sources/sync/agentKinds.ts
@@ -7,3 +7,31 @@ export const FALLBACK_AGENT_KINDS = [
     'hermes', 'kilo', 'qodercli', 'maki',
 ] as const;
 export const AGENT_KINDS = FALLBACK_AGENT_KINDS;
+
+export type AgentAvailability = 'installed' | 'unavailable' | 'unknown';
+export type AgentCatalogOption = { kind: string; availability: AgentAvailability };
+
+export function resolveAgentCatalog(result: { kinds?: string[]; installed?: string[] }): {
+    options: AgentCatalogOption[];
+    authoritative: boolean;
+} {
+    const kinds = [...new Set((result.kinds ?? []).filter((kind) => /^[a-z][a-z0-9_-]{0,31}$/.test(kind)))].slice(0, 64);
+    if (kinds.length === 0) {
+        return {
+            options: FALLBACK_AGENT_KINDS.map((kind) => ({ kind, availability: 'unknown' })),
+            authoritative: false,
+        };
+    }
+    if (!Array.isArray(result.installed)) {
+        return { options: kinds.map((kind) => ({ kind, availability: 'unknown' })), authoritative: false };
+    }
+    const installed = new Set(result.installed.filter((kind) => kinds.includes(kind)));
+    return {
+        options: kinds.map((kind): AgentCatalogOption => ({
+            kind,
+            availability: installed.has(kind) ? 'installed' : 'unavailable',
+        })).sort((left, right) => Number(right.availability === 'installed') - Number(left.availability === 'installed')
+            || left.kind.localeCompare(right.kind)),
+        authoritative: true,
+    };
+}

--- a/apps/mobile/sources/sync/sessionMapping.ts
+++ b/apps/mobile/sources/sync/sessionMapping.ts
@@ -131,7 +131,7 @@ export function machineInfoToMachine(info: MachineInfo): Machine {
         activeAt: parseTime(info.lastSeenAt),
         metadata: {
             host: '',
-            platform: 'linux',
+            platform: info.platform ?? '',
             muxrCliVersion: info.hostVersion ?? 'muxr',
             muxrHomeDir: '',
             homeDir: '',

--- a/apps/mobile/sources/sync/storage.ts
+++ b/apps/mobile/sources/sync/storage.ts
@@ -185,7 +185,7 @@ interface StorageState {
     currentViewingSessionId: string | null;
     unreadSessionIds: Set<string>;
     attentionEntries: AttentionEntry[];
-    applySessions: (sessions: (Omit<Session, 'presence'> & { presence?: 'online' | number })[]) => void;
+    applySessions: (sessions: (Omit<Session, 'presence'> & { presence?: 'online' | number })[], replace?: boolean) => void;
     applyHerdrTree: (workspaces: HerdrTreeWorkspace[]) => void;
     applyMachines: (machines: Machine[], replace?: boolean) => void;
     deleteMachine: (machineId: string) => void;
@@ -266,14 +266,15 @@ export const storage = create<StorageState>()((set, get) => ({
     currentViewingSessionId: null,
     unreadSessionIds: new Set<string>(),
     attentionEntries: [],
-    applySessions: (sessions) => set((state) => {
-        const merged = { ...state.sessions };
+    applySessions: (sessions, replace = false) => set((state) => {
+        const merged = replace ? {} as Record<string, Session> : { ...state.sessions };
         for (const session of sessions) {
             // metadata is replaced wholesale, and session.list carries neither a
             // title nor live model/lifecycle state. Carry those over or a catalog
             // refresh briefly turns working/blocked panes into done panes, fires
             // false completion notifications and re-arms the recent-agent buffer.
-            const known = merged[session.id]?.metadata;
+            const previous = replace ? state.sessions[session.id] : merged[session.id];
+            const known = previous?.metadata;
             const metadata = session.metadata === null
                 ? session.metadata
                 : {
@@ -293,7 +294,7 @@ export const storage = create<StorageState>()((set, get) => ({
                           }),
                     ...session.metadata,
                 };
-            const existing = merged[session.id];
+            const existing = previous;
             const catalogHasLifecycle = session.metadata?.agentStatus !== undefined;
             merged[session.id] = {
                 ...existing,

--- a/apps/mobile/sources/sync/sync.ts
+++ b/apps/mobile/sources/sync/sync.ts
@@ -157,6 +157,7 @@ class MuxrSync {
     private pendingShell = new Map<string, (outcome: ShellOutcome) => void>();
     private openedSessions = new Set<string>();
     private opening = new Map<string, Promise<void>>();
+    private activeMachineId: string | undefined;
     private herdrTreeRequest = 0;
     encryption!: Encryption;
     anonID = 'muxr-local';
@@ -397,6 +398,7 @@ class MuxrSync {
         if (!this.hasTransport()) {
             storage.getState().setSocketStatus('disconnected');
             storage.getState().applyMachines([], true);
+            storage.getState().applySessions([], true);
             storage.getState().applyHerdrTree([]);
             storage.getState().markSessionsLoaded();
             await this.refreshAccountSession();
@@ -421,8 +423,8 @@ class MuxrSync {
             client.request('attention.catalog', {}).catch(() => ({ revision: 0, entries: [] })),
             this.refreshHerdTree().catch(() => undefined),
         ]);
-        storage.getState().applyMachines(machines.map(machineInfoToMachine));
-        storage.getState().applySessions(sessions.map((info) => sessionInfoToSession(info)));
+        storage.getState().applyMachines(machines.map(machineInfoToMachine), true);
+        storage.getState().applySessions(sessions.map((info) => sessionInfoToSession(info)), true);
         storage.getState().markSessionsLoaded();
         storage.getState().applyAttentionCatalog(attention.entries);
     }
@@ -482,6 +484,16 @@ class MuxrSync {
         this.credentials = credentials;
         await this.initEncryption(credentials);
         const settings = await loadConnectionSettingsAsync();
+        const switchedMachine = this.activeMachineId !== undefined && this.activeMachineId !== settings.machineId;
+        this.activeMachineId = settings.machineId;
+        if (switchedMachine) {
+            this.openedSessions.clear();
+            this.opening.clear();
+            this.herdrTreeRequest += 1;
+            storage.getState().applyMachines([], true);
+            storage.getState().applySessions([], true);
+            storage.getState().applyHerdrTree([]);
+        }
         if (settings.mode === 'hosted' && settings.machineId !== '') {
             await loadHostedGrant(settings.machineId);
             await refreshHostedGrant(settings.machineId);

--- a/packages/contract/src/sessionDomain.ts
+++ b/packages/contract/src/sessionDomain.ts
@@ -47,4 +47,5 @@ export interface MachineInfo {
     online: boolean;
     lastSeenAt?: string;
     hostVersion?: string;
+    platform?: string;
 }

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -43,6 +43,15 @@ const INTEGRATION_COMMANDS = {
 
 const print = (text = '') => process.stdout.write(`${text}\n`);
 const error = (text) => process.stderr.write(`${text}\n`);
+async function printTerminalQr(value) {
+    const qr = await QRCode.toString(value, { type: 'utf8', margin: 4, errorCorrectionLevel: 'M' });
+    const width = Math.max(...qr.split('\n').map((line) => [...line].length));
+    if (process.stdout.columns !== undefined && width > process.stdout.columns) {
+        print(`QR omitted because this terminal is ${process.stdout.columns} columns wide; use the exact string below.`);
+        return;
+    }
+    print(qr.split('\n').map((line) => `\x1b[47m\x1b[30m${line}\x1b[0m`).join('\n'));
+}
 function env(name) {
     return process.env[name]?.trim() || undefined;
 }
@@ -631,7 +640,7 @@ export async function runMachines(command = 'list', args = []) {
                 ...(typeof created.body.web_url === 'string' ? { web: created.body.web_url } : {}) })).toString('base64url');
             const link = `muxr://enroll?payload=${payload}`;
             print('');
-            if (process.stdout.isTTY) print(await QRCode.toString(link, { type: 'terminal', small: true }));
+            if (process.stdout.isTTY) await printTerminalQr(link);
             print('Machine enrollment string (single-use, expires in five minutes):');
             print(link);
             const path = join(stateDir(), 'enrollment-link.txt');
@@ -2185,7 +2194,7 @@ async function runSelfhostPair(state, requestedKind = 'native', requestedAuthori
         }
         const pairValue = pending.pairString;
         if (typeof pairValue !== 'string') throw new Error('pairing string is unavailable');
-        if (!browser && process.stdout.isTTY) print(await QRCode.toString(pairValue, { type: 'terminal', small: true }));
+        if (!browser && process.stdout.isTTY) await printTerminalQr(pairValue);
         print(browser ? `Open this ${pending.authority === 'observe' ? 'view-only' : 'control'} browser link within two minutes:` : 'Pairing string (expires in two minutes):');
         print(pairValue);
         if (browser) print('Browser access expires after eight hours.');
@@ -2396,7 +2405,7 @@ export async function runAccount(command, args = []) {
             });
             const pairUrl = `${result.body.verification_uri}#${fragment}`;
             print(`Open: ${pairUrl}`);
-            if (process.stdout.isTTY) print(await QRCode.toString(pairUrl, { type: 'terminal', small: true }));
+            if (process.stdout.isTTY) await printTerminalQr(pairUrl);
             print('Waiting for the device to claim this single-use pairing session…');
             const expiresAt = Date.now() + Number(result.body.expires_in ?? 300) * 1000;
             while (Date.now() < expiresAt) {


### PR DESCRIPTION
## Summary

- render terminal QRs with the required four-module quiet zone and skip codes that would wrap in narrow terminals
- show the active saved machine on Home and add a multi-machine switcher
- clear stale machine/session/tree state when changing pairings so old sessions do not remain stuck reconnecting
- remove forgotten machines immediately instead of resurrecting them from stale live rows
- report macOS/Windows/Linux from the host instead of hardcoding every machine as Linux
- filter the Home composer to launchable host-reported agents and show their real icons

## Root causes

- `qrcode`'s compact terminal renderer hardcodes a one-module quiet zone; the reported photographed QR is not decodable
- sync closed the previous socket on machine switch but retained the old catalog and opened-session ids
- Home used the static agent superset and `machineInfoToMachine` hardcoded `linux`
- Settings unioned stale live rows back into the saved-pairing list after deletion

## Validation

- [x] reported QR photograph fails `zbarimg`; the same payload with the new renderer decodes exactly
- [x] focused host dispatcher and account/machine handoff tests
- [x] full suite: **30/30 passed**
- [x] final adversarial Fable gate: **SHIP — no remaining blockers**
