### PR TITLE
Recover Herdr during service restart

### DIFF
--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -23,6 +23,7 @@ const installDir = join(scratch, 'install');
 const home = join(scratch, 'home');
 const binDir = join(scratch, 'bin');
 const fakeState = join(scratch, 'herdr-installed');
+const fakeServerState = join(scratch, 'herdr-server-running');
 const fakeLog = join(scratch, 'herdr.log');
 mkdirSync(tarDir, { recursive: true });
 mkdirSync(installDir, { recursive: true });
@@ -32,11 +33,19 @@ mkdirSync(join(home, '.config', 'herdr'), { recursive: true });
 const instructionPath = join(home, '.pi', 'agent', 'AGENTS.md');
 writeFileSync(instructionPath, '# Existing user instructions\n\nKeep this line.\n');
 writeFileSync(join(home, '.config', 'herdr', 'config.toml'), '# user herdr config\nchannel = "stable"\n');
+writeFileSync(fakeServerState, 'running\n');
 
 const fakeHerdr = `#!/bin/sh
 case "$*" in
   "--version") echo "herdr 0.8.0" ;;
-  "status") echo "server: running" ;;
+  "status server --json")
+    if [ "$FAKE_HERDR_HANG" = 1 ]; then exec /bin/sleep 5; fi
+    if [ -f "$FAKE_HERDR_SERVER_STATE" ]; then echo '{"running":true}';
+    else echo '{"running":false}'; fi ;;
+  "status")
+    if [ -f "$FAKE_HERDR_SERVER_STATE" ]; then printf 'server:\n  status: running\n';
+    else printf 'server:\n  status: not running\n'; fi ;;
+  "server") printf '%s\n' server-start >> "$FAKE_HERDR_LOG"; : > "$FAKE_HERDR_SERVER_STATE" ;;
   "plugin list --json")
     if [ -n "$FAKE_PLUGIN_LIST" ]; then printf '%s\n' "$FAKE_PLUGIN_LIST";
     else echo '{"result":{"plugins":[]}}'; fi ;;
@@ -96,6 +105,7 @@ function cliEnv(targetHome = home, extra = {}) {
         MUXR_PS_BIN: '/usr/bin/ps',
         HERDR_BIN: join(binDir, 'herdr'),
         FAKE_HERDR_STATE: fakeState,
+        FAKE_HERDR_SERVER_STATE: fakeServerState,
         FAKE_HERDR_LOG: fakeLog,
         MUXR_NO_SERVICE_COMMANDS: '1',
         MUXR_SKIP_HOSTED_AUTH: '1',
@@ -500,7 +510,20 @@ try {
     assert.match(movedSetupLinks, new RegExp(`plugin link ${join(pluginRoot, 'voice-openai').replaceAll('\\', '\\\\')} --enabled`));
     assert.equal(readFileSync(join(home, '.muxr', 'setup-manifest.json'), 'utf8'), manifestAfterFirst);
     run(cli, ['daemon', 'install', '--mode', 'selfhost'], { cwd: installDir, env });
-    run(cli, ['daemon', 'restart'], { cwd: installDir, env });
+    rmSync(fakeServerState, { force: true });
+    const deadDoctor = run(cli, ['doctor'], { cwd: installDir, env, allowFailure: true });
+    assert.notEqual(deadDoctor.status, 0, 'doctor accepted a stopped Herdr server');
+    assert.match(`${deadDoctor.stdout}${deadDoctor.stderr}`, /FAIL\s+herdr server\s+not running/);
+    const hungProbeStarted = Date.now();
+    const hungDoctor = run(cli, ['doctor'], { cwd: installDir, env: { ...env, FAKE_HERDR_HANG: '1' }, allowFailure: true });
+    assert.notEqual(hungDoctor.status, 0, 'doctor accepted an unresponsive Herdr server');
+    assert.ok(Date.now() - hungProbeStarted < 3_000, 'unresponsive Herdr blocked doctor');
+    const wizardUrl = `file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'setup-wizard.mjs')}`;
+    const deadInspection = run(process.execPath, ['--input-type=module', '-e', `import {inspectSetup} from ${JSON.stringify(wizardUrl)}; console.log(JSON.stringify(inspectSetup().herdr))`], { cwd: installDir, env });
+    assert.equal(JSON.parse(deadInspection.stdout).running, false, 'onboarding accepted a stopped Herdr server');
+    const restarted = run(cli, ['daemon', 'restart'], { cwd: installDir, env });
+    assert.ok(existsSync(fakeServerState), 'daemon restart did not recover a stopped Herdr server');
+    assert.match(restarted.stdout, /herdr server ready[\s\S]*muxr services restarted/);
     const updateNpm = join(scratch, 'update-npm');
     const updateLog = join(scratch, 'update.log');
     writeFileSync(updateNpm, '#!/bin/sh\nif [ "$1" = view ]; then printf \'"%s"\\n\' "${MUXR_UPDATE_LATEST:-9.9.9}"; exit 0; fi\nif [ "$1 $2" = "root --global" ]; then printf "%s\\n" "$MUXR_UPDATE_NPM_ROOT"; exit 0; fi\nif [ "$1" = install ]; then printf "%s\\n" "$*" >> "$MUXR_UPDATE_LOG"; exit 0; fi\nexit 1\n', { mode: 0o755 });
@@ -700,14 +723,14 @@ try {
 
     const staleHerdr = join(macHome, 'Library', 'LaunchAgents', 'herdr-server.plist');
     const repairHerdr = join(binDir, 'herdr-repair');
-    writeFileSync(staleHerdr, '<plist><dict><key>ProgramArguments</key><array><string>/missing/herdr</string><string>server</string></array></dict></plist>\n');
-    writeFileSync(repairHerdr, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    writeFileSync(staleHerdr, '<plist><dict><key>Label</key><string>dev.herdr.server</string><key>ProgramArguments</key><array><string>/missing/herdr</string><string>server</string></array></dict></plist>\n');
+    writeFileSync(repairHerdr, '#!/bin/sh\n[ "$*" = "status server --json" ] && echo \'{"running":true}\'\nexit 0\n', { mode: 0o755 });
     const localSetupUrl = `file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'local-setup.mjs')}`;
     run(process.execPath, ['--input-type=module', '-e', `import {ensureHerdrServer} from ${JSON.stringify(localSetupUrl)}; await ensureHerdrServer(${JSON.stringify(repairHerdr)})`], {
         cwd: installDir, env: macEnv, allowFailure: true,
     });
     assert.match(readFileSync(staleHerdr, 'utf8'), new RegExp(repairHerdr.replaceAll('/', '\\/')), 'stale Herdr plist was not repaired');
-    assert.match(readFileSync(launchctlLog, 'utf8'), /bootout gui\/\d+\/herdr-server[\s\S]*bootstrap gui\/\d+ .*herdr-server\.plist[\s\S]*kickstart -k gui\/\d+\/herdr-server/, 'loaded repaired Herdr plist was not reloaded');
+    assert.match(readFileSync(launchctlLog, 'utf8'), /bootout gui\/\d+\/dev\.herdr\.server[\s\S]*bootstrap gui\/\d+ .*herdr-server\.plist[\s\S]*kickstart -k gui\/\d+\/dev\.herdr\.server/, 'loaded repaired Herdr plist was not reloaded by its declared label');
     run(cli, ['daemon', 'status'], { cwd: installDir, env: macEnv });
     run(cli, ['daemon', 'uninstall'], { cwd: installDir, env: macEnv });
 

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -180,6 +180,7 @@ function run(command, args, options = {}) {
         status: result.status ?? 1,
         stdout: result.stdout?.trim() ?? '',
         stderr: result.stderr?.trim() ?? '',
+        errorCode: result.error?.code,
     };
 }
 
@@ -519,12 +520,17 @@ function repairHerdrServiceUnits(binary, dryRun) {
     return repaired;
 }
 
+function launchdLabel(unitPath) {
+    return readFileSync(unitPath, 'utf8').match(/<key>Label<\/key>\s*<string>([^<]+)<\/string>/)?.[1]
+        ?? basename(unitPath, '.plist');
+}
+
 /** Start herdr through its own service manager so it stays managed. */
 function startHerdrServiceUnits(unitPaths) {
     for (const unitPath of unitPaths) {
         if (platform() === 'darwin') {
             const domain = `gui/${process.getuid()}`;
-            const service = `${domain}/${basename(unitPath, '.plist')}`;
+            const service = `${domain}/${launchdLabel(unitPath)}`;
             const loaded = run('launchctl', ['print', service]);
             if (loaded.ok) {
                 const unloaded = run('launchctl', ['bootout', service]);
@@ -535,28 +541,43 @@ function startHerdrServiceUnits(unitPaths) {
             const started = run('launchctl', ['kickstart', '-k', service]);
             if (!started.ok) throw new Error(started.stderr || started.stdout || `could not start ${service}`);
         } else {
-            run('systemctl', ['--user', 'start', basename(unitPath)]);
+            const started = run('systemctl', ['--user', 'start', basename(unitPath)]);
+            if (!started.ok) throw new Error(started.stderr || started.stdout || `could not start ${basename(unitPath)}`);
         }
     }
+}
+
+export function herdrServerIsReady(binary) {
+    const scoped = run(binary, ['status', 'server', '--json'], { timeout: 500 });
+    if (scoped.ok) {
+        try {
+            const running = JSON.parse(scoped.stdout).running;
+            if (typeof running === 'boolean') return running;
+        } catch {}
+    }
+    if (scoped.errorCode === 'ETIMEDOUT') return false;
+    const legacy = run(binary, ['status'], { timeout: 500 });
+    return legacy.ok && /\bserver:\s*(?:\n\s*status:\s*)?running\b/i.test(legacy.stdout);
 }
 
 /**
  * Make sure the herdr server is running: repair a stale service path first,
  * then start it. Idempotent — host-up calls this on every service start.
  */
-export async function ensureHerdrServer(binary = herdrBin(), dryRun = false) {
+export async function ensureHerdrServer(binary = herdrBin(), dryRun = false, quiet = false) {
     if (!binary) throw new Error(`herdr is missing; ${HERDR_INSTALL_HINT}`);
     const repaired = repairHerdrServiceUnits(binary, dryRun);
     if (!dryRun && repaired.length > 0 && env('MUXR_NO_SERVICE_COMMANDS') !== '1' && platform() === 'darwin') {
         startHerdrServiceUnits(repaired);
     }
-    let status = run(binary, ['status']);
-    if (!status.ok) {
+    let ready = herdrServerIsReady(binary);
+    if (!ready) {
         if (dryRun) {
             print('  would start the herdr server');
         } else {
             const units = env('MUXR_NO_SERVICE_COMMANDS') === '1' ? [] : herdrServiceUnitPaths();
             let logPath;
+            let spawnError;
             if (units.length > 0) {
                 // Start the managed unit, not a stray process: a direct spawn
                 // lands in muxr.service's cgroup (`muxr daemon stop` kills
@@ -567,20 +588,22 @@ export async function ensureHerdrServer(binary = herdrBin(), dryRun = false) {
                 ensurePrivateDir(dirname(logPath));
                 const out = openSync(logPath, 'a', 0o600);
                 const server = spawn(binary, ['server'], { detached: true, stdio: ['ignore', out, out] });
+                server.once('error', (cause) => { spawnError = cause; });
                 server.unref();
             }
-            for (let attempt = 0; attempt < 30 && !status.ok; attempt += 1) {
-                await new Promise((resolve) => setTimeout(resolve, 300));
-                status = run(binary, ['status']);
+            for (let attempt = 0; attempt < 12 && !ready && spawnError === undefined; attempt += 1) {
+                await new Promise((resolve) => setTimeout(resolve, 250));
+                ready = herdrServerIsReady(binary);
             }
-            if (!status.ok) {
+            if (!ready) {
+                if (spawnError !== undefined) throw spawnError;
                 throw new Error(units.length > 0
-                    ? `herdr server did not start; check \`journalctl --user -u ${units.map((unit) => basename(unit)).join(' ')}\``
+                    ? `herdr server did not start; check its service logs and \`muxr doctor\``
                     : `herdr server did not start; see ${logPath}`);
             }
         }
     }
-    print(`  ✓ herdr server ${dryRun && !status.ok ? 'would be started' : 'ready'}`);
+    if (!quiet) print(`  ✓ herdr server ${dryRun && !ready ? 'would be started' : 'ready'}`);
     return binary;
 }
 
@@ -1269,11 +1292,20 @@ export async function runDaemon(args = []) {
             return result.ok ? 0 : 1;
         }
         if (!['start', 'stop', 'restart', 'status'].includes(action)) throw new Error('usage: muxr daemon install|uninstall|start|stop|restart|status|logs');
+        let herdrFailure;
+        if ((action === 'start' || action === 'restart') && daemonMode() !== 'relay') {
+            try { await ensureHerdrServer(undefined, false, args.includes('--quiet')); }
+            catch (cause) { herdrFailure = cause; }
+        }
         const result = serviceCommand(action);
         if (!result.ok) {
             if (action === 'status') print('muxr service is stopped or unavailable.');
             else error(result.stderr || result.stdout || `muxr service ${action} failed`);
             return 1;
+        }
+        if (herdrFailure !== undefined) {
+            error(`  warn: muxr service ${action === 'restart' ? 'restarted' : 'started'}, but Herdr did not recover: ${herdrFailure instanceof Error ? herdrFailure.message : String(herdrFailure)}`);
+            return 0;
         }
         if (!args.includes('--quiet')) {
             if (action === 'start') print('  ✓ muxr service started and enabled for login');
@@ -2443,8 +2475,7 @@ export async function runSetup(args = []) {
             installRequested: args.includes('--install-herdr'),
         });
         if (binary) {
-            const status = run(binary, ['status']);
-            print(`  ${status.ok ? '✓' : 'warn:'} herdr status${status.stdout ? ` — ${status.stdout.split('\n')[0]}` : ''}`);
+            await ensureHerdrServer(binary, dryRun);
             await ensureBundledPlugins(binary, dryRun);
             const integrationArgs = ['sync', ...(dryRun ? ['--dry-run'] : []), ...(args.includes('--force') ? ['--force'] : [])];
             if (args.includes('--all')) integrationArgs.push('--all');
@@ -2699,11 +2730,11 @@ export async function runDoctor() {
         add(versionOk ? 'ok' : 'fail', 'herdr', versionOk
             ? versionResult.stdout
             : `${versionResult.stdout || versionResult.stderr || 'unreadable version'} — needs >= ${MIN_HERDR.join('.')}; run \`herdr update\` after reviewing the upgrade`);
-        const status = run(binary, ['status']);
-        add(status.ok ? 'ok' : 'fail', 'herdr server', status.ok
-            ? status.stdout.split('\n')[0] || 'running'
-            : `${status.stdout.split('\n')[0] || status.stderr || 'not running'} — start it with \`herdr server\``,
-            status.ok ? undefined : { label: 'start the herdr server', run: async () => { await ensureHerdrServer(binary); } });
+        const serverReady = herdrServerIsReady(binary);
+        add(serverReady ? 'ok' : 'fail', 'herdr server', serverReady
+            ? 'running'
+            : 'not running — start it with `herdr server`',
+            serverReady ? undefined : { label: 'start the herdr server', run: async () => { await ensureHerdrServer(binary); } });
         const integrations = run(binary, ['integration', 'status']);
         if (integrations.ok) {
             const statuses = parseIntegrationStatus(integrations.stdout);

--- a/scripts/setup-wizard.mjs
+++ b/scripts/setup-wizard.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { networkInterfaces, userInfo } from 'node:os';
 import { intro, heading, status, note, outro, prompt, select, withSpinner, withFullscreen, setupStep, completeFullscreen, BACK } from './setup-ui.mjs';
-import { runDoctor, runLocalPrerequisites, runMachines, runPair, runRemoteConnect, runSelfHost, runTailscale, selfhostPublicSummary, sharedMachineCount, tailscaleBin } from './local-setup.mjs';
+import { herdrServerIsReady, runDoctor, runLocalPrerequisites, runMachines, runPair, runRemoteConnect, runSelfHost, runTailscale, selfhostPublicSummary, sharedMachineCount, tailscaleBin } from './local-setup.mjs';
 
 function command(name, args = []) {
     const result = spawnSync(name, args, { encoding: 'utf8', timeout: 120_000 });
@@ -87,12 +87,12 @@ function probeCloudflared() {
 }
 
 export function inspectSetup() {
-    const herdrVersion = command(herdr(), ['--version']);
-    const herdrStatus = herdrVersion.ok ? command(herdr(), ['status']) : { ok: false, output: '' };
-    const integration = herdrVersion.ok ? command(herdr(), ['integration', 'status']) : { ok: false, output: '' };
+    const binary = herdr();
+    const herdrVersion = command(binary, ['--version']);
+    const integration = herdrVersion.ok ? command(binary, ['integration', 'status']) : { ok: false, output: '' };
     const agents = integrationSummary(integration);
     return {
-        herdr: { installed: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrStatus.ok },
+        herdr: { installed: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrVersion.ok && herdrServerIsReady(binary) },
         agents,
         tailscale: probeTailscale(),
         cloudflared: probeCloudflared(),


### PR DESCRIPTION
## Summary

- detect Herdr server health from the actual `running` field instead of the CLI exit code
- recover a stopped/unresponsive Herdr server before restarting muxr without blocking the host restart on partial failure
- bound health probes so a wedged socket cannot hang `muxr restart` or `muxr doctor`
- make doctor, setup, and fullscreen onboarding report the same truthful Herdr state
- honor declared launchd labels and surface systemd start failures

## Root cause

`herdr status` intentionally exits `0` even when it prints `status: not running`. muxr treated exit `0` as liveness, skipped startup, and falsely reported Herdr ready. This exactly produced “computer online, agent runtime not answering” after reboot.

## Validation

- package flow reproduces exit-0/dead-server state and proves restart recovery
- package flow proves doctor and onboarding reject a dead server
- package flow proves a hung status probe returns promptly
- package flow covers a launchd plist whose filename differs from its `Label`
- full suite: 30/30 passed
- package smoke passed independently

Initial adversarial reviewer and Oracle blockers were addressed: all sibling status callers now share the real liveness helper, and Herdr failure no longer prevents the muxr host service command from running.
