### PR TITLE
Fix daemon agent environment during onboarding

### DIFF
--- a/apps/host/src/herdr/terminalManager.test.ts
+++ b/apps/host/src/herdr/terminalManager.test.ts
@@ -28,6 +28,7 @@ interface FakeSocket extends EventEmitter {
 const fakes = vi.hoisted(() => ({
     children: [] as FakeChild[],
     sockets: [] as FakeSocket[],
+    failSpawn: false,
 }));
 
 vi.mock('node:child_process', async (importOriginal) => {
@@ -53,6 +54,7 @@ vi.mock('node:child_process', async (importOriginal) => {
             child.stdout = new Emitter();
             child.kill = vi.fn(() => true);
             fakes.children.push(child);
+            queueMicrotask(() => child.emit(fakes.failSpawn ? 'error' : 'spawn', new Error('spawn herdr ENOENT')));
             return child;
         }),
     };
@@ -88,6 +90,7 @@ describe('TerminalManager stream exit', () => {
     beforeEach(() => {
         fakes.children.length = 0;
         fakes.sockets.length = 0;
+        fakes.failSpawn = false;
     });
 
     it('moves same-pane control to the newest device without dropping observers or stealing back', async () => {
@@ -140,6 +143,22 @@ describe('TerminalManager stream exit', () => {
         phoneB!.emit('message', Buffer.from(JSON.stringify(envelope)));
         expect(childA!.stdin.write).not.toHaveBeenCalledWith(expect.stringContaining('stale'));
         expect(childB!.stdin.write).toHaveBeenCalledWith(`${plaintext}\n`);
+    });
+
+    it('rejects attach when Herdr cannot start instead of leaving the phone reconnecting', async () => {
+        const identity = {
+            get: vi.fn(() => ({ paneId: 'workspace:pane' })),
+        } as unknown as IdentityStore;
+        const manager = new TerminalManager({
+            relayUrl: 'ws://relay.test',
+            machineId: 'machine',
+            identity,
+        });
+        fakes.failSpawn = true;
+
+        await expect(manager.attach({ sessionId: 'session', channel: 'channel', cols: 100, rows: 30 }))
+            .rejects.toThrow('could not start Herdr');
+        expect(fakes.sockets[0]?.close).toHaveBeenCalledOnce();
     });
 
     it('does not write a late client frame into a cleanly exited stream', async () => {

--- a/apps/host/src/herdr/terminalManager.ts
+++ b/apps/host/src/herdr/terminalManager.ts
@@ -148,6 +148,25 @@ export class TerminalManager {
             ],
             { stdio: ['pipe', 'pipe', 'inherit'] },
         );
+        // spawn() reports ENOENT asynchronously. Do not acknowledge the attach
+        // request until Herdr actually starts: otherwise the reason is lost
+        // before the phone joins and a permanent PATH fault looks like endless
+        // network reconnecting.
+        await new Promise<void>((resolve, reject) => {
+            const cleanup = (): void => {
+                child.off('spawn', onSpawn);
+                child.off('error', onError);
+            };
+            const onSpawn = (): void => { cleanup(); resolve(); };
+            const onError = (error: Error): void => {
+                cleanup();
+                socket.close();
+                process.stderr.write(`terminal: could not start ${herdr}: ${error.message}\n`);
+                reject(new Error(`terminal: could not start Herdr: ${error.message}`));
+            };
+            child.once('spawn', onSpawn);
+            child.once('error', onError);
+        });
 
         const attachment: Attachment = {
             sessionId: params.sessionId,
@@ -301,6 +320,7 @@ export class TerminalManager {
         // An unspawnable herdr binary (PATH drift, upgrade window) must not take
         // the whole host down with an unhandled 'error' event.
         child.on('error', (error) => {
+            process.stderr.write(`terminal: could not start ${herdr}: ${error.message}\n`);
             finish(`herdr stream failed: ${error.message}`);
         });
         socket.on('close', () => {

--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -43,7 +43,8 @@ function resolveHostVersion(): string | undefined {
     return undefined;
 }
 
-class HostedAuthExpiredError extends Error {}
+class NonRecoverableAuthError extends Error {}
+class HostedAuthExpiredError extends NonRecoverableAuthError {}
 
 interface HostedAuthState {
     version: 1;
@@ -73,6 +74,83 @@ interface MachineCrypto {
     };
 }
 
+function validBase64(value: unknown, bytes: number): boolean {
+    if (typeof value !== 'string' || value.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return false;
+    try { return Buffer.from(value, 'base64').length === bytes; }
+    catch { return false; }
+}
+
+function parseSealedGrant(value: unknown): Record<string, unknown> | undefined {
+    if (typeof value !== 'string' || value.length === 0) return undefined;
+    try {
+        const grant = JSON.parse(value) as Record<string, unknown>;
+        return grant.v === 1
+            && validBase64(grant.sender, 32)
+            && validBase64(grant.signer, 32)
+            && validBase64(grant.sig, 64)
+            && typeof grant.box === 'string'
+            && /^[A-Za-z0-9+/]+={0,2}$/.test(grant.box)
+            && Buffer.from(grant.box, 'base64').length > 40
+            ? grant : undefined;
+    } catch { return undefined; }
+}
+
+function validDevice(value: unknown): boolean {
+    if (typeof value !== 'object' || value === null) return false;
+    const device = value as Record<string, unknown>;
+    return typeof device.deviceId === 'string' && device.deviceId.length > 0
+        && validBase64(device.devicePublicKey, 32)
+        && validBase64(device.ingressKey, 32)
+        && typeof device.expiresAt === 'string' && Number.isFinite(Date.parse(device.expiresAt))
+        && (device.kind === undefined || device.kind === 'browser')
+        && (device.authority === undefined || device.authority === 'control' || device.authority === 'observe');
+}
+
+function validMachineCrypto(value: unknown, expected: 'hosted' | 'selfhost'): value is MachineCrypto {
+    if (typeof value !== 'object' || value === null) return false;
+    const crypto = value as Partial<MachineCrypto>;
+    const keys = validBase64(crypto.signingPublicKey, 32)
+        && validBase64(crypto.signingSecretKey, 64)
+        && validBase64(crypto.boxPublicKey, 32)
+        && validBase64(crypto.boxSecretKey, 32)
+        && validBase64(crypto.dataKey, 32);
+    if (!keys || !Number.isInteger(crypto.keyVersion) || crypto.keyVersion! < 1
+        || !Array.isArray(crypto.devices) || !crypto.devices.every(validDevice)
+        || new Set(crypto.devices.map((device) => device.deviceId)).size !== crypto.devices.length) return false;
+    const pending = crypto.pendingRotation as unknown as Record<string, unknown> | undefined;
+    if (pending === undefined) return true;
+    const devices = pending.devices;
+    const grants = pending.grants;
+    if (!validBase64(pending.dataKey, 32) || !Array.isArray(devices) || !devices.every(validDevice)
+        || new Set(devices.map((device) => device.deviceId)).size !== devices.length || !Array.isArray(grants)
+        || grants.length !== devices.length) return false;
+    const selfhost = pending.kind === 'selfhost-revoke-v1';
+    if (expected === 'hosted' ? selfhost : !selfhost) return false;
+    const version = pending.keyVersion;
+    const previous = pending.previousKeyVersion;
+    const versionValid = selfhost
+        ? Number.isInteger(previous) && Number.isInteger(version) && version === (previous as number) + 1
+            && (crypto.keyVersion === previous || crypto.keyVersion === version)
+            && typeof pending.revokedDeviceId === 'string' && typeof pending.revokedDeviceName === 'string'
+        : pending.kind === undefined && Number.isInteger(version) && version === crypto.keyVersion! + 1;
+    if (!versionValid) return false;
+    const byId = new Map(devices.map((device) => [device.deviceId, device]));
+    const expectedKeys = new Set(devices.map((device) => device.devicePublicKey));
+    const seen = new Set<string>();
+    return grants.every((entry) => {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const candidate = entry as Record<string, unknown>;
+        const deviceKey = selfhost
+            ? byId.get(candidate.deviceId)?.devicePublicKey
+            : candidate.device_public_key;
+        const sealed = parseSealedGrant(candidate.grant);
+        if (typeof deviceKey !== 'string' || !expectedKeys.has(deviceKey) || seen.has(deviceKey) || sealed === undefined
+            || sealed.sender !== crypto.boxPublicKey || sealed.signer !== crypto.signingPublicKey) return false;
+        seen.add(deviceKey);
+        return true;
+    }) && seen.size === expectedKeys.size;
+}
+
 interface SelfhostState {
     version: 1;
     relayPort?: number;
@@ -93,15 +171,27 @@ function readSelfhostAuth(): SelfhostState | undefined {
     if (!existsSync(path)) return undefined;
     const info = lstatSync(path);
     if (!info.isFile() || info.isSymbolicLink() || (info.mode & 0o077) !== 0) {
-        throw new Error(`${path} must be a regular owner-only file`);
+        throw new NonRecoverableAuthError(`${path} must be a regular owner-only file`);
     }
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<SelfhostState>;
-    if (parsed.version !== 1 || typeof parsed.machine?.id !== 'string' || parsed.machine.crypto === undefined
+    let parsed: Partial<SelfhostState>;
+    try { parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<SelfhostState>; }
+    catch (error) {
+        if (error instanceof SyntaxError) throw new NonRecoverableAuthError(`${path} contains malformed JSON`);
+        if ((error as NodeJS.ErrnoException)?.code === 'EACCES' || (error as NodeJS.ErrnoException)?.code === 'EPERM') {
+            throw new NonRecoverableAuthError(`${path} cannot be read; restore owner read permission and run \`muxr doctor\``);
+        }
+        throw error;
+    }
+    if (parsed.version !== 1 || typeof parsed.machine?.id !== 'string' || !validMachineCrypto(parsed.machine.crypto, 'selfhost')
         || typeof parsed.mintSecret !== 'string' && typeof parsed.machineCredential !== 'string'
         || parsed.relayLocation === 'remote' && typeof parsed.relayUrl !== 'string'
-        || parsed.relayLocation !== 'remote' && typeof parsed.relayPort !== 'number') return undefined;
-    if (parsed.credentialExpiresAt !== undefined && Date.parse(parsed.credentialExpiresAt) <= Date.now()) {
-        throw new HostedAuthExpiredError('remote relay machine credential expired; create a fresh enrollment from the relay owner');
+        || parsed.relayLocation !== 'remote' && typeof parsed.relayPort !== 'number') {
+        throw new NonRecoverableAuthError(`${path} has an unsupported or incomplete schema`);
+    }
+    if (parsed.credentialExpiresAt !== undefined) {
+        const expires = Date.parse(parsed.credentialExpiresAt);
+        if (!Number.isFinite(expires)) throw new NonRecoverableAuthError(`${path} has an invalid credential expiry`);
+        if (expires <= Date.now()) throw new HostedAuthExpiredError('remote relay machine credential expired; create a fresh enrollment from the relay owner');
     }
     return parsed as SelfhostState;
 }
@@ -115,11 +205,22 @@ function readHostedAuth(): HostedAuthState | undefined {
     if (!existsSync(path)) return undefined;
     const info = lstatSync(path);
     if (!info.isFile() || info.isSymbolicLink() || (info.mode & 0o077) !== 0) {
-        throw new Error(`${path} must be a regular owner-only file`);
+        throw new NonRecoverableAuthError(`${path} must be a regular owner-only file`);
     }
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<HostedAuthState>;
+    let parsed: Partial<HostedAuthState>;
+    try { parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<HostedAuthState>; }
+    catch (error) {
+        if (error instanceof SyntaxError) throw new NonRecoverableAuthError(`${path} contains malformed JSON`);
+        if ((error as NodeJS.ErrnoException)?.code === 'EACCES' || (error as NodeJS.ErrnoException)?.code === 'EPERM') {
+            throw new NonRecoverableAuthError(`${path} cannot be read; restore owner read permission and run \`muxr doctor\``);
+        }
+        throw error;
+    }
     if (parsed.version !== 1 || typeof parsed.controlUrl !== 'string' || typeof parsed.relayUrl !== 'string' || typeof parsed.credential !== 'string'
-        || typeof parsed.credentialExpiresAt !== 'string' || typeof parsed.machine?.id !== 'string') return undefined;
+        || typeof parsed.credentialExpiresAt !== 'string' || !Number.isFinite(Date.parse(parsed.credentialExpiresAt))
+        || typeof parsed.machine?.id !== 'string' || !validMachineCrypto(parsed.machine.crypto, 'hosted')) {
+        throw new NonRecoverableAuthError(`${path} has an unsupported or incomplete schema`);
+    }
     if (Date.parse(parsed.credentialExpiresAt) <= Date.now()) throw new HostedAuthExpiredError('hosted machine credential expired; run `muxr login`');
     return parsed as HostedAuthState;
 }
@@ -264,7 +365,10 @@ function readAuthStates() {
     try { return { hostedAuth: readHostedAuth(), selfhostAuth: readSelfhostAuth() }; }
     catch (error) {
         process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-        process.exit(error instanceof HostedAuthExpiredError ? 0 : 1);
+        // Deterministic auth faults cannot heal by restarting. Transient I/O
+        // errors remain failures so the service manager may retry.
+        const code = (error as NodeJS.ErrnoException)?.code;
+        process.exit(error instanceof NonRecoverableAuthError || code === 'EACCES' || code === 'EPERM' ? 0 : 1);
     }
 }
 const { hostedAuth, selfhostAuth } = readAuthStates();
@@ -283,9 +387,14 @@ if (requestedMode !== undefined && requestedMode !== 'hosted' && requestedMode !
 const mode = requestedMode ?? (hostedAuth !== undefined ? 'hosted' : selfhostAuth !== undefined ? 'selfhost' : useFake ? 'local' : undefined);
 if (mode === undefined) throw new Error('no hosted auth state; set MUXR_MODE=local explicitly for development');
 const token = env('MUXR_RELAY_TOKEN') ?? (mode === 'hosted' ? hostedAuth?.credential : mode === 'selfhost' ? selfhostAuth?.machineCredential ?? selfhostAuth?.mintSecret : undefined);
-if (mode === 'hosted' && hostedAuth === undefined) throw new Error('hosted mode requires muxr setup/login state');
-if (mode === 'selfhost' && selfhostAuth === undefined) throw new Error('selfhost mode requires `muxr self-host` state');
-if (mode === 'hosted' && hostedAuth?.machine.crypto === undefined) throw new Error('hosted machine keys are missing; run `muxr setup` and re-pair devices');
+if (mode === 'hosted' && hostedAuth === undefined) {
+    process.stderr.write('hosted mode requires muxr setup/login state; run `muxr doctor`\n');
+    process.exit(0);
+}
+if (mode === 'selfhost' && selfhostAuth === undefined) {
+    process.stderr.write('selfhost mode requires muxr setup state; run `muxr doctor`\n');
+    process.exit(0);
+}
 
 async function main(): Promise<void> {
     if (mode === 'hosted') await reconcileHostedKeys(hostedAuth!);

--- a/apps/mobile/sources/app/(app)/new-agent.tsx
+++ b/apps/mobile/sources/app/(app)/new-agent.tsx
@@ -219,7 +219,7 @@ export default function NewAgentScreen() {
     const [catalog, setCatalog] = React.useState<readonly AgentOption[]>(
         FALLBACK_AGENT_KINDS.map((kind) => ({ kind, availability: 'unknown' })),
     );
-    const [catalogSource, setCatalogSource] = React.useState<'loading' | 'host' | 'fallback'>('loading');
+    const [catalogSource, setCatalogSource] = React.useState<'loading' | 'host' | 'unknown' | 'fallback'>('loading');
     const [selected, setSelected] = React.useState<ReadonlySet<string>>(new Set());
     const [cwd, setCwd] = React.useState(settings.lastSessionCwd ?? '');
     const [worktree, setWorktree] = React.useState(false);
@@ -242,7 +242,7 @@ export default function NewAgentScreen() {
                 if (!live) return;
                 const resolved = resolveAgentCatalog(result);
                 setCatalog(resolved.options);
-                setCatalogSource(resolved.authoritative ? 'host' : 'fallback');
+                setCatalogSource(resolved.authoritative ? 'host' : 'unknown');
                 if (resolved.authoritative) {
                     const installed = new Set(resolved.options.filter((option) => option.availability === 'installed').map((option) => option.kind));
                     // An empty host probe is usually a broken service environment,
@@ -363,7 +363,7 @@ export default function NewAgentScreen() {
                         <Text style={styles.sectionLabel}>AGENT</Text>
                         <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
                             <Text style={styles.squadBadgeText}>
-                                {catalogSource === 'host' ? 'FROM HERDR' : catalogSource === 'loading' ? 'CHECKING HOST' : 'OFFLINE FALLBACK'}
+                                {catalogSource === 'host' ? 'FROM HERDR' : catalogSource === 'loading' ? 'CHECKING HOST' : catalogSource === 'unknown' ? 'HOST AVAILABILITY UNKNOWN' : 'OFFLINE FALLBACK'}
                             </Text>
                             {squad && (
                                 <View style={styles.squadBadge}>

--- a/apps/mobile/sources/app/(app)/new-agent.tsx
+++ b/apps/mobile/sources/app/(app)/new-agent.tsx
@@ -245,7 +245,9 @@ export default function NewAgentScreen() {
                 setCatalogSource(resolved.authoritative ? 'host' : 'fallback');
                 if (resolved.authoritative) {
                     const installed = new Set(resolved.options.filter((option) => option.availability === 'installed').map((option) => option.kind));
-                    setSelected((previous) => new Set([...previous].filter((kind) => installed.has(kind))));
+                    // An empty host probe is usually a broken service environment,
+                    // not proof that the user's saved squad should be erased.
+                    if (installed.size > 0) setSelected((previous) => new Set([...previous].filter((kind) => installed.has(kind))));
                 }
             })
             .catch(() => { if (live) setCatalogSource('fallback'); });

--- a/apps/mobile/sources/components/HomeDock.tsx
+++ b/apps/mobile/sources/components/HomeDock.tsx
@@ -641,8 +641,8 @@ export const HomeDock = React.memo(({
     const availableAgents = AGENTS.filter((agent) => visibleAgentKeys.has(agent.key));
     const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0] ?? AGENTS[0];
     React.useEffect(() => {
-        if (hostAgentKinds !== null && !hostAgentKinds.includes(agentType)) {
-            setAgentType((hostAgentKinds.find((kind) => kind !== 'shell') ?? 'shell') as NewSessionAgentType);
+        if (hostAgentKinds !== null && hostAgentKinds.some((kind) => kind !== 'shell') && !hostAgentKinds.includes(agentType)) {
+            setAgentType(hostAgentKinds.find((kind) => kind !== 'shell') as NewSessionAgentType);
         }
     }, [agentType, hostAgentKinds, setAgentType]);
     const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
@@ -781,8 +781,8 @@ export const HomeDock = React.memo(({
     }, [setAgentType]);
 
     React.useEffect(() => {
-        if (availableAgents.length > 0 && !availableAgents.some((agent) => agent.key === agentType)) {
-            selectAgent(availableAgents[0].key);
+        if (availableAgents.some((agent) => agent.key !== 'shell') && !availableAgents.some((agent) => agent.key === agentType)) {
+            selectAgent(availableAgents.find((agent) => agent.key !== 'shell')!.key);
         }
     }, [agentType, availableAgents, selectAgent]);
 

--- a/apps/mobile/sources/components/HomeDock.tsx
+++ b/apps/mobile/sources/components/HomeDock.tsx
@@ -516,6 +516,7 @@ export const HomeDock = React.memo(({
     const setWorktreeKey = useNewSessionDraft((state) => state.setWorktreeKey);
     const socketStatus = useSocketStatus();
     const [hostAgentKinds, setHostAgentKinds] = React.useState<string[] | null>(null);
+    const [hostAgentKindsAuthoritative, setHostAgentKindsAuthoritative] = React.useState(false);
     const machines = useAllMachines({ includeOffline: true });
     const sessions = useSessions();
     const selectedMachine = React.useMemo(
@@ -626,6 +627,7 @@ export const HomeDock = React.memo(({
     React.useEffect(() => {
         let cancelled = false;
         setHostAgentKinds(null);
+        setHostAgentKindsAuthoritative(false);
         if (socketStatus.status !== 'connected') return () => { cancelled = true; };
         void sync.request('herdr.agentKinds', {}).then((result) => {
             if (cancelled) return;
@@ -634,17 +636,24 @@ export const HomeDock = React.memo(({
                 .filter((option) => option.availability !== 'unavailable')
                 .map((option) => option.kind);
             setHostAgentKinds([...new Set(['shell', ...launchable])]);
-        }).catch(() => { if (!cancelled) setHostAgentKinds(null); });
+            setHostAgentKindsAuthoritative(resolved.authoritative);
+        }).catch(() => {
+            if (!cancelled) {
+                setHostAgentKinds(null);
+                setHostAgentKindsAuthoritative(false);
+            }
+        });
         return () => { cancelled = true; };
     }, [socketStatus.status]);
     const visibleAgentKeys = new Set(hostAgentKinds ?? ['shell', agentType]);
+    if (!hostAgentKindsAuthoritative) visibleAgentKeys.add(agentType);
     const availableAgents = AGENTS.filter((agent) => visibleAgentKeys.has(agent.key));
     const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0] ?? AGENTS[0];
     React.useEffect(() => {
-        if (hostAgentKinds !== null && hostAgentKinds.some((kind) => kind !== 'shell') && !hostAgentKinds.includes(agentType)) {
+        if (hostAgentKindsAuthoritative && hostAgentKinds !== null && hostAgentKinds.some((kind) => kind !== 'shell') && !hostAgentKinds.includes(agentType)) {
             setAgentType(hostAgentKinds.find((kind) => kind !== 'shell') as NewSessionAgentType);
         }
-    }, [agentType, hostAgentKinds, setAgentType]);
+    }, [agentType, hostAgentKinds, hostAgentKindsAuthoritative, setAgentType]);
     const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
     const keyboardStyle = useAnimatedStyle(() => ({
@@ -781,10 +790,10 @@ export const HomeDock = React.memo(({
     }, [setAgentType]);
 
     React.useEffect(() => {
-        if (availableAgents.some((agent) => agent.key !== 'shell') && !availableAgents.some((agent) => agent.key === agentType)) {
+        if (hostAgentKindsAuthoritative && availableAgents.some((agent) => agent.key !== 'shell') && !availableAgents.some((agent) => agent.key === agentType)) {
             selectAgent(availableAgents.find((agent) => agent.key !== 'shell')!.key);
         }
-    }, [agentType, availableAgents, selectAgent]);
+    }, [agentType, availableAgents, hostAgentKindsAuthoritative, selectAgent]);
 
     type SettingsRow = {
         page: string;

--- a/apps/mobile/sources/sync/agentKinds.ts
+++ b/apps/mobile/sources/sync/agentKinds.ts
@@ -26,6 +26,14 @@ export function resolveAgentCatalog(result: { kinds?: string[]; installed?: stri
         return { options: kinds.map((kind) => ({ kind, availability: 'unknown' })), authoritative: false };
     }
     const installed = new Set(result.installed.filter((kind) => kinds.includes(kind)));
+    // A non-empty manifest catalog with zero executable hits is usually a
+    // stripped daemon PATH, not authoritative proof that every agent vanished.
+    // Preserve the host's bounded catalog as unknown until at least one probe
+    // succeeds instead of collapsing the composer to Shell and overwriting the
+    // user's saved choice.
+    if (installed.size === 0) {
+        return { options: kinds.map((kind) => ({ kind, availability: 'unknown' })), authoritative: false };
+    }
     return {
         options: kinds.map((kind): AgentCatalogOption => ({
             kind,

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
 import {
+    chmodSync,
     existsSync,
     mkdirSync,
     mkdtempSync,
@@ -272,6 +273,30 @@ try {
     const cli = join(installDir, 'node_modules', '.bin', 'muxr');
     const installedPackage = join(installDir, 'node_modules', '@trymuxr', 'cli');
     const installedPlugins = join(installedPackage, 'plugins');
+    if (existsSync('/usr/bin/script')) {
+        const uiFlow = join(scratch, 'setup-ui-flow.mjs');
+        writeFileSync(uiFlow, `import {withFullscreen, setupStep, outro, select} from ${JSON.stringify(`file://${join(installedPackage, 'setup-ui.mjs')}`)};\nif (process.argv[2] === 'full') await withFullscreen(async () => { setupStep(1, 5, 'Check this machine'); outro('Setup receipt'); return 0; });\nelse await withFullscreen(async () => { await select('Choose connection', [{value:'lan',title:'LAN',description:'same network'}]); return 0; });\n`);
+        const fullUiEnv = { ...process.env, TERM: 'xterm-256color' };
+        delete fullUiEnv.CI;
+        delete fullUiEnv.SSH_CONNECTION;
+        delete fullUiEnv.MUXR_NO_TUI;
+        const fullUi = run('/usr/bin/script', ['-qfec', `stty cols 106 rows 43; ${process.execPath} ${uiFlow} full`, '/dev/null'], {
+            input: '\n', env: fullUiEnv,
+        }).stdout;
+        assert.match(fullUi, /\x1b\[\?1049h/);
+        assert.match(fullUi, /\x1b\[\?1049l/);
+        assert.match(fullUi, /◆ Setup receipt/, 'fullscreen success left no durable receipt');
+        const appendUi = run('/usr/bin/script', ['-qfec', `${process.execPath} ${uiFlow} append`, '/dev/null'], {
+            input: '1\n', env: { ...process.env, TERM: 'dumb', SSH_CONNECTION: 'test' },
+        }).stdout;
+        assert.doesNotMatch(appendUi, /\x1b\[/, 'SSH/dumb setup emitted cursor or style control sequences');
+        assert.match(appendUi, /1\. LAN[\s\S]*Choose 1-1/, 'SSH setup did not use the append-only numbered selector');
+        const smallUi = run('/usr/bin/script', ['-qfec', `stty cols 70 rows 24; ${process.execPath} ${uiFlow} append`, '/dev/null'], {
+            input: '1\n', env: fullUiEnv,
+        }).stdout;
+        assert.doesNotMatch(smallUi, /\x1b\[\?1049h|\x1b\[[0-9]+A/, 'small local setup used fullscreen or cursor redraw');
+        assert.match(smallUi, /1\. LAN[\s\S]*Choose 1-1/, 'small local setup did not use the append-only selector');
+    }
     const docsOutput = run(cli, ['plugin', 'docs'], { cwd: installDir }).stdout;
     assert.match(docsOutput, new RegExp(`Plugin guide: ${join(installedPackage, 'PLUGINS.md').replaceAll('\\', '\\\\')}`));
     assert.match(docsOutput, new RegExp(`Agent skill: ${join(installedPackage, 'skills', 'muxr-plugin-authoring', 'SKILL.md').replaceAll('\\', '\\\\')}`));
@@ -374,7 +399,7 @@ try {
     assert.equal(promptSmoke.code, 0, promptSmoke.output);
     assert.doesNotMatch(promptSmoke.output, /unsettled top-level await|SyntaxError/);
     const menuCancel = await runTty(cli, cliEnv(), '\u0003', 20_000, undefined, 'never', 'What would you like to do?');
-    assert.equal(menuCancel.code, 0, menuCancel.output);
+    assert.ok(menuCancel.code === 0 || menuCancel.code === 130, menuCancel.output);
     assert.doesNotMatch(menuCancel.output, /Get started\s+ muxr setup/, 'cancelling the menu printed command help');
     const inspectHome = join(scratch, 'inspect-home');
     mkdirSync(inspectHome, { recursive: true });
@@ -521,6 +546,34 @@ try {
     assert.notEqual(stoppedDoctor.status, 0, 'doctor accepted a configured relay that was not running');
     assert.match(`${stoppedDoctor.stdout}${stoppedDoctor.stderr}`, /not reachable/);
 
+    const hostedAuthPath = join(home, '.muxr', 'auth.json');
+    const key32 = Buffer.alloc(32).toString('base64');
+    const key64 = Buffer.alloc(64).toString('base64');
+    writeFileSync(hostedAuthPath, `${JSON.stringify({
+        version: 1,
+        controlUrl: 'https://control.test',
+        relayUrl: 'wss://relay.test',
+        credential: 'machine-credential',
+        credentialExpiresAt: '9999-12-31T23:59:59.999Z',
+        machine: { id: 'machine', crypto: {
+            signingPublicKey: key32, signingSecretKey: key64, boxPublicKey: key32, boxSecretKey: key32, dataKey: key32,
+            keyVersion: 1, devices: [],
+            pendingRotation: { keyVersion: 2, dataKey: key32, devices: [], grants: [{ device_public_key: key32, grant: '' }] },
+        } },
+    })}\n`, { mode: 0o600 });
+    const authDoctor = run(cli, ['doctor'], { cwd: installDir, env, allowFailure: true });
+    assert.notEqual(authDoctor.status, 0, 'doctor accepted incomplete hosted auth');
+    assert.match(`${authDoctor.stdout}${authDoctor.stderr}`, /hosted auth.*incomplete/s);
+    const corruptHost = run(cli, ['up'], { cwd: installDir, env: { ...env, MUXR_MODE: 'hosted' }, allowFailure: true });
+    assert.equal(corruptHost.status, 0, 'deterministic hosted auth corruption would restart-loop');
+    assert.match(`${corruptHost.stdout}${corruptHost.stderr}`, /unsupported or incomplete schema/);
+    chmodSync(hostedAuthPath, 0o000);
+    const unreadableHost = run(cli, ['up'], { cwd: installDir, env: { ...env, MUXR_MODE: 'hosted' }, allowFailure: true });
+    assert.equal(unreadableHost.status, 0, 'unreadable hosted auth would restart-loop');
+    assert.match(`${unreadableHost.stdout}${unreadableHost.stderr}`, /cannot be read|EACCES|EPERM/);
+    chmodSync(hostedAuthPath, 0o600);
+    rmSync(hostedAuthPath, { force: true });
+
     const host = spawn(cli, ['up', '--fake'], { cwd: installDir, env: { ...env, MUXR_MODE: 'selfhost' }, stdio: ['ignore', 'pipe', 'pipe'] });
     let hostOutput = '';
     host.stdout.on('data', (chunk) => { hostOutput += chunk; });
@@ -644,6 +697,17 @@ try {
     assert.match(readFileSync(launchctlLog, 'utf8'), /bootstrap[\s\S]*kickstart/, 'first macOS start did not kickstart after bootstrap');
     run(cli, ['daemon', 'start'], { cwd: installDir, env: macEnv });
     assert.match(readFileSync(launchctlLog, 'utf8'), /bootstrap[\s\S]*kickstart[\s\S]*bootout[\s\S]*bootstrap[\s\S]*kickstart/, 'macOS start reused a stale loaded plist');
+
+    const staleHerdr = join(macHome, 'Library', 'LaunchAgents', 'herdr-server.plist');
+    const repairHerdr = join(binDir, 'herdr-repair');
+    writeFileSync(staleHerdr, '<plist><dict><key>ProgramArguments</key><array><string>/missing/herdr</string><string>server</string></array></dict></plist>\n');
+    writeFileSync(repairHerdr, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const localSetupUrl = `file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'local-setup.mjs')}`;
+    run(process.execPath, ['--input-type=module', '-e', `import {ensureHerdrServer} from ${JSON.stringify(localSetupUrl)}; await ensureHerdrServer(${JSON.stringify(repairHerdr)})`], {
+        cwd: installDir, env: macEnv, allowFailure: true,
+    });
+    assert.match(readFileSync(staleHerdr, 'utf8'), new RegExp(repairHerdr.replaceAll('/', '\\/')), 'stale Herdr plist was not repaired');
+    assert.match(readFileSync(launchctlLog, 'utf8'), /bootout gui\/\d+\/herdr-server[\s\S]*bootstrap gui\/\d+ .*herdr-server\.plist[\s\S]*kickstart -k gui\/\d+\/herdr-server/, 'loaded repaired Herdr plist was not reloaded');
     run(cli, ['daemon', 'status'], { cwd: installDir, env: macEnv });
     run(cli, ['daemon', 'uninstall'], { cwd: installDir, env: macEnv });
 

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -494,7 +494,10 @@ try {
     assert.ok(!existsSync(updateLog), 'prefix mismatch reached npm install');
     run(cli, ['update', '--yes'], { cwd: installDir, env: updateEnv });
     assert.match(readFileSync(updateLog, 'utf8'), /install --global --ignore-scripts @trymuxr\/cli@9\.9\.9/);
-    assert.match(readFileSync(join(home, '.config', 'systemd', 'user', 'muxr.service'), 'utf8'), /MUXR_MODE=.*selfhost/, 'update removed the daemon mode');
+    const linuxUnit = readFileSync(join(home, '.config', 'systemd', 'user', 'muxr.service'), 'utf8');
+    assert.match(linuxUnit, /MUXR_MODE=.*selfhost/, 'update removed the daemon mode');
+    assert.ok(linuxUnit.includes(`Environment=PATH="${env.PATH}:`), 'Linux daemon dropped the interactive executable path');
+    assert.ok(linuxUnit.includes(`Environment=HERDR_BIN="${env.HERDR_BIN}"`), 'Linux daemon did not pin the Herdr binary');
     assert.equal(readFileSync(join(home, '.config', 'herdr', 'config.toml'), 'utf8'), configBefore);
     const instructions = readFileSync(instructionPath, 'utf8');
     assert.equal(instructions.match(/muxr:herdr-skill:start/g)?.length, 1);
@@ -632,9 +635,15 @@ try {
     mkdirSync(macHome, { recursive: true });
     const macEnv = cliEnv(macHome, { MUXR_PLATFORM: 'darwin', MUXR_NO_SERVICE_COMMANDS: '' });
     run(cli, ['daemon', 'install'], { cwd: installDir, env: macEnv });
-    assert.match(readFileSync(join(macHome, 'Library', 'LaunchAgents', 'com.muxr.host.plist'), 'utf8'), /com\.muxr\.host/);
+    const macPlist = readFileSync(join(macHome, 'Library', 'LaunchAgents', 'com.muxr.host.plist'), 'utf8');
+    assert.match(macPlist, /com\.muxr\.host/);
+    assert.match(macPlist, /<key>RunAtLoad<\/key><true\/>/, 'macOS daemon will not start automatically after login');
+    assert.ok(macPlist.includes(`<key>PATH</key><string>${macEnv.PATH}:`), 'macOS daemon dropped the interactive executable path');
+    assert.ok(macPlist.includes(`<key>HERDR_BIN</key><string>${macEnv.HERDR_BIN}</string>`), 'macOS daemon did not pin the Herdr binary');
     run(cli, ['daemon', 'start'], { cwd: installDir, env: macEnv });
     assert.match(readFileSync(launchctlLog, 'utf8'), /bootstrap[\s\S]*kickstart/, 'first macOS start did not kickstart after bootstrap');
+    run(cli, ['daemon', 'start'], { cwd: installDir, env: macEnv });
+    assert.match(readFileSync(launchctlLog, 'utf8'), /bootstrap[\s\S]*kickstart[\s\S]*bootout[\s\S]*bootstrap[\s\S]*kickstart/, 'macOS start reused a stale loaded plist');
     run(cli, ['daemon', 'status'], { cwd: installDir, env: macEnv });
     run(cli, ['daemon', 'uninstall'], { cwd: installDir, env: macEnv });
 

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -19,7 +19,7 @@ import {
     writeFileSync,
 } from 'node:fs';
 import { homedir, hostname, networkInterfaces, platform as hostPlatform, tmpdir, userInfo } from 'node:os';
-import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { basename, delimiter, dirname, isAbsolute, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 
 const MIN_HERDR = [0, 8, 0];
@@ -44,10 +44,20 @@ const INTEGRATION_COMMANDS = {
 const print = (text = '') => process.stdout.write(`${text}\n`);
 const error = (text) => process.stderr.write(`${text}\n`);
 async function printTerminalQr(value) {
+    if (!process.stdout.isTTY || process.env.TERM === 'dumb' || process.env.NO_COLOR !== undefined
+        || process.env.MUXR_NO_TUI === '1' || process.env.SSH_CONNECTION) {
+        print('QR omitted in append-only/plain output; use the exact pairing string below.');
+        return;
+    }
     const qr = await QRCode.toString(value, { type: 'utf8', margin: 4, errorCorrectionLevel: 'M' });
-    const width = Math.max(...qr.split('\n').map((line) => [...line].length));
-    if (process.stdout.columns !== undefined && width > process.stdout.columns) {
-        print(`QR omitted because this terminal is ${process.stdout.columns} columns wide; use the exact string below.`);
+    const lines = qr.split('\n');
+    const width = Math.max(...lines.map((line) => [...line].length));
+    const tooWide = process.stdout.columns !== undefined && width > process.stdout.columns;
+    // Pairing prints the exact string, save location, and waiting state after
+    // the QR. Keep those rows plus the complete quiet zone visible together.
+    const tooTall = process.stdout.rows !== undefined && lines.length + 5 > process.stdout.rows;
+    if (tooWide || tooTall) {
+        print(`QR omitted because this terminal is ${process.stdout.columns ?? 'too few'} columns × ${process.stdout.rows ?? 'too few'} rows; use the exact pairing string below.`);
         return;
     }
     print(qr.split('\n').map((line) => `\x1b[47m\x1b[30m${line}\x1b[0m`).join('\n'));
@@ -175,11 +185,12 @@ function run(command, args, options = {}) {
 
 function herdrBin() {
     const configured = env('HERDR_BIN');
-    if (configured) return configured;
-    return executable('herdr') || [
+    const selected = configured ? executable(configured) : executable('herdr') || [
         join(env('HERDR_INSTALL_DIR') || join(home(), '.local', 'bin'), 'herdr'),
         '/usr/local/bin/herdr',
     ].find((candidate) => executable(candidate));
+    if (configured && selected === undefined) throw new Error(`HERDR_BIN does not resolve to an executable: ${configured}`);
+    return selected === undefined ? undefined : realpathSync(resolve(selected));
 }
 
 export function tailscaleBin() {
@@ -484,6 +495,7 @@ function herdrServiceUnitPaths() {
  * genuinely stale pinned path; never touch a unit whose exec still resolves.
  */
 function repairHerdrServiceUnits(binary, dryRun) {
+    const repaired = [];
     for (const unitPath of herdrServiceUnitPaths()) {
         const pinned = staleUnitPaths(unitPath).find((path) => basename(path) === 'herdr');
         if (pinned === undefined || pinned === binary) continue;
@@ -501,18 +513,27 @@ function repairHerdrServiceUnits(binary, dryRun) {
         const backupPath = backup(unitPath);
         atomicWrite(unitPath, updated, statSync(unitPath).mode & 0o777);
         print(`  repaired ${unitPath}: was \`${execLine}\`, now runs ${binary} (backup: ${backupPath})`);
+        repaired.push(unitPath);
         if (env('MUXR_NO_SERVICE_COMMANDS') !== '1' && platform() === 'linux') run('systemctl', ['--user', 'daemon-reload']);
     }
+    return repaired;
 }
 
 /** Start herdr through its own service manager so it stays managed. */
 function startHerdrServiceUnits(unitPaths) {
     for (const unitPath of unitPaths) {
         if (platform() === 'darwin') {
-            const service = `gui/${process.getuid()}/${basename(unitPath, '.plist')}`;
+            const domain = `gui/${process.getuid()}`;
+            const service = `${domain}/${basename(unitPath, '.plist')}`;
             const loaded = run('launchctl', ['print', service]);
-            if (loaded.ok) run('launchctl', ['kickstart', '-k', service]);
-            else run('launchctl', ['bootstrap', `gui/${process.getuid()}`, unitPath]);
+            if (loaded.ok) {
+                const unloaded = run('launchctl', ['bootout', service]);
+                if (!unloaded.ok) throw new Error(unloaded.stderr || unloaded.stdout || `could not unload ${service}`);
+            }
+            const bootstrapped = run('launchctl', ['bootstrap', domain, unitPath]);
+            if (!bootstrapped.ok) throw new Error(bootstrapped.stderr || bootstrapped.stdout || `could not load ${service}`);
+            const started = run('launchctl', ['kickstart', '-k', service]);
+            if (!started.ok) throw new Error(started.stderr || started.stdout || `could not start ${service}`);
         } else {
             run('systemctl', ['--user', 'start', basename(unitPath)]);
         }
@@ -525,7 +546,10 @@ function startHerdrServiceUnits(unitPaths) {
  */
 export async function ensureHerdrServer(binary = herdrBin(), dryRun = false) {
     if (!binary) throw new Error(`herdr is missing; ${HERDR_INSTALL_HINT}`);
-    repairHerdrServiceUnits(binary, dryRun);
+    const repaired = repairHerdrServiceUnits(binary, dryRun);
+    if (!dryRun && repaired.length > 0 && env('MUXR_NO_SERVICE_COMMANDS') !== '1' && platform() === 'darwin') {
+        startHerdrServiceUnits(repaired);
+    }
     let status = run(binary, ['status']);
     if (!status.ok) {
         if (dryRun) {
@@ -537,7 +561,7 @@ export async function ensureHerdrServer(binary = herdrBin(), dryRun = false) {
                 // Start the managed unit, not a stray process: a direct spawn
                 // lands in muxr.service's cgroup (`muxr daemon stop` kills
                 // herdr) and races the systemd-started server at boot.
-                startHerdrServiceUnits(units);
+                if (repaired.length === 0 || platform() !== 'darwin') startHerdrServiceUnits(units);
             } else {
                 logPath = join(stateDir(), 'logs', 'herdr.log');
                 ensurePrivateDir(dirname(logPath));
@@ -1008,7 +1032,7 @@ function daemonDefinition(mode) {
         '/usr/local/bin',
         '/usr/bin',
         '/bin',
-    ].filter(Boolean))].join(delimiter);
+    ].filter((directory) => typeof directory === 'string' && isAbsolute(directory)))].join(delimiter);
     if (platform() === 'darwin') {
         const path = join(home(), 'Library', 'LaunchAgents', 'com.muxr.host.plist');
         const environment = [
@@ -1287,11 +1311,75 @@ function loadAuthState() {
             throw new Error(`${authPath()} must be a regular owner-only file`);
         }
         const parsed = JSON.parse(readFileSync(authPath(), 'utf8'));
-        return parsed.version === 1 ? parsed : undefined;
+        if (parsed.version !== 1) throw new Error(`${authPath()} has an unsupported schema`);
+        return parsed;
     } catch (cause) {
         if (cause?.code === 'ENOENT') return undefined;
         throw cause;
     }
+}
+
+function validMachineCrypto(value, expected) {
+    if (typeof value !== 'object' || value === null) return false;
+    const validBase64 = (text, bytes) => {
+        if (typeof text !== 'string' || text.length % 4 !== 0 || !/^[A-Za-z0-9+/]+={0,2}$/.test(text)) return false;
+        try { return Buffer.from(text, 'base64').length === bytes; } catch { return false; }
+    };
+    const keys = validBase64(value.signingPublicKey, 32)
+        && validBase64(value.signingSecretKey, 64)
+        && validBase64(value.boxPublicKey, 32)
+        && validBase64(value.boxSecretKey, 32)
+        && validBase64(value.dataKey, 32);
+    const parseGrant = (text) => {
+        if (typeof text !== 'string' || text.length === 0) return undefined;
+        try {
+            const grant = JSON.parse(text);
+            return grant.v === 1
+                && validBase64(grant.sender, 32)
+                && validBase64(grant.signer, 32)
+                && validBase64(grant.sig, 64)
+                && typeof grant.box === 'string'
+                && /^[A-Za-z0-9+/]+={0,2}$/.test(grant.box)
+                && Buffer.from(grant.box, 'base64').length > 40
+                ? grant : undefined;
+        } catch { return undefined; }
+    };
+    const validDevice = (device) => typeof device === 'object' && device !== null
+        && typeof device.deviceId === 'string' && device.deviceId.length > 0
+        && validBase64(device.devicePublicKey, 32)
+        && validBase64(device.ingressKey, 32)
+        && typeof device.expiresAt === 'string' && Number.isFinite(Date.parse(device.expiresAt))
+        && (device.kind === undefined || device.kind === 'browser')
+        && (device.authority === undefined || device.authority === 'control' || device.authority === 'observe');
+    if (!keys || !Number.isInteger(value.keyVersion) || value.keyVersion < 1
+        || !Array.isArray(value.devices) || !value.devices.every(validDevice)
+        || new Set(value.devices.map((device) => device.deviceId)).size !== value.devices.length) return false;
+    const pending = value.pendingRotation;
+    if (pending === undefined) return true;
+    if (!validBase64(pending.dataKey, 32) || !Array.isArray(pending.devices) || !pending.devices.every(validDevice)
+        || new Set(pending.devices.map((device) => device.deviceId)).size !== pending.devices.length
+        || !Array.isArray(pending.grants) || pending.grants.length !== pending.devices.length) return false;
+    const selfhost = pending.kind === 'selfhost-revoke-v1';
+    if (expected === 'hosted' ? selfhost : !selfhost) return false;
+    const versionValid = selfhost
+        ? Number.isInteger(pending.previousKeyVersion) && Number.isInteger(pending.keyVersion)
+            && pending.keyVersion === pending.previousKeyVersion + 1
+            && (value.keyVersion === pending.previousKeyVersion || value.keyVersion === pending.keyVersion)
+            && typeof pending.revokedDeviceId === 'string' && typeof pending.revokedDeviceName === 'string'
+        : pending.kind === undefined && Number.isInteger(pending.keyVersion) && pending.keyVersion === value.keyVersion + 1;
+    if (!versionValid) return false;
+    const byId = new Map(pending.devices.map((device) => [device.deviceId, device]));
+    const expectedKeys = new Set(pending.devices.map((device) => device.devicePublicKey));
+    const seen = new Set();
+    return pending.grants.every((entry) => {
+        if (typeof entry !== 'object' || entry === null) return false;
+        const deviceKey = selfhost ? byId.get(entry.deviceId)?.devicePublicKey : entry.device_public_key;
+        const grant = parseGrant(entry.grant);
+        if (typeof deviceKey !== 'string' || !expectedKeys.has(deviceKey) || seen.has(deviceKey) || grant === undefined
+            || grant.sender !== value.boxPublicKey || grant.signer !== value.signingPublicKey) return false;
+        seen.add(deviceKey);
+        return true;
+    }) && seen.size === expectedKeys.size;
 }
 
 function machineIdentity(existing) {
@@ -2365,10 +2453,13 @@ export async function runSetup(args = []) {
         }
         if (dryRun) print('  would start/resume hosted device authorization and single-use QR pairing');
         else if ((await runHostedLogin(args)) !== 0) throw new Error('hosted login failed');
+        // Bring the host online before showing a device QR. The old order let
+        // the phone claim a grant and begin connecting to a host that did not
+        // exist yet on a clean machine.
+        await startMuxrDaemon('hosted', args);
         if (!dryRun && process.env.MUXR_SKIP_HOSTED_AUTH !== '1' && (await runAccount('pair')) !== 0) {
             throw new Error('secure device pairing failed');
         }
-        await startMuxrDaemon('hosted', args);
         print('  Live Voice is optional; configure it from the muxr Voice plugin pane.');
         print('Ready — open muxr.');
         return 0;
@@ -2548,17 +2639,59 @@ export async function runDoctor() {
     add(runtime ? 'ok' : 'fail', managedMode === 'relay' ? 'relay' : 'host', runtime
         ? `${managedMode === 'relay' ? 'relay' : 'host'} runtime present`
         : `missing ${managedMode === 'relay' ? 'relay' : 'host'} runtime; rebuild or reinstall muxr`);
-    const binary = managedMode === 'relay' ? undefined : herdrBin();
+    if (existsSync(authPath()) || managedMode === 'hosted') {
+        try {
+            const auth = loadAuthState();
+            const complete = auth !== undefined
+                && typeof auth.controlUrl === 'string'
+                && typeof auth.relayUrl === 'string'
+                && typeof auth.credential === 'string'
+                && typeof auth.credentialExpiresAt === 'string'
+                && typeof auth.machine?.id === 'string'
+                && validMachineCrypto(auth.machine?.crypto, 'hosted');
+            const expires = complete ? Date.parse(auth.credentialExpiresAt) : NaN;
+            const pending = auth?.pending;
+            const pendingValid = !complete
+                && auth?.version === 1
+                && typeof auth.machine?.id === 'string'
+                && validMachineCrypto(auth.machine?.crypto, 'hosted')
+                && typeof pending?.controlUrl === 'string'
+                && typeof pending?.deviceCode === 'string'
+                && typeof pending?.userCode === 'string'
+                && typeof pending?.verificationUri === 'string'
+                && typeof pending?.expiresAt === 'string'
+                && Number.isFinite(Date.parse(pending.expiresAt))
+                && Date.parse(pending.expiresAt) > Date.now();
+            add(complete && Number.isFinite(expires) && expires > Date.now() ? 'ok' : pendingValid ? 'warn' : 'fail', 'hosted auth', complete
+                ? Number.isFinite(expires) && expires > Date.now()
+                    ? 'owner-only auth state valid'
+                    : 'credential expired — run `muxr login`'
+                : pendingValid
+                    ? 'authorization is incomplete — rerun `muxr setup` to resume it'
+                    : `~/.muxr/auth.json is incomplete — back it up before moving it aside, then run \`muxr login\``);
+        } catch (cause) {
+            add('fail', 'hosted auth', `${cause instanceof Error ? cause.message : String(cause)} — back up ~/.muxr/auth.json before moving it aside, then run \`muxr login\``);
+        }
+    }
+    let binary;
+    let binaryIssue;
+    try { binary = managedMode === 'relay' ? undefined : herdrBin(); }
+    catch (cause) {
+        binaryIssue = cause instanceof Error ? cause.message : String(cause);
+        add('fail', 'herdr', binaryIssue);
+    }
     if (managedMode === 'relay') {
         add('ok', 'profile', 'shared relay only · Herdr and agent integrations not required');
     } else if (!binary) {
-        add('fail', 'herdr', `missing — ${HERDR_INSTALL_HINT}`, {
-            label: 'install and start Herdr',
-            run: async () => {
-                const installed = await ensureHerdr({ dryRun: false, noInstall: false, installRequested: true });
-                await ensureHerdrServer(installed);
-            },
-        });
+        if (binaryIssue === undefined) {
+            add('fail', 'herdr', `missing — ${HERDR_INSTALL_HINT}`, {
+                label: 'install and start Herdr',
+                run: async () => {
+                    const installed = await ensureHerdr({ dryRun: false, noInstall: false, installRequested: true });
+                    await ensureHerdrServer(installed);
+                },
+            });
+        }
     } else {
         const versionResult = run(binary, ['--version']);
         const version = parseVersion(versionResult.stdout);
@@ -2626,9 +2759,28 @@ export async function runDoctor() {
             : `muxr.service is ${enabled.stdout || 'not enabled'} — it will not survive a reboot; enable it with \`muxr daemon start\``,
             isEnabled ? undefined : { label: 'enable and start the muxr service', run: () => runDaemon(['start']) });
     }
-    const selfhost = readSelfhostState();
+    if (platform() === 'darwin' && existsSync(muxrServicePath) && env('MUXR_NO_SERVICE_COMMANDS') !== '1') {
+        const definition = readFileSync(muxrServicePath, 'utf8');
+        const loaded = serviceCommand('status');
+        const startsAtLogin = /<key>RunAtLoad<\/key><true\/>/.test(definition);
+        add(loaded.ok && startsAtLogin ? 'ok' : 'fail', 'service loaded', loaded.ok && startsAtLogin
+            ? 'com.muxr.host is loaded and starts at login'
+            : `${loaded.ok ? 'service is loaded but RunAtLoad is off' : 'com.muxr.host is not loaded'} — run \`muxr daemon start\``,
+            loaded.ok && startsAtLogin ? undefined : { label: 'load the muxr service for login', run: () => runDaemon(['start']) });
+    }
+    let selfhost = readSelfhostState();
     if (selfhostStateUnreadable()) {
         add('fail', 'self-host state', `${selfhostPath()} exists but is unreadable (truncated or corrupt) — move it aside with \`mv ${selfhostPath()} ${selfhostPath()}.broken\` only after pairings are backed up; setup refuses to mint a new identity over it`);
+    } else if (managedMode === 'selfhost' && selfhost !== undefined) {
+        const expires = selfhost.credentialExpiresAt === undefined ? undefined : Date.parse(selfhost.credentialExpiresAt);
+        const valid = typeof selfhost.machine?.id === 'string' && validMachineCrypto(selfhost.machine?.crypto, 'selfhost')
+            && (typeof selfhost.mintSecret === 'string' || typeof selfhost.machineCredential === 'string')
+            && (selfhost.relayLocation === 'remote' ? typeof selfhost.relayUrl === 'string' : typeof selfhost.relayPort === 'number')
+            && (expires === undefined || Number.isFinite(expires) && expires > Date.now());
+        if (!valid) {
+            add('fail', 'self-host state', `${selfhostPath()} has an incomplete machine, crypto, or credential schema — back it up before moving it aside; setup will not overwrite it`);
+            selfhost = undefined;
+        }
     }
     const relayReady = await selfhostRelayHealthy(selfhost);
     const relayDetail = selfhost?.relayLocation === 'remote'

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -441,7 +441,7 @@ async function ensureBundledPlugins(binary, dryRun) {
     }
 }
 
-/** Absolute paths referenced by a service file's exec line that no longer exist. */
+/** Absolute executable paths pinned by a service file that no longer exist. */
 function staleUnitPaths(unitPath) {
     const content = readFileSync(unitPath, 'utf8');
     // systemd allows -@!:+ prefixes on the executable; strip them before
@@ -451,9 +451,13 @@ function staleUnitPaths(unitPath) {
         ? [...execStart.matchAll(/"([^"]+)"|(\S+)/g)].map((match) => match[1] ?? match[2])
         : [...(content.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/)?.[1] ?? '')
             .matchAll(/<string>([^<]+)<\/string>/g)].map((match) => match[1]);
-    return tokens
+    const systemdHerdr = content.match(/^Environment=HERDR_BIN=(?:"([^"]+)"|(\S+))$/m);
+    const plistHerdr = content.match(/<key>HERDR_BIN<\/key><string>([^<]+)<\/string>/)?.[1]
+        ?.replaceAll('&quot;', '"').replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&amp;', '&');
+    return [...tokens, systemdHerdr?.[1] ?? systemdHerdr?.[2], plistHerdr]
+        .filter((token) => typeof token === 'string')
         // Undo systemd %% escaping so a path containing % is not a false FAIL.
-        .map((token) => token.replaceAll('%%', '%'))
+        .map((token) => token.replaceAll('%%', '%').replaceAll('\\"', '"').replaceAll('\\\\', '\\'))
         .filter((token) => token.startsWith('/') && !existsSync(token));
 }
 
@@ -840,13 +844,20 @@ export async function runIntegrations(args = []) {
             if (status === 'unknown') {
                 print(`  warn: ${id} is not reported by this herdr build; lifecycle integration skipped`);
             } else if (status !== 'current') {
-                print(`  ${dryRun ? 'would run' : 'run'} herdr integration install ${id} (${status})`);
+                print(`  ${dryRun ? 'would install' : 'installing'} ${id} lifecycle integration${status === 'not installed' ? '' : ` (was ${status})`}`);
                 if (!dryRun) {
                     const result = run(binary, ['integration', 'install', id]);
                     if (!result.ok) {
                         print(`  warn: ${id} lifecycle integration skipped (${result.stderr || result.stdout || 'install failed'})`);
                         continue;
                     }
+                    const verified = run(binary, ['integration', 'status']);
+                    const verifiedStatus = verified.ok ? parseIntegrationStatus(verified.stdout).get(id) : undefined;
+                    if (verifiedStatus !== 'current') {
+                        print(`  warn: ${id} lifecycle integration did not verify (${verifiedStatus ?? (verified.stderr || 'status unavailable')})`);
+                        continue;
+                    }
+                    print(`  ✓ ${id} lifecycle integration installed and verified`);
                     if (status === 'not installed' && !manifest.herdrInstalled.includes(id)) manifest.herdrInstalled.push(id);
                 }
             } else {
@@ -977,19 +988,44 @@ function daemonDefinition(mode) {
     if (mode !== undefined && mode !== 'hosted' && mode !== 'selfhost' && mode !== 'relay') throw new Error('--mode must be hosted, selfhost, or relay');
     const cli = realpathSync(process.argv[1]);
     const logs = join(stateDir(), 'logs');
+    const serviceHerdr = herdrBin();
+    const servicePath = [...new Set([
+        ...(process.env.PATH ?? '').split(delimiter),
+        dirname(process.execPath),
+        ...(serviceHerdr === undefined ? [] : [dirname(serviceHerdr)]),
+        join(home(), '.local', 'bin'),
+        join(home(), '.local', 'share', 'mise', 'shims'),
+        join(home(), '.npm-global', 'bin'),
+        join(home(), '.bun', 'bin'),
+        join(home(), '.volta', 'bin'),
+        join(home(), '.deno', 'bin'),
+        join(home(), '.cargo', 'bin'),
+        join(home(), 'Library', 'pnpm'),
+        join(home(), '.yarn', 'bin'),
+        join(home(), '.nix-profile', 'bin'),
+        '/opt/homebrew/bin',
+        '/opt/homebrew/sbin',
+        '/usr/local/bin',
+        '/usr/bin',
+        '/bin',
+    ].filter(Boolean))].join(delimiter);
     if (platform() === 'darwin') {
         const path = join(home(), 'Library', 'LaunchAgents', 'com.muxr.host.plist');
         const environment = [
+            ['PATH', servicePath],
+            ...(serviceHerdr === undefined ? [] : [['HERDR_BIN', serviceHerdr]]),
             ...(mode === undefined ? [] : [['MUXR_MODE', mode]]),
             ...(process.env.MUXR_HOME?.trim() ? [['MUXR_HOME', stateDir()]] : []),
         ];
         const modeEnv = environment.length === 0 ? '' : `\n<key>EnvironmentVariables</key><dict>${environment.map(([key, value]) => `<key>${key}</key><string>${xml(value)}</string>`).join('')}</dict>`;
-        const content = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n<key>Label</key><string>com.muxr.host</string>\n<key>ProgramArguments</key><array><string>${xml(process.execPath)}</string><string>${xml(cli)}</string><string>up</string></array>${modeEnv}\n<key>RunAtLoad</key><false/>\n<key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>\n<key>StandardOutPath</key><string>${xml(join(logs, 'daemon.log'))}</string>\n<key>StandardErrorPath</key><string>${xml(join(logs, 'daemon.log'))}</string>\n</dict></plist>\n`;
+        const content = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict>\n<key>Label</key><string>com.muxr.host</string>\n<key>ProgramArguments</key><array><string>${xml(process.execPath)}</string><string>${xml(cli)}</string><string>up</string></array>${modeEnv}\n<key>RunAtLoad</key><true/>\n<key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>\n<key>StandardOutPath</key><string>${xml(join(logs, 'daemon.log'))}</string>\n<key>StandardErrorPath</key><string>${xml(join(logs, 'daemon.log'))}</string>\n</dict></plist>\n`;
         return { path, content, mode: 0o600 };
     }
     if (platform() === 'linux') {
         const path = join(home(), '.config', 'systemd', 'user', 'muxr.service');
         const modeEnv = [
+            `Environment=PATH=${systemdArg(servicePath)}`,
+            ...(serviceHerdr === undefined ? [] : [`Environment=HERDR_BIN=${systemdArg(serviceHerdr)}`]),
             ...(mode === undefined ? [] : [`Environment=MUXR_MODE=${systemdArg(mode)}`]),
             ...(process.env.MUXR_HOME?.trim() ? [`Environment=MUXR_HOME=${systemdArg(stateDir())}`] : []),
         ].join('\n');
@@ -1012,7 +1048,10 @@ function serviceCommand(action) {
         if (action === 'reload') return { ok: true, stdout: '', stderr: '' };
         if (action === 'start') {
             const loaded = run('launchctl', ['print', service]);
-            if (loaded.ok) return run('launchctl', ['kickstart', '-k', service]);
+            if (loaded.ok) {
+                const unloaded = run('launchctl', ['bootout', service]);
+                if (!unloaded.ok) return unloaded;
+            }
             const bootstrapped = run('launchctl', ['bootstrap', domain, plist]);
             return bootstrapped.ok ? run('launchctl', ['kickstart', '-k', service]) : bootstrapped;
         }
@@ -1772,9 +1811,10 @@ async function startMuxrDaemon(mode, args = [], restartRunning = true) {
                 return selfhostRelayHealthy(state);
             })();
             if (relayReady) {
+                const relayDetail = mode === 'selfhost' || mode === 'relay' ? '; relay reachable' : '';
                 print(wasRunning
-                    ? `  ✓ muxr background service ${restartRunning ? 'updated, restarted, and' : 'already running and'} verified in ${mode} mode`
-                    : `  ✓ muxr background service installed, started, and verified in ${mode} mode`);
+                    ? `  ✓ muxr background service ${restartRunning ? 'updated and restarted' : 'already running'} in ${mode} mode${relayDetail}`
+                    : `  ✓ muxr background service installed and running in ${mode} mode${relayDetail}`);
                 return;
             }
         }
@@ -2534,7 +2574,7 @@ export async function runDoctor() {
         const integrations = run(binary, ['integration', 'status']);
         if (integrations.ok) {
             const statuses = parseIntegrationStatus(integrations.stdout);
-            const detected = detectedTargets().map((target) => `${target.id}:${statuses.get(target.id) ?? 'unknown'}`);
+            const detected = detectedLifecycleTargets(statuses).map(([id, status]) => `${id}:${status}`);
             const needsSync = detected.some((status) => !status.endsWith(':current'));
             add(needsSync ? 'warn' : 'ok', 'integrations', needsSync
                 ? `${detected.join(', ')} — run \`muxr integrations sync\``

--- a/scripts/setup-ui.mjs
+++ b/scripts/setup-ui.mjs
@@ -1,12 +1,144 @@
 import { createInterface, emitKeypressEvents } from 'node:readline';
 
 const interactive = () => Boolean(process.stdin.isTTY && process.stdout.isTTY);
-const ansi = (code, text) => interactive() && process.env.NO_COLOR === undefined ? `\x1b[${code}m${text}\x1b[0m` : text;
+const ansi = (code, text) => interactive() && process.env.NO_COLOR === undefined && process.env.TERM !== 'dumb' ? `\x1b[${code}m${text}\x1b[0m` : text;
 const dim = (text) => ansi('2', text);
 const bold = (text) => ansi('1', text);
 const green = (text) => ansi('32', text);
 const yellow = (text) => ansi('33', text);
 const inverse = (text) => ansi('7', text);
+let fullscreen = false;
+let setupSession = false;
+let holdFullscreen = false;
+let persistentReceipt = '';
+
+const richInteractive = () => interactive()
+    && process.env.MUXR_NO_TUI !== '1'
+    && !process.env.SSH_CONNECTION
+    && !process.env.CI
+    && process.env.TERM !== 'dumb'
+    && (!setupSession || (process.stdout.columns ?? 80) >= 80 && (process.stdout.rows ?? 24) >= 40);
+const fullscreenSupported = () => richInteractive()
+    && (process.stdout.columns ?? 80) >= 80
+    && (process.stdout.rows ?? 24) >= 40;
+
+function leaveFullscreen() {
+    if (!fullscreen) return;
+    process.stdout.write('\x1b[?25h\x1b[?1049l');
+    fullscreen = false;
+    holdFullscreen = false;
+}
+
+async function waitForContinue() {
+    process.stdout.write(`\n  ${dim('enter continue · ctrl-c exit')}\x1b[K`);
+    emitKeypressEvents(process.stdin);
+    const wasRaw = process.stdin.isRaw;
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    await new Promise((resolve) => {
+        const onKey = (_text, key = {}) => {
+            if (key.name !== 'return' && !(key.ctrl && key.name === 'c')) return;
+            process.stdin.off('keypress', onKey);
+            process.stdin.setRawMode?.(Boolean(wasRaw));
+            process.stdin.pause();
+            resolve();
+        };
+        process.stdin.on('keypress', onKey);
+    });
+}
+
+/** OMP-style alternate-screen shell for local onboarding. SSH/non-TTY keeps
+ * append-only output so logs and automation remain inspectable. */
+export async function withFullscreen(task) {
+    if (setupSession) return task();
+    setupSession = true;
+    persistentReceipt = '';
+    if (!fullscreenSupported()) {
+        try { return await task(); }
+        finally { setupSession = false; }
+    }
+    fullscreen = true;
+    holdFullscreen = false;
+    process.stdout.write('\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H');
+    const originalOutputWrite = process.stdout.write.bind(process.stdout);
+    const originalErrorWrite = process.stderr.write.bind(process.stderr);
+    let output = '';
+    let errors = '';
+    let failed = false;
+    process.stdout.write = (chunk, ...args) => {
+        output += String(chunk);
+        return originalOutputWrite(chunk, ...args);
+    };
+    process.stderr.write = (chunk, ...args) => {
+        errors += String(chunk);
+        return originalErrorWrite(chunk, ...args);
+    };
+    const onExit = () => leaveFullscreen();
+    process.once('exit', onExit);
+    try {
+        const result = await task();
+        failed = typeof result === 'number' && result !== 0;
+        if (holdFullscreen || failed) await waitForContinue();
+        return result;
+    } catch (cause) {
+        failed = true;
+        process.stderr.write(`\n  Setup stopped: ${cause instanceof Error ? cause.message : String(cause)}\n`);
+        await waitForContinue();
+        throw cause;
+    } finally {
+        process.stdout.write = originalOutputWrite;
+        process.stderr.write = originalErrorWrite;
+        process.off('exit', onExit);
+        leaveFullscreen();
+        setupSession = false;
+        // Alternate-screen failures must remain copyable after restoration.
+        if (failed) {
+            const clear = '\x1b[2J\x1b[H';
+            const screen = output.slice(Math.max(0, output.lastIndexOf(clear)));
+            const plain = `${screen}\n${errors}`
+                .replace(/\x1b\[[0-9;?]*[ -\/]*[@-~]/g, '')
+                .replaceAll('\r', '\n')
+                .trim();
+            if (plain) originalErrorWrite(`${plain}\n`);
+        } else if (persistentReceipt) {
+            originalOutputWrite(`\n◆ ${persistentReceipt}\n\n`);
+        }
+    }
+}
+
+export function setupStep(current, total, title) {
+    if (!fullscreen) {
+        heading(title);
+        return;
+    }
+    const columns = process.stdout.columns ?? 80;
+    const rows = process.stdout.rows ?? 24;
+    const center = (text) => `${' '.repeat(Math.max(0, Math.floor((columns - [...text].length) / 2)))}${text}`;
+    const width = Math.max(10, Math.min(42, columns - 16));
+    const filled = Math.round(width * current / total);
+    process.stdout.write('\x1b[2J\x1b[H');
+    if (rows >= 34) {
+        const logo = [
+            '███╗   ███╗██╗   ██╗██╗  ██╗██████╗',
+            '████╗ ████║██║   ██║╚██╗██╔╝██╔══██╗',
+            '██╔████╔██║██║   ██║ ╚███╔╝ ██████╔╝',
+            '██║╚██╔╝██║██║   ██║ ██╔██╗ ██╔══██╗',
+            '██║ ╚═╝ ██║╚██████╔╝██╔╝ ██╗██║  ██║',
+            '╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝',
+        ];
+        process.stdout.write(`\n${logo.map((line) => bold(center(line))).join('\n')}\n`);
+        process.stdout.write(`${dim(center('Your agents. One pocket.'))}\n\n`);
+    } else {
+        process.stdout.write(`\n  ${bold('MUXR')}  ${dim('Your agents. One pocket.')}\n\n`);
+    }
+    process.stdout.write(`  ${dim(`Setup step ${current} of ${total}`)}\n`);
+    process.stdout.write(`  ${green('━'.repeat(filled))}${dim('━'.repeat(width - filled))}\n`);
+    process.stdout.write(`\n  ${bold(title)}\n\n`);
+}
+
+export function completeFullscreen() {
+    holdFullscreen = fullscreen;
+}
 
 export function intro() {
     process.stdout.write(`\n${bold('  ███╗   ███╗██╗   ██╗██╗  ██╗██████╗')}\n`);
@@ -34,8 +166,9 @@ export function note(lines) {
     process.stdout.write(`  ${dim('└')}\n`);
 }
 
-export function outro(text) {
-    process.stdout.write(`\n${green('◆')} ${bold(text)}\n\n`);
+export function outro(text, kind = 'ok') {
+    if (setupSession) persistentReceipt = text;
+    process.stdout.write(`\n${kind === 'ok' ? green('◆') : yellow('◆')} ${bold(text)}\n\n`);
 }
 
 // Returned by select() on escape/left so callers can go up one level;
@@ -44,6 +177,27 @@ export const BACK = Symbol('muxr.back');
 
 export async function select(message, choices, initial = 0) {
     if (!interactive()) return choices[initial]?.value;
+    if (!richInteractive()) {
+        process.stdout.write(`${bold(`◆ ${message}`)}\n`);
+        choices.forEach((choice, index) => {
+            process.stdout.write(`  ${index + 1}. ${choice.disabled ? dim(choice.title) : choice.title}${choice.disabled ? ` ${dim('(unavailable)')}` : ''}\n`);
+            if (choice.description) process.stdout.write(`     ${dim(choice.description)}\n`);
+        });
+        for (;;) {
+            const reader = createInterface({ input: process.stdin, output: process.stdout });
+            const answer = await new Promise((resolve) => {
+                reader.once('SIGINT', () => setupSession ? process.exit(130) : resolve(undefined));
+                reader.question(`  Choose 1-${choices.length}${initial >= 0 ? ` (${initial + 1})` : ''}, or b to ${setupSession ? 'cancel setup' : 'go back'}: `, resolve);
+            });
+            reader.close();
+            if (answer === undefined) return undefined;
+            const value = String(answer).trim().toLowerCase();
+            if (value === 'b' || value === 'back') return BACK;
+            const index = value === '' ? initial : Number(value) - 1;
+            if (Number.isInteger(index) && choices[index] !== undefined && !choices[index].disabled) return choices[index].value;
+            process.stdout.write('  Enter the number of an available option.\n');
+        }
+    }
     emitKeypressEvents(process.stdin);
     const wasRaw = process.stdin.isRaw;
     process.stdin.setRawMode?.(true);
@@ -58,8 +212,9 @@ export async function select(message, choices, initial = 0) {
         const width = process.stdout.columns || 80;
         const wrapped = (length) => Math.max(1, Math.ceil(length / width));
         return wrapped(2 + message.length)
-            + choices.reduce((total, choice, index) => total + wrapped(4 + choice.title.length + (index === selected ? 2 : 0)
-                + (choice.description ? choice.description.length + 1 : 0)), 0)
+            + choices.reduce((total, choice, index) => total
+                + wrapped(4 + choice.title.length + (choice.disabled ? 14 : 0) + (index === selected ? 2 : 0))
+                + (choice.description ? wrapped(6 + choice.description.length) : 0), 0)
             + 1;
     };
     const draw = (first = false) => {
@@ -68,10 +223,11 @@ export async function select(message, choices, initial = 0) {
         choices.forEach((choice, index) => {
             const active = index === selected;
             const marker = choice.disabled ? dim('○') : active ? green('●') : dim('○');
-            const label = choice.disabled ? dim(choice.title) : active ? inverse(` ${choice.title} `) : choice.title;
-            process.stdout.write(`  ${marker} ${label}${choice.description ? ` ${dim(choice.description)}` : ''}\x1b[K\n`);
+            const label = choice.disabled ? dim(`${choice.title} · unavailable`) : active ? inverse(` ${choice.title} `) : choice.title;
+            process.stdout.write(`  ${marker} ${label}\x1b[K\n`);
+            if (choice.description) process.stdout.write(`      ${dim(choice.description)}\x1b[K\n`);
         });
-        process.stdout.write(`  ${dim('esc back · ctrl-c quit')}\x1b[K\n`);
+        process.stdout.write(`  ${dim(setupSession ? 'esc cancel setup · ctrl-c quit' : 'esc back · ctrl-c quit')}\x1b[K\n`);
         lastRows = frameRows();
     };
     let lastRows = 0;
@@ -86,7 +242,8 @@ export async function select(message, choices, initial = 0) {
             if (key.ctrl && key.name === 'c') {
                 cleanup();
                 process.stdout.write('\n');
-                resolve(undefined);
+                if (setupSession) process.exit(130);
+                else resolve(undefined);
                 return;
             }
             if (key.name === 'escape' || key.name === 'left') {
@@ -115,6 +272,7 @@ export async function select(message, choices, initial = 0) {
 export async function prompt(message, initial = '') {
     if (!interactive()) return initial;
     const suffix = initial ? ` ${dim(`(${initial})`)}` : '';
+    if (fullscreen) process.stdout.write('\x1b[?25h');
     const reader = createInterface({ input: process.stdin, output: process.stdout });
     const answer = await new Promise((resolve) => {
         let settled = false;
@@ -123,15 +281,16 @@ export async function prompt(message, initial = '') {
             settled = true;
             resolve(value);
         };
-        reader.once('SIGINT', () => finish(undefined));
+        reader.once('SIGINT', () => setupSession ? process.exit(130) : finish(undefined));
         reader.question(`${bold(`◆ ${message}`)}${suffix}\n  › `, finish);
     });
     reader.close();
+    if (fullscreen) process.stdout.write('\x1b[?25l');
     return typeof answer === 'string' ? answer.trim() || initial : undefined;
 }
 
 export async function withSpinner(label, task) {
-    if (!interactive()) {
+    if (!richInteractive()) {
         process.stdout.write(`  … ${label}\n`);
         return task();
     }

--- a/scripts/setup-wizard.mjs
+++ b/scripts/setup-wizard.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import { networkInterfaces, userInfo } from 'node:os';
-import { intro, heading, status, note, outro, prompt, select, withSpinner, BACK } from './setup-ui.mjs';
+import { intro, heading, status, note, outro, prompt, select, withSpinner, withFullscreen, setupStep, completeFullscreen, BACK } from './setup-ui.mjs';
 import { runDoctor, runLocalPrerequisites, runMachines, runPair, runRemoteConnect, runSelfHost, runTailscale, selfhostPublicSummary, sharedMachineCount, tailscaleBin } from './local-setup.mjs';
 
 function command(name, args = []) {
@@ -34,11 +34,11 @@ function lanAddress() {
     return undefined;
 }
 
-function integrationSummary(output) {
-    const lines = output.split('\n').map((line) => line.trim()).filter(Boolean);
+function integrationSummary(result) {
+    const lines = result.output.split('\n').map((line) => line.trim()).filter(Boolean);
     const current = lines.filter((line) => /:\s+current\b/.test(line)).map((line) => line.split(':', 1)[0]);
     const available = lines.filter((line) => !/:\s+not installed\b/.test(line)).map((line) => line.split(':', 1)[0]);
-    return { current, available };
+    return { current, available, checked: result.ok, error: result.ok ? undefined : lines[0] || 'herdr integration status failed' };
 }
 
 const TAILSCALE_INSTALL_URL = 'https://tailscale.com/download';
@@ -90,7 +90,7 @@ export function inspectSetup() {
     const herdrVersion = command(herdr(), ['--version']);
     const herdrStatus = herdrVersion.ok ? command(herdr(), ['status']) : { ok: false, output: '' };
     const integration = herdrVersion.ok ? command(herdr(), ['integration', 'status']) : { ok: false, output: '' };
-    const agents = integrationSummary(integration.output);
+    const agents = integrationSummary(integration);
     return {
         herdr: { installed: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrStatus.ok },
         agents,
@@ -104,7 +104,9 @@ function renderInspection(found) {
     heading('Checking this machine');
     status('Herdr', found.herdr.installed ? found.herdr.version : 'not installed — will be installed during setup', found.herdr.installed ? 'ok' : 'warn');
     status('Herdr server', found.herdr.running ? 'running' : 'will be started', found.herdr.running ? 'ok' : 'warn');
-    status('Agent integrations', `${found.agents.current.length} ready${found.agents.current.length ? ` — ${found.agents.current.slice(0, 5).join(', ')}${found.agents.current.length > 5 ? '…' : ''}` : ''}`, found.agents.current.length ? 'ok' : 'warn');
+    status('Agent integrations', found.agents.checked
+        ? `${found.agents.current.length} ready${found.agents.current.length ? ` — ${found.agents.current.slice(0, 5).join(', ')}${found.agents.current.length > 5 ? '…' : ''}` : ''}`
+        : `availability check failed — ${found.agents.error}; run \`muxr doctor\``, found.agents.checked && found.agents.current.length ? 'ok' : 'warn');
     status('Tailscale', found.tailscale.connected ? `connected — ${found.tailscale.ip}` : found.tailscale.detail, found.tailscale.connected ? 'ok' : 'off');
     status('Cloudflare Tunnel', found.cloudflared.ok ? 'available' : found.cloudflared.detail, found.cloudflared.ok ? 'ok' : 'off');
     process.stdout.write('\n');
@@ -153,6 +155,7 @@ async function choosePlugins() {
             status(plugin.title, 'already installed', 'ok');
             continue;
         }
+        setupStep(3, 5, 'Optional Herdr add-ons');
         const choice = await select(`Add ${plugin.title.toLowerCase()}?`, [
             { value: 'skip', title: 'No', description: 'leave Herdr unchanged' },
             { value: 'install', title: 'Yes', description: `${plugin.description} · ${plugin.repo}` },
@@ -225,24 +228,28 @@ function connectionLabel(mode, endpoint, port) {
 const aborted = (value) => value === undefined || value === BACK;
 
 // Any abort before Apply must say so; a silent exit reads as "something ran".
-function cancelled() {
-    outro('Cancelled. Nothing changed.');
+function cancelled(prerequisiteChanged = false) {
+    outro(prerequisiteChanged
+        ? 'Setup cancelled. The Tailscale connection you approved may remain active.'
+        : 'Cancelled. Nothing changed.');
+    completeFullscreen();
     return 0;
 }
 
 // The remedy for a disconnected Tailscale is runnable, so offer it
 // behind an explicit choice instead of only printing it.
 async function offerTailscaleConnect(found) {
-    if (found.tailscale.connected || !found.tailscale.installed) return;
+    if (found.tailscale.connected || !found.tailscale.installed) return false;
     const attempt = await select(`Tailscale is installed but not connected (${found.tailscale.detail}). Connect it now?`, [
         { value: false, title: 'Not now', description: 'continue without Tailscale' },
         { value: true, title: process.platform === 'darwin' ? 'Connect Tailscale' : 'Run sudo tailscale up', description: process.platform === 'darwin' ? 'ask the installed Mac app to bring this node up' : 'bring the node up and grant this user operator access' },
     ]);
-    if (attempt !== true) return;
+    if (aborted(attempt)) return BACK;
+    if (attempt !== true) return false;
     let up;
     if (process.platform === 'darwin') {
         up = spawnSync('open', ['-a', 'Tailscale'], { stdio: 'inherit' });
-        if (up.status === 0 && await prompt('Approve the Tailscale system extension and sign in, then press Enter') === undefined) return;
+        if (up.status === 0 && await prompt('Approve the Tailscale system extension and sign in, then press Enter') === undefined) return true;
     } else {
         // USER can be unset (sudo, cron, containers); an empty --operator makes
         // the offered remedy fail with a usage error.
@@ -255,6 +262,7 @@ async function offerTailscaleConnect(found) {
     found.tailscale = probeTailscale();
     if (found.tailscale.connected) status('Tailscale', `connected — ${found.tailscale.ip}`, 'ok');
     else status('Tailscale', `${found.tailscale.detail ?? 'still not connected'}${up.status ? ` (connect command exited ${up.status})` : ''}`, 'warn');
+    return up.error === undefined;
 }
 
 export async function runSetup(args = []) {
@@ -281,12 +289,17 @@ export async function runSetup(args = []) {
         return runSelfHost(args);
     }
 
-    intro();
+    return withFullscreen(async () => {
+    setupStep(1, 5, 'Check this machine');
     const found = await withSpinner('Inspecting Herdr, agents, and networking', async () => inspectSetup());
     renderInspection(found);
-    await offerTailscaleConnect(found);
+    const tailscaleResult = await offerTailscaleConnect(found);
+    if (aborted(tailscaleResult)) return cancelled();
+    const prerequisiteChanged = tailscaleResult === true;
+    const cancelSetup = () => cancelled(prerequisiteChanged);
     const current = await selfhostPublicSummary();
 
+    setupStep(2, 5, 'Choose how your phone connects');
     let mode = requestedMode;
     if (mode === 'selfhost') mode = undefined;
     if (!mode) {
@@ -297,7 +310,7 @@ export async function runSetup(args = []) {
         const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
         mode = await select('How should your phone connect?', connectionChoices, initial);
     }
-    if (aborted(mode)) return cancelled();
+    if (aborted(mode)) return cancelSetup();
     if (!['tailscale', 'tailscale-direct', 'lan', 'external', 'cloudflare'].includes(mode)) {
         process.stderr.write(`unknown setup mode: ${mode}\n`);
         return 1;
@@ -317,8 +330,9 @@ export async function runSetup(args = []) {
 
     let port = current === undefined && value(args, '--port') === undefined ? 8792 : undefined;
     while (port === undefined) {
+        setupStep(2, 5, 'Choose connection port');
         const portText = await prompt('Local connection port', value(args, '--port') ?? String(current.relayPort));
-        if (portText === undefined) return cancelled();
+        if (portText === undefined) return cancelSetup();
         const parsed = Number(portText);
         if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
         else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
@@ -326,8 +340,9 @@ export async function runSetup(args = []) {
     let endpoint;
     if (mode === 'external') {
         while (endpoint === undefined) {
+            setupStep(2, 5, 'Enter your server address');
             const entered = await prompt('External relay URL (wss://...)', current?.connectionMode === 'external' ? current.relayUrl : '');
-            if (entered === undefined) return cancelled();
+            if (entered === undefined) return cancelSetup();
             try {
                 const parsed = new URL(entered);
                 if (parsed.protocol === 'wss:' && parsed.hostname && !parsed.username && !parsed.password && parsed.pathname === '/' && !parsed.search && !parsed.hash) endpoint = parsed.toString().replace(/\/$/, '');
@@ -339,13 +354,14 @@ export async function runSetup(args = []) {
     }
 
     const secureWebMode = ['tailscale', 'external', 'cloudflare'].includes(mode);
+    setupStep(2, 5, 'Choose app access');
     const web = secureWebMode
         ? await select('Host the browser client too?', [
             { value: false, title: 'Native app only', description: 'do not expose the browser client' },
             { value: true, title: 'Host the browser client', description: 'serve it over the selected HTTPS/WSS connection' },
         ], current?.webEnabled ? 1 : 0)
         : false;
-    if (aborted(web)) return cancelled();
+    if (aborted(web)) return cancelSetup();
     if (!secureWebMode) status('Browser client', 'requires Tailscale Serve, External WSS, or Cloudflare; native app only', 'off');
     const desiredUrl = mode === 'lan' ? `ws://${found.lan}:${port}`
         : mode === 'external' ? endpoint
@@ -374,22 +390,25 @@ export async function runSetup(args = []) {
             { value: 'both', title: 'Phone, then control browser', description: 'complete both pairing steps' },
         ] : []),
     ];
+    setupStep(2, 5, 'Choose what to pair');
     const pairing = pairingChoices.length === 1 ? pairingChoices[0].value : await select(connectionChanged && current !== undefined
         ? 'The connection changed. Keep existing devices or pair another one?'
         : 'Pair a client?', pairingChoices);
-    if (aborted(pairing)) return cancelled();
+    if (aborted(pairing)) return cancelSetup();
 
-    const syncIntegrations = await select(`Connect your coding agents (${found.agents.available.length} detected)?`, [
+    setupStep(3, 5, 'Connect agents and add-ons');
+    const syncIntegrations = await select(found.agents.checked
+        ? `Connect your coding agents (${found.agents.available.length} detected)?`
+        : 'Agent availability could not be checked. Retry integration setup anyway?', [
         { value: true, title: 'Connect coding agents', description: 'keeps their status current' },
         { value: false, title: 'Leave integrations unchanged', description: 'do not install or alter coding-agent hooks' },
     ]);
-    if (aborted(syncIntegrations)) return cancelled();
+    if (aborted(syncIntegrations)) return cancelSetup();
 
-    if (current !== undefined) heading('Optional Herdr add-ons');
     const plugins = current === undefined ? [] : await choosePlugins();
-    if (plugins === undefined) return cancelled();
+    if (plugins === undefined) return cancelSetup();
 
-    heading('Review setup');
+    setupStep(4, 5, 'Review setup');
     note([
         `Connection: ${connectionLabel(mode, endpoint, port)}`,
         `Herdr: ${found.herdr.installed ? 'adopt existing installation and ensure its server is running' : 'download, install, and start during setup'}`,
@@ -407,11 +426,9 @@ export async function runSetup(args = []) {
         { value: false, title: 'Cancel', description: 'leave this machine unchanged' },
         { value: true, title: 'Apply setup', description: 'make the reviewed changes, verify health, then show the pairing QR' },
     ], 1);
-    if (apply !== true) {
-        outro('Cancelled. Nothing changed.');
-        return 0;
-    }
+    if (apply !== true) return cancelSetup();
 
+    setupStep(5, 5, 'Install, start, and pair');
     const prerequisiteArgs = [
         ...args.filter((arg) => arg !== '--from-plugin'),
         ...(found.herdr.installed ? [] : ['--install-herdr']),
@@ -435,7 +452,7 @@ export async function runSetup(args = []) {
     const doctor = await runDoctor();
     if (doctor !== 0) return doctor;
     const summary = await selfhostPublicSummary();
-    heading('Setup complete');
+    setupStep(5, 5, 'Setup complete');
     note([
         `Your host runs here. Phones reach it over ${relayKind(mode)}.${pairing === 'none' ? ' Pair with `muxr pair` when ready.' : ''}`,
         `Connection: ${connectionLabel(mode, endpoint, port)}`,
@@ -448,13 +465,21 @@ export async function runSetup(args = []) {
         `Integrations: ${syncIntegrations ? 'selected providers synced' : 'unchanged'}`,
         `Pairing: ${pairing === 'none' ? 'existing devices kept' : browserPairFailed ? 'phone paired; browser pairing failed' : pairing === 'both' ? 'phone and control browser paired' : `${pairing} paired`}${!browserPairFailed && (pairing === 'browser' || pairing === 'browser-view' || pairing === 'both') ? ' · browser expires in eight hours' : ''}`,
         `Plugins: bundled${pluginResult.installed.length ? ` + ${pluginResult.installed.map((plugin) => plugin.title).join(', ')}` : ''}`,
-        ...(pluginResult.failed.length ? [`Plugin install failed: ${pluginResult.failed.map((plugin) => plugin.title).join(', ')}`] : []),
+        ...(pluginResult.failed.length ? [
+            `Add-ons needing attention: ${pluginResult.failed.map((plugin) => plugin.title).join(', ')}`,
+            'Retry add-ons by rerunning `muxr setup`; core pairing remains active.',
+        ] : []),
         'Configuration: ~/.muxr (owner-only)',
     ]);
-    outro(pairing === 'none'
-        ? 'Setup updated. Existing devices will reconnect automatically.'
-        : 'Paired. Open muxr on your phone, or run `muxr` anytime to change these choices.');
-    return browserPairFailed ? 1 : 0;
+    const partial = browserPairFailed || pluginResult.failed.length > 0;
+    outro(partial
+        ? 'Core setup is ready, but one or more optional steps need attention.'
+        : pairing === 'none'
+            ? 'Setup updated. Existing devices will reconnect automatically.'
+            : 'Paired. Open muxr on your phone, or run `muxr` anytime to change these choices.', partial ? 'warn' : 'ok');
+    completeFullscreen();
+    return partial ? 1 : 0;
+    });
 }
 
 export async function runSharedRelaySetup() {
@@ -465,7 +490,9 @@ export async function runSharedRelaySetup() {
     intro();
     const found = await withSpinner('Inspecting secure networking on this server', async () => inspectSetup());
     renderInspection(found);
-    await offerTailscaleConnect(found);
+    const tailscaleResult = await offerTailscaleConnect(found);
+    if (aborted(tailscaleResult)) return cancelled();
+    const cancelRelaySetup = () => cancelled(tailscaleResult === true);
     const current = await selfhostPublicSummary();
     if (current !== undefined && current.relayRole !== 'shared') {
         process.stderr.write('This machine already runs an agent host. Use a dedicated VPS for a shared relay, or remove the existing setup first.\n');
@@ -479,11 +506,11 @@ export async function runSharedRelaySetup() {
     status('relay', 'agent hosts dial out to it — the only choice is how they reach it', 'ok');
     process.stdout.write('\n');
     let mode = await select('How should machines reach this shared relay?', options, initial);
-    if (aborted(mode)) return cancelled();
+    if (aborted(mode)) return cancelRelaySetup();
     let port;
     while (port === undefined) {
         const entered = await prompt('Relay port', String(current?.relayPort ?? 8792));
-        if (entered === undefined) return cancelled();
+        if (entered === undefined) return cancelRelaySetup();
         const parsed = Number(entered);
         if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
         else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
@@ -492,7 +519,7 @@ export async function runSharedRelaySetup() {
     if (mode === 'external') {
         while (endpoint === undefined) {
             const entered = await prompt('Public relay URL (wss://...)', current?.connectionMode === 'external' ? current.relayUrl : '');
-            if (entered === undefined) return cancelled();
+            if (entered === undefined) return cancelRelaySetup();
             try {
                 const parsed = new URL(entered);
                 if (parsed.protocol === 'wss:' && parsed.hostname && !parsed.username && !parsed.password
@@ -511,7 +538,7 @@ export async function runSharedRelaySetup() {
         { value: false, title: 'Relay only', description: 'route encrypted native-app traffic only' },
         { value: true, title: 'Relay + browser', description: 'serve control or view-only browser clients over the same HTTPS origin' },
     ], current?.webEnabled ? 1 : 0);
-    if (aborted(web)) return cancelled();
+    if (aborted(web)) return cancelRelaySetup();
     heading('Review shared relay');
     note([
         `Public connection: ${connectionLabel(mode, endpoint, port)}`,
@@ -526,7 +553,7 @@ export async function runSharedRelaySetup() {
         { value: false, title: 'Cancel', description: 'leave this server unchanged' },
         { value: true, title: 'Apply shared relay', description: 'configure ingress, relay, web, and its service' },
     ], 1);
-    if (apply !== true) return cancelled();
+    if (apply !== true) return cancelRelaySetup();
     const relayArgs = ['--relay-only', '--managed-relay', '--reconfigure', '--port', String(port), '--connection-mode', mode];
     if (mode === 'external') relayArgs.push('--advertise', endpoint);
     if (web) relayArgs.push('--web', '--yes');


### PR DESCRIPTION
## Summary

- persist a widened executable PATH and absolute Herdr binary in launchd and systemd services
- reload macOS service definitions on start and enable login startup
- fail terminal attach with a named Herdr spawn error instead of reconnecting forever
- make empty agent probes non-authoritative so they cannot erase saved choices
- verify lifecycle integration installation and make setup output truthful
- teach doctor to validate pinned Herdr paths and all detected lifecycle integrations

## Root cause

The daemon could connect to Herdr's Unix socket while launchd/systemd could not spawn the `herdr` CLI or resolve installed agents. This produced a green machine connection, Shell-only agent inventory, and terminal reconnect loops from one restricted service environment.

## Validation

- adversarial Oracle gate: `SHIP-CODE-FOR-MANUAL-QA`
- exact reviewed diff: `b7816bd56529172f`
- Vitest: 42 files / 170 tests passed
- package smoke passed
- package lifecycle smoke passed

## Manual release gate

Do not merge/release until clean macOS and Linux onboarding pass real QR pairing, terminal attach, agent launch, reboot reconnect, and SSH/non-login setup.
