### PR TITLE
refactor: apply thermonuclear codebase audit

### DIFF
--- a/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/.agents/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: thermo-nuclear-code-quality-review
+description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+disable-model-invocation: true
+---
+
+# Thermo-Nuclear Code Quality Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep code quality audit of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce Spaghetti code, improve succinctness and legibility.
+> Be ambitious, if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.

--- a/.claude/skills/thermo-nuclear-code-quality-review
+++ b/.claude/skills/thermo-nuclear-code-quality-review
@@ -1,0 +1,1 @@
+../../.agents/skills/thermo-nuclear-code-quality-review

--- a/apps/host/src/domain/atomicWriteJson.ts
+++ b/apps/host/src/domain/atomicWriteJson.ts
@@ -1,5 +1,5 @@
 import { mkdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 /** Atomic JSON write: temp file in the same directory, then rename. */
 export async function atomicWriteJson(filePath: string, value: unknown): Promise<void> {
@@ -8,9 +8,4 @@ export async function atomicWriteJson(filePath: string, value: unknown): Promise
     const body = `${JSON.stringify(value)}\n`;
     await writeFile(tempPath, body, { encoding: 'utf8', mode: 0o600 });
     await rename(tempPath, filePath);
-}
-
-function basename(filePath: string): string {
-    const index = filePath.lastIndexOf('/');
-    return index === -1 ? filePath : filePath.slice(index + 1);
 }

--- a/apps/host/src/herdr/pluginCatalog.test.ts
+++ b/apps/host/src/herdr/pluginCatalog.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { pluginInvalidationFrame, PluginCatalog, PluginRefreshGate, WriteReplayFence, Semaphore, boundRpcDisplay, rpcReplayKey, runPluginProcess, type HerdrPlugin } from './pluginCatalog.js';
+import { pluginInvalidationFrame, PluginCatalog, PluginRefreshGate, WriteReplayFence, Semaphore, rpcReplayKey, runPluginProcess, type HerdrPlugin } from './pluginCatalog.js';
 import { buildPluginPublicContext } from './pluginPublicContext.js';
-import { MAX_RPC_RESULT_STRING_BYTES, parseManifest, parsePluginAction, pluginCompatibilityError } from '@muxr/contract';
+import { MAX_RPC_RESULT_STRING_BYTES, boundRpcDisplay, parseManifest, parsePluginAction, pluginCompatibilityError } from '@muxr/contract';
 
 function plugin(root: string, actions: HerdrPlugin['actions'] = []): HerdrPlugin {
     return {
@@ -280,7 +280,7 @@ describe('plugin catalog flow', () => {
         expect(section.children.map((node) => node.type)).toEqual(['field', 'field', 'field', 'button']);
         expect(catalog.call(loaded.pluginId, loaded.manifestHash!, 'save-rpc')).toEqual({ method: 'save', entry: 'rpc.mjs', mode: 'write', modeDeclared: true });
         expect(catalog.call(loaded.pluginId, loaded.manifestHash!, 'list-rpc')).toEqual({ method: 'list', entry: 'rpc.mjs', mode: 'read', modeDeclared: true });
-        expect(catalog.callTarget(loaded.pluginId, loaded.manifestHash!, 'list-rpc')).toEqual({ method: 'list', entry: 'rpc.mjs', mode: 'read', modeDeclared: true, pluginRoot: root });
+        expect(catalog.callTarget(loaded.pluginId, loaded.manifestHash!, 'list-rpc')).toEqual({ method: 'list', entry: 'rpc.mjs', mode: 'read', modeDeclared: true, pluginRoot: await realpath(root) });
 
         // Unknown fields in the raw manifest rotate the approval hash even when
         // the validated projection is byte-identical.
@@ -562,13 +562,13 @@ describe('plugin catalog flow', () => {
 
         await rm(linkRoot);
         await symlink(secondRoot, linkRoot, 'dir');
-        expect(catalog.callTarget('example.muxr-ui', firstHash, 'read').pluginRoot).toBe(firstRoot);
+        expect(catalog.callTarget('example.muxr-ui', firstHash, 'read').pluginRoot).toBe(await realpath(firstRoot));
 
         await catalog.refresh([plugin(linkRoot)]);
         const second = catalog.list((_, hash) => approved.has(hash))[0]!;
         expect(second.manifestHash).not.toBe(firstHash);
         expect(second.approved).toBe(false);
-        expect(catalog.callTarget('example.muxr-ui', second.manifestHash!, 'read').pluginRoot).toBe(secondRoot);
+        expect(catalog.callTarget('example.muxr-ui', second.manifestHash!, 'read').pluginRoot).toBe(await realpath(secondRoot));
     });
 
     it('binds RPC target root to the validated hash snapshot', async () => {
@@ -583,12 +583,12 @@ describe('plugin catalog flow', () => {
         const catalog = new PluginCatalog();
         await catalog.refresh([plugin(oldRoot)]);
         const oldHash = catalog.list(() => true)[0]!.manifestHash!;
-        expect(catalog.callTarget('example.muxr-ui', oldHash, 'read').pluginRoot).toBe(oldRoot);
+        expect(catalog.callTarget('example.muxr-ui', oldHash, 'read').pluginRoot).toBe(await realpath(oldRoot));
         await catalog.refresh([plugin(newRoot)]);
         const newHash = catalog.list(() => true)[0]!.manifestHash!;
         expect(newHash).not.toBe(oldHash);
         expect(() => catalog.callTarget('example.muxr-ui', oldHash, 'read')).toThrow('unavailable or changed');
-        expect(catalog.callTarget('example.muxr-ui', newHash, 'read').pluginRoot).toBe(newRoot);
+        expect(catalog.callTarget('example.muxr-ui', newHash, 'read').pluginRoot).toBe(await realpath(newRoot));
     });
 
     it('passes RPC input on stdin, never through the child environment', async () => {

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -6,14 +6,11 @@ import { homedir } from 'node:os';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 import type { PluginsInvalidatedFrame, PluginContextRequest, PluginManifestV1, PluginRpcMode, PluginSource, PluginSummary } from '@muxr/contract';
 import {
-    MAX_RPC_ARRAY_ENTRIES,
-    MAX_RPC_DISPLAY_DEPTH,
-    MAX_RPC_RESULT_STRING_BYTES,
     MAX_RPC_STDERR_BYTES,
     MAX_RPC_STDOUT_BYTES,
     PLUGIN_CALL_DEADLINE_MS,
     PLUGIN_CALL_KILL_GRACE_MS,
-    capUtf8Bytes,
+    boundRpcDisplay,
     isValidPluginId,
     parseManifest,
     sanitizeDisplayText,
@@ -350,14 +347,16 @@ function sourceIdentity(source: PluginSource, pluginRoot: string): string {
 
 type NpmProvenance = { schemaVersion: 1; pluginId: string; root: string; name: string; version: string; integrity: string };
 function npmProvenance(plugin: HerdrPlugin, pluginRoot?: string): PluginSource | undefined {
-    let root;
-    try { root = pluginRoot ?? realpathSync(plugin.plugin_root); } catch { return undefined; }
-    const expectedRoot = resolve(process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr'), 'extensions');
+    const expectedRootPath = resolve(process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr'), 'extensions');
+    let root: string;
+    let expectedRoot: string;
     try {
-        const extensionStat = lstatSync(expectedRoot);
+        root = realpathSync(pluginRoot ?? plugin.plugin_root);
+        const extensionStat = lstatSync(expectedRootPath);
         if (extensionStat.isSymbolicLink() || !extensionStat.isDirectory()) return undefined;
-        const provenanceStat = lstatSync(join(expectedRoot, '.provenance'));
+        const provenanceStat = lstatSync(join(expectedRootPath, '.provenance'));
         if (provenanceStat.isSymbolicLink() || !provenanceStat.isDirectory()) return undefined;
+        expectedRoot = realpathSync(expectedRootPath);
     } catch { return undefined; }
     const rel = relative(expectedRoot, root);
     if (rel === '' || rel.startsWith('..') || isAbsolute(rel) || rel.includes('\\') || rel.split(/[\\/]/).length !== 1 || rel !== plugin.plugin_id) return undefined;
@@ -369,7 +368,10 @@ function npmProvenance(plugin: HerdrPlugin, pluginRoot?: string): PluginSource |
         let raw;
         try { raw = readFileSync(fd, 'utf8'); } finally { closeSync(fd); }
         const parsed = JSON.parse(raw) as Partial<NpmProvenance>;
-        if (parsed.schemaVersion !== 1 || parsed.pluginId !== plugin.plugin_id || parsed.root !== root
+        let declaredRoot: string;
+        try { declaredRoot = typeof parsed.root === 'string' ? realpathSync(parsed.root) : ''; }
+        catch { return undefined; }
+        if (parsed.schemaVersion !== 1 || parsed.pluginId !== plugin.plugin_id || declaredRoot !== root
             || typeof parsed.name !== 'string' || !/^@[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$|^[A-Za-z0-9._-]+$/.test(parsed.name)
             || typeof parsed.version !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(parsed.version)
             || typeof parsed.integrity !== 'string' || parsed.name.length > 200 || parsed.version.length > 80 || parsed.integrity.length > 200 || !/^(?:sha256|sha512)-[A-Za-z0-9+/=]+$/.test(parsed.integrity)) return undefined;
@@ -420,29 +422,6 @@ function safeText(value: string, max: number): string[] {
     catch { return []; }
 }
 
-/**
- * Cap every string in an RPC result before it reaches mobile. The 64 KiB stdout
- * limit bounds total transport; this bounds each transported string to the same
- * 64 KiB ceiling (never splitting a code point) and strips
- * controls/bidi/zero-width. JSON null is preserved (a null result stays a
- * successful null, and nulls survive inside arrays/objects). Subtrees past the
- * depth cap are dropped, never returned raw. Output objects are null-prototype
- * so plugin-chosen keys like `__proto__` become plain data instead of prototype
- * assignments.
- */
-export function boundRpcDisplay(value: unknown, depth = 0): unknown {
-    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
-    if (value === null) return null;
-    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
-    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
-    if (typeof value !== 'object') return value;
-    const out: Record<string, unknown> = Object.create(null);
-    for (const [key, entry] of Object.entries(value)) {
-        const bounded = boundRpcDisplay(entry, depth + 1);
-        if (bounded !== undefined) out[key] = bounded;
-    }
-    return out;
-}
 
 export interface RunPluginProcessOptions {
     pluginId: string;

--- a/apps/mobile/sources/app/(app)/new-agent.tsx
+++ b/apps/mobile/sources/app/(app)/new-agent.tsx
@@ -10,7 +10,6 @@
 import * as React from 'react';
 import {
     ActivityIndicator,
-    Platform,
     Pressable,
     ScrollView,
     View,
@@ -35,7 +34,7 @@ import {
 } from '@/state/connectionSettings';
 
 import { FALLBACK_AGENT_KINDS, resolveAgentCatalog, type AgentCatalogOption } from '@/sync/agentKinds';
-import { getCachedHostedGrant } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 const MAX_SQUAD = 4;
 const MAX_RECENT_CHIPS = 6;
@@ -214,7 +213,8 @@ export default function NewAgentScreen() {
     const { theme } = useUnistyles();
     const insets = useSafeAreaInsets();
     const settings = getCachedConnectionSettings();
-    const canControl = Platform.OS !== 'web' || getCachedHostedGrant(settings.machineId)?.authority === 'control';
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
 
     const [catalog, setCatalog] = React.useState<readonly AgentOption[]>(
         FALLBACK_AGENT_KINDS.map((kind) => ({ kind, availability: 'unknown' })),

--- a/apps/mobile/sources/components/ActiveSessionsGroupCompact.tsx
+++ b/apps/mobile/sources/components/ActiveSessionsGroupCompact.tsx
@@ -19,7 +19,7 @@ import { useRouter } from 'expo-router';
 import { SessionShortcutHintBadge } from './ShortcutHints';
 import { buildActiveSessionDisplayGroups } from '@/utils/sessionDisplayOrder';
 import { ProviderIcon } from './ProviderIcon';
-import { currentDeviceAuthority } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 interface ActiveSessionsGroupProps {
     sessions: SessionRowData[];
@@ -32,6 +32,8 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
     const { theme } = useUnistyles();
     const router = useRouter();
     const draft = useNewSessionDraft();
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
 
     const sessionPath = session.path || '';
     const isWorktree = isWorktreePath(sessionPath);
@@ -85,7 +87,7 @@ const SectionHeader = React.memo(({ session, displayPath }: { session: SessionRo
             </View>
 
             {/* + button — vertically centered, large hit area; desktop: hover-only */}
-            {currentDeviceAuthority() === 'control' && <Pressable
+            {canControl && <Pressable
                 onPress={handleAdd}
                 hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
                 style={[styles.addButton, { opacity: Platform.OS !== 'web' || isHovered ? 1 : 0 }]}

--- a/apps/mobile/sources/components/Avatar.tsx
+++ b/apps/mobile/sources/components/Avatar.tsx
@@ -6,13 +6,9 @@ import { AvatarGradient } from "./AvatarGradient";
 import { AvatarBrutalist } from "./AvatarBrutalist";
 import { useSetting } from '@/sync/storage';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import type { GeneratedAvatarProps } from './generatedAvatar';
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
+interface AvatarProps extends GeneratedAvatarProps {
     flavor?: string | null;
     clientId?: string | null;
     imageUrl?: string | null;
@@ -93,7 +89,7 @@ export const Avatar = React.memo((props: AvatarProps) => {
 
     // Original generated avatar logic
     // Determine which avatar variant to render
-    let AvatarComponent: React.ComponentType<any>;
+    let AvatarComponent: React.ComponentType<GeneratedAvatarProps>;
     if (avatarStyle === 'pixelated') {
         AvatarComponent = AvatarSkia;
     } else if (avatarStyle === 'brutalist') {

--- a/apps/mobile/sources/components/AvatarBrutalist.tsx
+++ b/apps/mobile/sources/components/AvatarBrutalist.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
 import { View } from "react-native";
 import { Image } from "expo-image";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
-interface AvatarBrutalistProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const abstractImages = [
     require('@/assets/images/brutalist/Abstract-1.png'),
@@ -450,28 +444,19 @@ const colorPairs = [
     { tint: '#84E600', background: '#C026D3' }  // Lime → Magenta
 ];
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
-export const AvatarBrutalist = React.memo((props: AvatarBrutalistProps) => {
+export const AvatarBrutalist = React.memo((props: GeneratedAvatarProps) => {
     const { id, size = 32, square = false, monochrome = false } = props;
 
-    const imageIndex = hashCode(id) % allImages.length;
-    const colorIndex = hashCode(id + 'color') % colorPairs.length;
+    const imageIndex = avatarHash(id) % allImages.length;
+    const colorIndex = avatarHash(`${id}color`) % colorPairs.length;
 
     const imageSource = allImages[imageIndex];
     const colorPair = colorPairs[colorIndex];
     const tintColor = monochrome ? '#999999' : colorPair.tint;
     const backgroundColor = monochrome ? '#F0F0F0' : colorPair.background;
 
-    const dimension = square ? size : size;
+    const dimension = size;
     const borderRadius = square ? 0 : size / 2;
 
     return (

--- a/apps/mobile/sources/components/AvatarGradient.tsx
+++ b/apps/mobile/sources/components/AvatarGradient.tsx
@@ -1,16 +1,7 @@
 import * as React from "react";
 import { Image } from "expo-image";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
-// Copy hashCode function for consistency with Avatar.tsx
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 // Array of all 100 gradient images
 const gradientImages = [
@@ -116,19 +107,12 @@ const gradientImages = [
     require('@/assets/images/gradients/100.png'),
 ];
 
-interface AvatarGradientProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
-export const AvatarGradient = React.memo((props: AvatarGradientProps) => {
+export const AvatarGradient = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     
     // Use hashCode to get consistent gradient index
-    const imageIndex = hashCode(id) % 100;
+    const imageIndex = avatarHash(id) % 100;
     const gradientImage = gradientImages[imageIndex];
     
     return (

--- a/apps/mobile/sources/components/AvatarSkia.tsx
+++ b/apps/mobile/sources/components/AvatarSkia.tsx
@@ -1,18 +1,10 @@
 import * as React from "react";
 import { Canvas, Rect, Group, Skia } from "@shopify/react-native-skia";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
 const ELEMENTS = 64;
 const GRID_SIZE = 8; // 8x8 grid
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 function getRandomColor(number: number, colors?: string[], range?: number): string {
     if (colors && range) {
@@ -32,7 +24,7 @@ function hslToGrayscale(hslColor: string): string {
 }
 
 function generateColors(name: string, colors?: string[], monochrome?: boolean): string[] {
-    const numFromName = hashCode(name);
+    const numFromName = avatarHash(name);
     const range = colors?.length;
 
     const colorList = Array.from({ length: ELEMENTS }, (_, i) => {
@@ -43,18 +35,11 @@ function generateColors(name: string, colors?: string[], monochrome?: boolean): 
     return colorList;
 }
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const colors = ['#0a0310', '#49007e', '#ff005b', '#ff7d10', '#ffb238'];
 const grayscaleColors = ['#070707', '#242424', '#575757', '#979797', '#bbbbbb'];
 
-export const AvatarSkia = React.memo((props: AvatarProps) => {
+export const AvatarSkia = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     
     const defaultColors = monochrome ? grayscaleColors : colors;

--- a/apps/mobile/sources/components/AvatarSkia.web.tsx
+++ b/apps/mobile/sources/components/AvatarSkia.web.tsx
@@ -1,18 +1,10 @@
 import * as React from "react";
 import { View } from "react-native";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
 const ELEMENTS = 64;
 const GRID_SIZE = 8; // 8x8 grid
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 function getRandomColor(number: number, colors?: string[], range?: number): string {
     if (colors && range) {
@@ -32,7 +24,7 @@ function hslToGrayscale(hslColor: string): string {
 }
 
 function generateColors(name: string, colors?: string[], monochrome?: boolean): string[] {
-    const numFromName = hashCode(name);
+    const numFromName = avatarHash(name);
     const range = colors?.length;
 
     const colorList = Array.from({ length: ELEMENTS }, (_, i) => {
@@ -43,18 +35,11 @@ function generateColors(name: string, colors?: string[], monochrome?: boolean): 
     return colorList;
 }
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const colors = ['#0a0310', '#49007e', '#ff005b', '#ff7d10', '#ffb238'];
 const grayscaleColors = ['#070707', '#242424', '#575757', '#979797', '#bbbbbb'];
 
-export const AvatarSkia = React.memo((props: AvatarProps) => {
+export const AvatarSkia = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     const defaultColors = monochrome ? grayscaleColors : colors;
     const pixelColors = React.useMemo(() => generateColors(id, defaultColors, monochrome), [id, defaultColors]);

--- a/apps/mobile/sources/components/CommandPalette/CommandPaletteProvider.tsx
+++ b/apps/mobile/sources/components/CommandPalette/CommandPaletteProvider.tsx
@@ -18,7 +18,7 @@ import { isTauri } from '@/utils/isTauri';
 import { useVisibleSessionListViewData } from '@/hooks/useVisibleSessionListViewData';
 import { getSessionShortcutIdsInDisplayOrder } from '@/utils/sessionDisplayOrder';
 import { t } from '@/text';
-import { currentDeviceAuthority } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 const EMPTY_SESSION_IDS: readonly string[] = [];
 
@@ -30,7 +30,8 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
     const sessionListViewData = useVisibleSessionListViewData();
     const machines = useAllMachines();
     const navigateToSession = useNavigateToSession();
-    const canControl = currentDeviceAuthority() === 'control';
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
     const preferredModifier = useMemo(() => getPreferredShortcutModifier(
         typeof navigator === 'undefined' ? undefined : navigator
     ), []);

--- a/apps/mobile/sources/components/EmptySessionsTablet.tsx
+++ b/apps/mobile/sources/components/EmptySessionsTablet.tsx
@@ -7,7 +7,7 @@ import { useAllMachines } from '@/sync/storage';
 import { isMachineOnline } from '@/utils/machineUtils';
 import { useRouter } from 'expo-router';
 import { t } from '@/text';
-import { currentDeviceAuthority } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 const stylesheet = StyleSheet.create((theme) => ({
     container: {
@@ -61,7 +61,8 @@ export function EmptySessionsTablet() {
     const styles = stylesheet;
     const router = useRouter();
     const machines = useAllMachines();
-    const canControl = currentDeviceAuthority() === 'control';
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
     
     const hasOnlineMachines = React.useMemo(() => {
         return machines.some(machine => isMachineOnline(machine));

--- a/apps/mobile/sources/components/HomeDock.tsx
+++ b/apps/mobile/sources/components/HomeDock.tsx
@@ -17,54 +17,24 @@ import Animated, {
 import { MobileGlassSurface } from './MobileGlass';
 import { OptionSheet } from './OptionSheet';
 import { BubblePressable } from './BubblePressable';
-import { NativeSettingsMenu, type NativeSettingsMenuGroup } from './NativeSettingsMenu';
+import { NativeSettingsMenu } from './NativeSettingsMenu';
+import type { NativeSettingsMenuGroup } from './NativeSettingsMenu.types';
 import { AgentInputAttachmentStrip } from './AgentInputAttachmentStrip';
 import { Typography } from '@/constants/Typography';
 import { layout } from './layout';
 import { t } from '@/text';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import { PluginSlot } from '@/plugins/PluginSlot';
-import { useAllMachines, useSessions, useSocketStatus } from '@/sync/storage';
-import { formatLastSeen, formatPathRelativeToHome } from '@/utils/sessionUtils';
-import { isMachineOnline } from '@/utils/machineUtils';
-import { resolveAbsolutePath } from '@/utils/pathUtils';
-import { listWorktrees } from '@/utils/worktree';
-import type { Machine, Session } from '@/sync/storageTypes';
 
-interface ModeOption {
-    key: string;
-    name: string;
-    description?: string;
-    agentKind?: string;
-}
-import { AGENT_TYPES, type NewSessionAgentType } from '@/sync/persistence';
+import type { NewSessionAgentType } from '@/sync/persistence';
 import { useImagePicker } from '@/hooks/useImagePicker';
 import { Modal } from '@/modal';
-import { sync } from '@/sync/sync';
-import { resolveAgentCatalog } from '@/sync/agentKinds';
+import { useHomeDockEnvironment } from '@/hooks/useHomeDockEnvironment';
 
 export const MOBILE_HOME_DOCK_CONTENT_INSET = 108;
 
 type EnvironmentSetting = 'machine' | 'project' | 'worktree' | 'agent';
-type AgentSetting = 'agent';
 
-
-const AGENT_NAMES: Partial<Record<NewSessionAgentType, string>> = {
-    shell: 'Shell (no agent)',
-    pi: 'Pi',
-    claude: 'Claude Code',
-    codex: 'Codex',
-    omp: 'OMP',
-    opencode: 'OpenCode',
-    droid: 'Factory Droid',
-    qodercli: 'Qoder CLI',
-};
-
-const AGENTS = AGENT_TYPES.map((key) => ({
-    key,
-    name: AGENT_NAMES[key] ?? key.replace(/(^|[-_])(\w)/g, (_, prefix, letter) => `${prefix ? ' ' : ''}${letter.toUpperCase()}`),
-    ...(key === 'shell' ? {} : { agentKind: key }),
-}));
 
 const styles = StyleSheet.create((theme) => ({
     keyboardFollower: {
@@ -430,17 +400,6 @@ const styles = StyleSheet.create((theme) => ({
 }));
 
 
-function resolveOption(options: ModeOption[], preferred: Array<string | null | undefined>): ModeOption | null {
-    for (const key of preferred) {
-        const option = options.find((candidate) => candidate.key === key);
-        if (option) return option;
-    }
-    return options[0] ?? null;
-}
-
-function getMachineName(machine: Machine): string {
-    return machine.metadata?.displayName || machine.metadata?.host || 'Unknown machine';
-}
 
 function FocusConfigRevealRow({
     progress,
@@ -501,159 +460,24 @@ export const HomeDock = React.memo(({
         setText: onPromptChange,
     }), [onPromptChange]);
     const { selectedImages, pickImages, removeImage, clearImages } = useImagePicker();
-    const agentType = useNewSessionDraft((state) => state.agentType);
-    const selectedMachineId = useNewSessionDraft((state) => state.selectedMachineId);
-    const selectedPath = useNewSessionDraft((state) => state.selectedPath);
-    const sessionType = useNewSessionDraft((state) => state.sessionType);
-    const worktreeKey = useNewSessionDraft((state) => state.worktreeKey);
-    const permissionMode = useNewSessionDraft((state) => state.permissionMode);
-    const modelMode = useNewSessionDraft((state) => state.modelMode);
-    const effortLevel = useNewSessionDraft((state) => state.effortLevel);
-    const setMachineId = useNewSessionDraft((state) => state.setMachineId);
-    const setAgentType = useNewSessionDraft((state) => state.setAgentType);
-    const setPath = useNewSessionDraft((state) => state.setPath);
-    const setSessionType = useNewSessionDraft((state) => state.setSessionType);
-    const setWorktreeKey = useNewSessionDraft((state) => state.setWorktreeKey);
-    const socketStatus = useSocketStatus();
-    const [hostAgentKinds, setHostAgentKinds] = React.useState<string[] | null>(null);
-    const [hostAgentKindsAuthoritative, setHostAgentKindsAuthoritative] = React.useState(false);
-    const machines = useAllMachines({ includeOffline: true });
-    const sessions = useSessions();
-    const selectedMachine = React.useMemo(
-        () => machines.find((machine) => machine.id === selectedMachineId) ?? null,
-        [machines, selectedMachineId],
-    );
-    const machineOptions = React.useMemo<ModeOption[]>(() => (
-        [...machines]
-            .sort((left, right) => Number(isMachineOnline(right)) - Number(isMachineOnline(left)))
-            .map((machine) => ({
-                key: machine.id,
-                name: getMachineName(machine),
-                description: isMachineOnline(machine)
-                    ? t('status.online')
-                    : t('status.lastSeen', { time: formatLastSeen(machine.activeAt, false) }),
-            }))
-    ), [machines]);
-    const currentMachine = resolveOption(machineOptions, [selectedMachineId]);
-
-    React.useEffect(() => {
-        if (!selectedMachineId && machineOptions[0]) {
-            setMachineId(machineOptions[0].key);
-        }
-    }, [machineOptions, selectedMachineId, setMachineId]);
-
-    const projectOptions = React.useMemo<ModeOption[]>(() => {
-        const paths = new Set<string>();
-        paths.add(selectedPath ?? '~');
-
-        if (selectedMachineId && sessions) {
-            for (const item of sessions) {
-                if (typeof item === 'string') continue;
-                const session = item as Session;
-                if (session.metadata?.machineId === selectedMachineId && session.metadata.path) {
-                    paths.add(session.metadata.path);
-                }
-            }
-        }
-
-        const homeDir = selectedMachine?.metadata?.homeDir;
-        return Array.from(paths).map((path) => {
-            const name = formatPathRelativeToHome(path, homeDir);
-            return {
-                key: path,
-                name,
-                description: name === path ? undefined : path,
-            };
-        });
-    }, [selectedMachine, selectedMachineId, selectedPath, sessions]);
-    const currentProject = resolveOption(projectOptions, [selectedPath, '~']);
-    // herdr creates worktrees for any agent kind in a git repo.
-    const supportsWorktree = true;
-    const selectedWorktreeKey = sessionType === 'worktree'
-        ? worktreeKey ?? '__new__'
-        : '__none__';
-    const [existingWorktrees, setExistingWorktrees] = React.useState<ModeOption[]>([]);
-
-    React.useEffect(() => {
-        const path = resolveAbsolutePath(selectedPath ?? '~', selectedMachine?.metadata?.homeDir);
-        if (!supportsWorktree || !selectedMachineId || !selectedMachine || !isMachineOnline(selectedMachine) || !path) {
-            setExistingWorktrees([]);
-            return;
-        }
-
-        let cancelled = false;
-        listWorktrees(selectedMachineId, path).then((worktrees) => {
-            if (cancelled) return;
-            setExistingWorktrees(worktrees.map((worktree) => ({
-                key: worktree.path,
-                name: worktree.branch,
-                description: worktree.path,
-            })));
-        });
-        return () => {
-            cancelled = true;
-        };
-    }, [selectedMachine, selectedMachineId, selectedPath, supportsWorktree]);
-
-    React.useEffect(() => {
-        if (!supportsWorktree && sessionType === 'worktree') {
-            setSessionType('simple');
-            setWorktreeKey(null);
-        }
-    }, [sessionType, setSessionType, setWorktreeKey, supportsWorktree]);
-
-    const worktreeOptions = React.useMemo<ModeOption[]>(() => {
-        if (!supportsWorktree) {
-            return [{
-                key: '__none__',
-                name: 'No worktree',
-                description: `Not supported by ${AGENTS.find((agent) => agent.key === agentType)?.name ?? agentType}`,
-            }];
-        }
-        const options: ModeOption[] = [
-            { key: '__none__', name: 'No worktree' },
-            { key: '__new__', name: 'Create new worktree' },
-            ...existingWorktrees,
-        ];
-        if (
-            worktreeKey
-            && !options.some((option) => option.key === worktreeKey)
-        ) {
-            options.push({ key: worktreeKey, name: worktreeKey });
-        }
-        return options;
-    }, [agentType, existingWorktrees, supportsWorktree, worktreeKey]);
-    const currentWorktree = resolveOption(worktreeOptions, [selectedWorktreeKey]);
-    React.useEffect(() => {
-        let cancelled = false;
-        setHostAgentKinds(null);
-        setHostAgentKindsAuthoritative(false);
-        if (socketStatus.status !== 'connected') return () => { cancelled = true; };
-        void sync.request('herdr.agentKinds', {}).then((result) => {
-            if (cancelled) return;
-            const resolved = resolveAgentCatalog(result);
-            const launchable = resolved.options
-                .filter((option) => option.availability !== 'unavailable')
-                .map((option) => option.kind);
-            setHostAgentKinds([...new Set(['shell', ...launchable])]);
-            setHostAgentKindsAuthoritative(resolved.authoritative);
-        }).catch(() => {
-            if (!cancelled) {
-                setHostAgentKinds(null);
-                setHostAgentKindsAuthoritative(false);
-            }
-        });
-        return () => { cancelled = true; };
-    }, [socketStatus.status]);
-    const visibleAgentKeys = new Set(hostAgentKinds ?? ['shell', agentType]);
-    if (!hostAgentKindsAuthoritative) visibleAgentKeys.add(agentType);
-    const availableAgents = AGENTS.filter((agent) => visibleAgentKeys.has(agent.key));
-    const currentAgent = availableAgents.find((agent) => agent.key === agentType) ?? availableAgents[0] ?? AGENTS[0];
-    React.useEffect(() => {
-        if (hostAgentKindsAuthoritative && hostAgentKinds !== null && hostAgentKinds.some((kind) => kind !== 'shell') && !hostAgentKinds.includes(agentType)) {
-            setAgentType(hostAgentKinds.find((kind) => kind !== 'shell') as NewSessionAgentType);
-        }
-    }, [agentType, hostAgentKinds, hostAgentKindsAuthoritative, setAgentType]);
+    const {
+        agentType,
+        availableAgents,
+        currentAgent,
+        currentMachine,
+        currentProject,
+        currentWorktree,
+        machineOptions,
+        projectOptions,
+        selectedMachineId,
+        selectedWorktreeKey,
+        selectAgent,
+        setMachineId,
+        setPath,
+        setSessionType,
+        setWorktreeKey,
+        worktreeOptions,
+    } = useHomeDockEnvironment();
     const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
     const keyboardStyle = useAnimatedStyle(() => ({
@@ -785,18 +609,9 @@ export const HomeDock = React.memo(({
         });
     }, [finishCloseFocusMode, focusPresentation]);
 
-    const selectAgent = React.useCallback((agent: NewSessionAgentType) => {
-        setAgentType(agent);
-    }, [setAgentType]);
-
-    React.useEffect(() => {
-        if (hostAgentKindsAuthoritative && availableAgents.some((agent) => agent.key !== 'shell') && !availableAgents.some((agent) => agent.key === agentType)) {
-            selectAgent(availableAgents.find((agent) => agent.key !== 'shell')!.key);
-        }
-    }, [agentType, availableAgents, hostAgentKindsAuthoritative, selectAgent]);
 
     type SettingsRow = {
-        page: string;
+        page: EnvironmentSetting;
         label: string;
         value: string;
         icon: React.ComponentProps<typeof Ionicons>['name'];
@@ -808,41 +623,14 @@ export const HomeDock = React.memo(({
         { page: 'project', label: 'PROJECT', value: currentProject?.name ?? '~', icon: 'folder-outline' },
         { page: 'worktree', label: 'WORKTREE', value: currentWorktree?.name ?? 'No worktree', icon: 'git-branch-outline' },
     ];
-    const agentRows: SettingsRow[] = [
-        { page: 'agent', label: 'AGENT', value: currentAgent.name, icon: 'hardware-chip-outline' },
-    ];
-
-    type PickerConfig = {
-        title: string;
-        options: ModeOption[];
-        selectedKey: string | null | undefined;
-        onSelect: (key: string) => void;
-    };
-
-    const getAgentPickerConfig = (setting: AgentSetting): PickerConfig => {
-        if (setting === 'agent') {
-            return { title: 'Agent', options: availableAgents, selectedKey: agentType, onSelect: (key) => selectAgent(key as NewSessionAgentType) };
-        }
-        return { title: 'Agent', options: [], selectedKey: undefined, onSelect: () => undefined };
-    };
-
-    const agentSettingsGroups: NativeSettingsMenuGroup[] = agentRows.map((row) => {
-        const config = getAgentPickerConfig(row.page as AgentSetting);
-        return {
-            key: row.page,
-            label: row.value || config.title,
-            systemImage: {
-                agent: 'cpu',
-                model: 'cube',
-                permission: 'shield',
-                effort: 'bolt',
-            }[row.page],
-            options: config.options.map((option) => ({ key: option.key, label: option.name })),
-            selectedKey: config.selectedKey,
-            onSelect: config.onSelect,
-        };
-    });
-    const gearSettingsGroups = agentSettingsGroups.filter((group) => group.key === 'agent');
+    const gearSettingsGroups: NativeSettingsMenuGroup[] = [{
+        key: 'agent',
+        label: currentAgent.name,
+        systemImage: 'cpu',
+        options: availableAgents.map((option) => ({ key: option.key, label: option.name })),
+        selectedKey: agentType,
+        onSelect: (key) => selectAgent(key as NewSessionAgentType),
+    }];
 
     const renderEnvironmentPickers = () => environmentRows.map((row, index) => (
         <FocusConfigRevealRow
@@ -851,7 +639,7 @@ export const HomeDock = React.memo(({
             index={index}
         >
             <BubblePressable
-                onPress={() => setOpenSheet(row.page as EnvironmentSetting)}
+                onPress={() => setOpenSheet(row.page)}
                 style={styles.focusConfigRow}
                 accessibilityRole="button"
                 accessibilityLabel={row.label}

--- a/apps/mobile/sources/components/MainView.tsx
+++ b/apps/mobile/sources/components/MainView.tsx
@@ -36,11 +36,12 @@ import { MOBILE_GLASS_HEADER_HEIGHT } from './navigation/headerMetrics';
 import { MobileGlassSurface } from './MobileGlass';
 import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
 import { useStartSessionFromDraft } from '@/hooks/useStartSessionFromDraft';
-import { currentDeviceAuthority, listPairedGrants, type StoredHostedGrant } from '@/state/hostedE2ee';
+import { listPairedGrants, type StoredHostedGrant } from '@/state/hostedE2ee';
 import { getCachedConnectionSettings, pairingTransport, saveConnectionSettings } from '@/state/connectionSettings';
 import { useAuth } from '@/auth/AuthContext';
 import { OptionSheet, type ModelMode } from './OptionSheet';
 import { Modal } from '@/modal';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 interface MainViewProps {
     variant: 'phone' | 'sidebar';
@@ -351,6 +352,8 @@ const HeaderRight = React.memo(({
 }) => {
     const router = useRouter();
     const { theme } = useUnistyles();
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
 
     if (activeTab === 'sessions') {
         if (Platform.OS !== 'web') {
@@ -385,7 +388,7 @@ const HeaderRight = React.memo(({
                 </View>
             );
         }
-        return currentDeviceAuthority() === 'control' ? (
+        return canControl ? (
             <View style={styles.headerActions}>
                 <Pressable
                     onPress={() => router.navigate('/new-agent')}

--- a/apps/mobile/sources/components/NativeSettingsMenu.android.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.android.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DropdownMenu, DropdownMenuItem } from '@expo/ui/jetpack-compose';
 import { View } from 'react-native';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 export function NativeSettingsMenu({ groups, children, style, flat = false }: NativeSettingsMenuProps) {
     return (

--- a/apps/mobile/sources/components/NativeSettingsMenu.ios.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.ios.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button, Host, HStack, Menu, Spacer } from '@expo/ui/swift-ui';
 import { contentShape, frame, opacity, shapes, tint } from '@expo/ui/swift-ui/modifiers';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 const systemImage = (name: string) => (
     name as React.ComponentProps<typeof Button>['systemImage']

--- a/apps/mobile/sources/components/NativeSettingsMenu.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.tsx
@@ -1,27 +1,7 @@
 import * as React from 'react';
-import { Platform, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform } from 'react-native';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
-export type NativeSettingsMenuOption = {
-    key: string;
-    label: string;
-};
-
-export type NativeSettingsMenuGroup = {
-    key: string;
-    label: string;
-    systemImage?: string;
-    options: NativeSettingsMenuOption[];
-    selectedKey: string | null | undefined;
-    onSelect: (key: string) => void;
-};
-
-export type NativeSettingsMenuProps = {
-    groups: NativeSettingsMenuGroup[];
-    children: React.ReactNode;
-    style?: StyleProp<ViewStyle>;
-    /** Render all options directly in the root menu instead of nesting by group. */
-    flat?: boolean;
-};
 
 const NativeSettingsMenuImpl = Platform.select<React.ComponentType<NativeSettingsMenuProps>>({
     ios: require('./NativeSettingsMenu.ios').NativeSettingsMenu,

--- a/apps/mobile/sources/components/NativeSettingsMenu.types.ts
+++ b/apps/mobile/sources/components/NativeSettingsMenu.types.ts
@@ -1,0 +1,24 @@
+import type * as React from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export type NativeSettingsMenuOption = {
+    key: string;
+    label: string;
+};
+
+export type NativeSettingsMenuGroup = {
+    key: string;
+    label: string;
+    systemImage?: string;
+    options: NativeSettingsMenuOption[];
+    selectedKey: string | null | undefined;
+    onSelect: (key: string) => void;
+};
+
+export type NativeSettingsMenuProps = {
+    groups: NativeSettingsMenuGroup[];
+    children: React.ReactNode;
+    style?: StyleProp<ViewStyle>;
+    /** Render all options directly in the root menu instead of nesting by group. */
+    flat?: boolean;
+};

--- a/apps/mobile/sources/components/NativeSettingsMenu.web.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.web.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 export function NativeSettingsMenu({ children, style }: NativeSettingsMenuProps) {
     return <View style={style}>{children}</View>;

--- a/apps/mobile/sources/components/SidebarView.tsx
+++ b/apps/mobile/sources/components/SidebarView.tsx
@@ -9,7 +9,7 @@ import { t } from '@/text';
 import { Ionicons } from '@expo/vector-icons';
 import { Typography } from '@/constants/Typography';
 import { ShortcutHintBadge, useShortcutHints } from './ShortcutHints';
-import { currentDeviceAuthority } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 const stylesheet = StyleSheet.create((theme) => ({
     container: {
@@ -77,6 +77,8 @@ export const SidebarView = React.memo(() => {
     const router = useRouter();
     const headerHeight = useHeaderHeight();
     const { visible: shortcutHintsVisible } = useShortcutHints();
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
 
     const handleNewSession = React.useCallback(() => {
         router.navigate('/new-agent');
@@ -85,7 +87,7 @@ export const SidebarView = React.memo(() => {
     return (
         <View style={[styles.container, { paddingTop: safeArea.top + headerHeight }]}>
             {/* New Session button */}
-            {currentDeviceAuthority() === 'control' && <View style={styles.headerRow}>
+            {canControl && <View style={styles.headerRow}>
                 <Pressable
                     onPress={handleNewSession}
                     style={({ pressed }) => [

--- a/apps/mobile/sources/components/generatedAvatar.ts
+++ b/apps/mobile/sources/components/generatedAvatar.ts
@@ -1,0 +1,17 @@
+export interface GeneratedAvatarProps {
+    id: string;
+    title?: boolean;
+    square?: boolean;
+    size?: number;
+    monochrome?: boolean;
+}
+
+/** Stable seed shared by every generated avatar renderer. */
+export function avatarHash(value: string): number {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+        hash = ((hash << 5) - hash) + value.charCodeAt(index);
+        hash &= hash;
+    }
+    return Math.abs(hash);
+}

--- a/apps/mobile/sources/components/markdown/MarkdownView.tsx
+++ b/apps/mobile/sources/components/markdown/MarkdownView.tsx
@@ -1,4 +1,5 @@
-import { MarkdownSpan, parseMarkdown } from './parseMarkdown';
+import { parseMarkdown } from './parseMarkdown';
+import type { MarkdownSpan } from './markdownTypes';
 import * as React from 'react';
 import { Image, Pressable, View, Platform } from 'react-native';
 import { HorizontalScrollView } from '../HorizontalScrollView';

--- a/apps/mobile/sources/components/markdown/markdownTypes.ts
+++ b/apps/mobile/sources/components/markdown/markdownTypes.ts
@@ -1,0 +1,40 @@
+export type MarkdownBlock = {
+    type: 'text';
+    content: MarkdownSpan[];
+} | {
+    type: 'header';
+    level: 1 | 2 | 3 | 4 | 5 | 6;
+    content: MarkdownSpan[];
+} | {
+    type: 'list';
+    items: { depth: number; spans: MarkdownSpan[] }[];
+} | {
+    type: 'numbered-list';
+    items: { number: number; depth: number; spans: MarkdownSpan[] }[];
+} | {
+    type: 'code-block';
+    language: string | null;
+    content: string;
+} | {
+    type: 'mermaid';
+    content: string;
+} | {
+    type: 'horizontal-rule';
+} | {
+    type: 'options';
+    items: string[];
+} | {
+    type: 'table';
+    headers: MarkdownSpan[][];
+    rows: MarkdownSpan[][][];
+} | {
+    type: 'image';
+    alt: string;
+    url: string;
+};
+
+export type MarkdownSpan = {
+    styles: ('italic' | 'bold' | 'semibold' | 'code')[];
+    text: string;
+    url: string | null;
+};

--- a/apps/mobile/sources/components/markdown/parseMarkdown.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdown.ts
@@ -1,45 +1,5 @@
 import { parseMarkdownBlock } from "./parseMarkdownBlock"
 
-export type MarkdownBlock = {
-    type: 'text'
-    content: MarkdownSpan[]
-} | {
-    type: 'header'
-    level: 1 | 2 | 3 | 4 | 5 | 6
-    content: MarkdownSpan[]
-} | {
-    type: 'list',
-    items: { depth: number, spans: MarkdownSpan[] }[]
-} | {
-    type: 'numbered-list',
-    items: { number: number, depth: number, spans: MarkdownSpan[] }[]
-} | {
-    type: 'code-block',
-    language: string | null,
-    content: string
-} | {
-    type: 'mermaid',
-    content: string
-} | {
-    type: 'horizontal-rule'
-} | {
-    type: 'options',
-    items: string[]
-} | {
-    type: 'table',
-    headers: MarkdownSpan[][],
-    rows: MarkdownSpan[][][]
-} | {
-    type: 'image',
-    alt: string,
-    url: string
-}
-
-export type MarkdownSpan = {
-    styles: ('italic' | 'bold' | 'semibold' | 'code')[],
-    text: string,
-    url: string | null
-}
 
 export function parseMarkdown(markdown: string) {
     return parseMarkdownBlock(markdown);

--- a/apps/mobile/sources/components/markdown/parseMarkdownBlock.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdownBlock.ts
@@ -1,4 +1,4 @@
-import type { MarkdownBlock, MarkdownSpan } from "./parseMarkdown";
+import type { MarkdownBlock, MarkdownSpan } from "./markdownTypes";
 import { parseMarkdownSpans } from "./parseMarkdownSpans";
 
 // Split a pipe-delimited table row into cells, stripping only the leading/trailing

--- a/apps/mobile/sources/components/markdown/parseMarkdownSpans.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdownSpans.ts
@@ -1,4 +1,4 @@
-import type { MarkdownSpan } from "./parseMarkdown";
+import type { MarkdownSpan } from "./markdownTypes";
 
 // Updated pattern to handle nested markdown and asterisks
 const pattern = /(\*\*(.*?)(?:\*\*|$))|(\*(.*?)(?:\*|$))|(\[([^\]]+)\](?:\(([^)]+)\))?)|(`(.*?)(?:`|$))/g;

--- a/apps/mobile/sources/hooks/useDeviceAuthority.ts
+++ b/apps/mobile/sources/hooks/useDeviceAuthority.ts
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Platform } from 'react-native';
+import { getCachedConnectionSettings } from '@/state/connectionSettings';
+import { currentDeviceAuthority, loadHostedGrant } from '@/state/hostedE2ee';
+import { useSocketStatus } from '@/sync/storage';
+
+export type DeviceAuthority = 'control' | 'observe';
+
+/** Reactive, fail-closed authority for every control-producing mobile surface. */
+export function useDeviceAuthority(): { authority: DeviceAuthority; loading: boolean } {
+    const { status: socketStatus } = useSocketStatus();
+    const connection = getCachedConnectionSettings();
+    const [state, setState] = React.useState<{ authority: DeviceAuthority; loading: boolean }>(() => {
+        const authority = currentDeviceAuthority();
+        return {
+            authority,
+            loading: Platform.OS === 'web' && connection.mode === 'hosted' && authority !== 'control',
+        };
+    });
+
+    React.useEffect(() => {
+        if (Platform.OS !== 'web') {
+            setState({ authority: 'control', loading: false });
+            return;
+        }
+        if (connection.mode === 'local') {
+            setState({ authority: 'observe', loading: false });
+            return;
+        }
+        let cancelled = false;
+        void loadHostedGrant(connection.machineId).then((grant) => {
+            if (!cancelled) setState({ authority: grant?.authority ?? 'observe', loading: false });
+        });
+        return () => { cancelled = true; };
+    }, [connection.machineId, connection.mode, socketStatus]);
+
+    return state;
+}

--- a/apps/mobile/sources/hooks/useHomeDockEnvironment.ts
+++ b/apps/mobile/sources/hooks/useHomeDockEnvironment.ts
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import { t } from '@/text';
+import { useNewSessionDraft } from '@/hooks/useNewSessionDraft';
+import { useAllMachines, useSessions, useSocketStatus } from '@/sync/storage';
+import { AGENT_TYPES, type NewSessionAgentType } from '@/sync/persistence';
+import type { Session } from '@/sync/storageTypes';
+import { sync } from '@/sync/sync';
+import { resolveAgentCatalog } from '@/sync/agentKinds';
+import { isMachineOnline } from '@/utils/machineUtils';
+import { resolveAbsolutePath } from '@/utils/pathUtils';
+import { formatLastSeen, formatPathRelativeToHome } from '@/utils/sessionUtils';
+import { listWorktrees } from '@/utils/worktree';
+
+export interface HomeDockOption {
+    key: string;
+    name: string;
+    description?: string;
+    agentKind?: string;
+}
+
+const AGENT_NAMES: Partial<Record<NewSessionAgentType, string>> = {
+    shell: 'Shell (no agent)',
+    pi: 'Pi',
+    claude: 'Claude Code',
+    codex: 'Codex',
+    omp: 'OMP',
+    opencode: 'OpenCode',
+    droid: 'Factory Droid',
+    qodercli: 'Qoder CLI',
+};
+
+export const HOME_DOCK_AGENTS: HomeDockOption[] = AGENT_TYPES.map((key) => ({
+    key,
+    name: AGENT_NAMES[key] ?? key.replace(/(^|[-_])(\w)/g, (_, prefix, letter) => `${prefix ? ' ' : ''}${letter.toUpperCase()}`),
+    ...(key === 'shell' ? {} : { agentKind: key }),
+}));
+
+function resolveOption(options: HomeDockOption[], preferred: Array<string | null | undefined>): HomeDockOption | null {
+    for (const key of preferred) {
+        const option = options.find((candidate) => candidate.key === key);
+        if (option !== undefined) return option;
+    }
+    return options[0] ?? null;
+}
+
+export function useHomeDockEnvironment() {
+    const agentType = useNewSessionDraft((state) => state.agentType);
+    const selectedMachineId = useNewSessionDraft((state) => state.selectedMachineId);
+    const selectedPath = useNewSessionDraft((state) => state.selectedPath);
+    const sessionType = useNewSessionDraft((state) => state.sessionType);
+    const worktreeKey = useNewSessionDraft((state) => state.worktreeKey);
+    const setMachineId = useNewSessionDraft((state) => state.setMachineId);
+    const setAgentType = useNewSessionDraft((state) => state.setAgentType);
+    const setPath = useNewSessionDraft((state) => state.setPath);
+    const setSessionType = useNewSessionDraft((state) => state.setSessionType);
+    const setWorktreeKey = useNewSessionDraft((state) => state.setWorktreeKey);
+    const socketStatus = useSocketStatus();
+    const machines = useAllMachines({ includeOffline: true });
+    const sessions = useSessions();
+    const [hostAgentKinds, setHostAgentKinds] = React.useState<string[] | null>(null);
+    const [hostAgentKindsAuthoritative, setHostAgentKindsAuthoritative] = React.useState(false);
+    const [existingWorktrees, setExistingWorktrees] = React.useState<HomeDockOption[]>([]);
+
+    const selectedMachine = React.useMemo(
+        () => machines.find((machine) => machine.id === selectedMachineId) ?? null,
+        [machines, selectedMachineId],
+    );
+    const machineOptions = React.useMemo<HomeDockOption[]>(() => (
+        [...machines]
+            .sort((left, right) => Number(isMachineOnline(right)) - Number(isMachineOnline(left)))
+            .map((machine) => ({
+                key: machine.id,
+                name: machine.metadata?.displayName || machine.metadata?.host || 'Unknown machine',
+                description: isMachineOnline(machine)
+                    ? t('status.online')
+                    : t('status.lastSeen', { time: formatLastSeen(machine.activeAt, false) }),
+            }))
+    ), [machines]);
+    const currentMachine = resolveOption(machineOptions, [selectedMachineId]);
+
+    React.useEffect(() => {
+        if ((selectedMachineId === null || selectedMachineId === '') && machineOptions[0] !== undefined) {
+            setMachineId(machineOptions[0].key);
+        }
+    }, [machineOptions, selectedMachineId, setMachineId]);
+
+    const projectOptions = React.useMemo<HomeDockOption[]>(() => {
+        const paths = new Set<string>([selectedPath ?? '~']);
+        if (selectedMachineId !== null && selectedMachineId !== '' && sessions !== null) {
+            for (const item of sessions) {
+                if (typeof item === 'string') continue;
+                const session = item as Session;
+                if (session.metadata?.machineId === selectedMachineId && session.metadata.path) paths.add(session.metadata.path);
+            }
+        }
+        const homeDir = selectedMachine?.metadata?.homeDir;
+        return Array.from(paths).map((path) => {
+            const name = formatPathRelativeToHome(path, homeDir);
+            return { key: path, name, ...(name === path ? {} : { description: path }) };
+        });
+    }, [selectedMachine, selectedMachineId, selectedPath, sessions]);
+    const currentProject = resolveOption(projectOptions, [selectedPath, '~']);
+    const selectedWorktreeKey = sessionType === 'worktree' ? worktreeKey ?? '__new__' : '__none__';
+
+    React.useEffect(() => {
+        const path = resolveAbsolutePath(selectedPath ?? '~', selectedMachine?.metadata?.homeDir);
+        if (selectedMachineId === null || selectedMachineId === '' || selectedMachine === null || !isMachineOnline(selectedMachine) || path === '') {
+            setExistingWorktrees([]);
+            return;
+        }
+        let cancelled = false;
+        void listWorktrees(selectedMachineId, path).then((worktrees) => {
+            if (!cancelled) {
+                setExistingWorktrees(worktrees.map((worktree) => ({
+                    key: worktree.path,
+                    name: worktree.branch,
+                    description: worktree.path,
+                })));
+            }
+        });
+        return () => { cancelled = true; };
+    }, [selectedMachine, selectedMachineId, selectedPath]);
+
+    const worktreeOptions = React.useMemo<HomeDockOption[]>(() => {
+        const options: HomeDockOption[] = [
+            { key: '__none__', name: 'No worktree' },
+            { key: '__new__', name: 'Create new worktree' },
+            ...existingWorktrees,
+        ];
+        if (worktreeKey !== null && worktreeKey !== '' && !options.some((option) => option.key === worktreeKey)) {
+            options.push({ key: worktreeKey, name: worktreeKey });
+        }
+        return options;
+    }, [existingWorktrees, worktreeKey]);
+    const currentWorktree = resolveOption(worktreeOptions, [selectedWorktreeKey]);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        setHostAgentKinds(null);
+        setHostAgentKindsAuthoritative(false);
+        if (socketStatus.status !== 'connected') return () => { cancelled = true; };
+        void sync.request('herdr.agentKinds', {}).then((result) => {
+            if (cancelled) return;
+            const resolved = resolveAgentCatalog(result);
+            const launchable = resolved.options
+                .filter((option) => option.availability !== 'unavailable')
+                .map((option) => option.kind);
+            setHostAgentKinds([...new Set(['shell', ...launchable])]);
+            setHostAgentKindsAuthoritative(resolved.authoritative);
+        }).catch(() => {
+            if (!cancelled) {
+                setHostAgentKinds(null);
+                setHostAgentKindsAuthoritative(false);
+            }
+        });
+        return () => { cancelled = true; };
+    }, [socketStatus.status]);
+
+    const availableAgents = React.useMemo(() => {
+        const visible = new Set(hostAgentKinds ?? ['shell', agentType]);
+        if (!hostAgentKindsAuthoritative) visible.add(agentType);
+        return HOME_DOCK_AGENTS.filter((agent) => visible.has(agent.key));
+    }, [agentType, hostAgentKinds, hostAgentKindsAuthoritative]);
+    const currentAgent = availableAgents.find((agent) => agent.key === agentType)
+        ?? availableAgents[0]
+        ?? HOME_DOCK_AGENTS[0]!;
+    const selectAgent = React.useCallback((agent: NewSessionAgentType) => setAgentType(agent), [setAgentType]);
+
+    React.useEffect(() => {
+        const firstAgent = availableAgents.find((agent) => agent.key !== 'shell');
+        if (hostAgentKindsAuthoritative && firstAgent !== undefined && !availableAgents.some((agent) => agent.key === agentType)) {
+            selectAgent(firstAgent.key as NewSessionAgentType);
+        }
+    }, [agentType, availableAgents, hostAgentKindsAuthoritative, selectAgent]);
+
+    return {
+        agentType,
+        availableAgents,
+        currentAgent,
+        currentMachine,
+        currentProject,
+        currentWorktree,
+        machineOptions,
+        projectOptions,
+        selectedMachineId,
+        selectedWorktreeKey,
+        selectAgent,
+        setMachineId,
+        setPath,
+        setSessionType,
+        setWorktreeKey,
+        worktreeOptions,
+    };
+}

--- a/apps/mobile/sources/plugins/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreen.tsx
@@ -3,14 +3,11 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StyleSheet, T
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
-import { PolarChart, Pie } from 'victory-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { Canvas, Path, Skia } from '@shopify/react-native-skia';
-import Animated, { Easing, FadeIn, FadeInDown, SlideInLeft, SlideInRight, cancelAnimation, runOnJS, useAnimatedStyle, useDerivedValue, useReducedMotion, useSharedValue, withDelay, withRepeat, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, { Easing, FadeIn, FadeInDown, SlideInLeft, SlideInRight, cancelAnimation, runOnJS, useAnimatedStyle, useReducedMotion, useSharedValue, withRepeat, withSpring, withTiming } from 'react-native-reanimated';
 import { useUnistyles } from 'react-native-unistyles';
-import type { PluginManifestV1, PluginScreenButtonNode, PluginScreenChartNode, PluginScreenContribution, PluginScreenNode, PluginScreenRowAction, PluginScreenRowNode, PluginScreenTone, PluginScreenTreeNode, PluginSource, PluginText, RequestParams } from '@muxr/contract';
+import type { PluginManifestV1, PluginScreenButtonNode, PluginScreenContribution, PluginScreenNode, PluginScreenRowAction, PluginScreenRowNode, PluginScreenTreeNode, PluginSource, PluginText, RequestParams } from '@muxr/contract';
 import { MAX_SCREEN_LIST_ROWS, PLUGIN_CALL_CLIENT_TIMEOUT_MS, capUtf8Bytes, defaultPluginText, sanitizeDisplayText } from '@muxr/contract';
-import type { Theme } from '@/theme';
 import { Switch } from '@/components/Switch';
 import { hapticsError, hapticsSelection, hapticsSuccess } from '@/components/haptics';
 import { NavigableDiff } from '@/components/diff/NavigableDiff';
@@ -23,12 +20,12 @@ import { toneColor } from './pluginTone';
 import { bindText, initialFieldValues, loadScreenData, resolvePath, runScreenButton, sharedPluginWriteKeys, shouldReloadAfterAction, type ScreenFieldValues } from './screenModel';
 import { resolvePluginText } from './pluginText';
 import { asScreenTree, type RuntimeTreeItem } from './screenTreeModel';
-import { asChartSeries, type PluginChartItem } from './chartModel';
 import { fileIcon, folderIcon, type FileIcon } from './fileIcon';
 import { t } from '@/text';
 import { boundText } from '@/utils/boundedText';
 import { Typography } from '@/constants/Typography';
 import { cardStyle, Meter, SectionLabel, ui, withAlpha } from '@/components/ui';
+import { DeclarativeScreenChart } from './DeclarativeScreenChart';
 
 /** Screen payloads survive a close: reopening renders at once, then refreshes. */
 const screenCache = new Map<string, unknown>();
@@ -37,74 +34,6 @@ registerPluginDataCacheInvalidator((pluginIds) => {
     else for (const pluginId of pluginIds) clearPluginCache(screenCache, pluginId);
 });
 
-/** Chart fills: untoned series get the accent, never a per-index rainbow. */
-function chartFill(theme: Theme, tone: PluginScreenTone | undefined): string {
-    return tone === undefined ? theme.colors.accent : toneColor(theme, tone);
-}
-
-/**
- * Rank by depth of one hue, never by a categorical rainbow: borrowing the
- * status colours for slice three and four is what makes a chart look cheap, and
- * it spends red on a series that is not in trouble.
- */
-function rampFill(theme: Theme, index: number, count: number): string {
-    const step = count <= 1 ? 0 : index / (count - 1);
-    return withAlpha(theme.colors.accent, 1 - step * 0.62);
-}
-
-/**
- * Open-bottom arc, so the gap reads as the scale's start and end rather than as
- * a slice that was left out of a pie.
- */
-function GaugeArc({ ratio, size, color, track }: { ratio: number; size: number; color: string; track: string }) {
-    const reduceMotion = useReducedMotion();
-    const sweep = useSharedValue(reduceMotion ? ratio : 0);
-    React.useEffect(() => {
-        sweep.value = reduceMotion ? ratio : withTiming(ratio, { duration: 620, easing: Easing.bezier(0.23, 1, 0.32, 1) });
-    }, [ratio, reduceMotion, sweep]);
-    const stroke = size * 0.085;
-    const radius = (size - stroke) / 2;
-    const box = Skia.XYWHRect(stroke / 2, stroke / 2, radius * 2, radius * 2);
-    const START = 135;
-    const SPAN = 270;
-    const trackPath = React.useMemo(() => {
-        const path = Skia.Path.Make();
-        path.addArc(box, START, SPAN);
-        return path;
-    }, [box]);
-    const valuePath = useDerivedValue(() => {
-        const path = Skia.Path.Make();
-        path.addArc(box, START, Math.max(0.001, SPAN * sweep.value));
-        return path;
-    });
-    return (
-        <Canvas style={{ width: size, height: size }}>
-            <Path path={trackPath} color={track} style="stroke" strokeWidth={stroke} strokeCap="round" />
-            <Path path={valuePath} color={color} style="stroke" strokeWidth={stroke} strokeCap="round" />
-        </Canvas>
-    );
-}
-
-function AnimatedColumn({ ratio, color, track, delay }: { ratio: number; color: string; track: string; delay: number }) {
-    const reduceMotion = useReducedMotion();
-    const height = useSharedValue(reduceMotion ? ratio : 0);
-    React.useEffect(() => {
-        height.value = reduceMotion ? ratio : withDelay(delay, withTiming(ratio, { duration: 480, easing: Easing.bezier(0.23, 1, 0.32, 1) }));
-    }, [delay, ratio, reduceMotion, height]);
-    // Floored so an idle day stays a visible baseline instead of disappearing.
-    const animated = useAnimatedStyle(() => ({ height: `${Math.max(2, Math.min(1, height.value) * 100)}%` }));
-    // No track behind the column: seven filled boxes with lighter boxes inside
-    // read as blocks, not as a shape you can compare across days.
-    return (
-        <View style={{ width: '100%', flex: 1, justifyContent: 'flex-end' }}>
-            <Animated.View style={[{ width: '100%', borderTopLeftRadius: 3, borderTopRightRadius: 3, backgroundColor: color }, animated]} />
-        </View>
-    );
-}
-
-function chartValue(item: PluginChartItem): string {
-    return item.valueLabel ?? String(item.value);
-}
 
 /** Indeterminate 2px bar: says "working" without taking the content's place. */
 function LoadingHairline({ active }: { active: boolean }) {
@@ -340,165 +269,6 @@ function ScreenTree(props: {
     </View>;
 }
 
-/**
- * Label, number, bar, qualifier. A ranked series, a gauge and a ring all reduce
- * to this, which is why a phone can decline three desktop chart shapes and lose
- * no information: an arc and a bar encode the same scalar, and a donut's legend
- * has to reprint every value anyway.
- */
-function MeterRow({ item, ratio, emphasis, delay, hero }: { item: PluginChartItem; ratio: number; emphasis: number; delay: number; hero?: boolean }) {
-    const { theme } = useUnistyles();
-    return (
-        <View>
-            <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 5 }}>
-                <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 13, flex: 1, marginRight: 12 }}>{item.label}</Text>
-                <Text style={{ color: item.tone === undefined || item.tone === 'secondary' ? theme.colors.text : toneColor(theme, item.tone), fontSize: hero === true ? 20 : 12.5, letterSpacing: hero === true ? -0.4 : 0, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>
-                {item.detail !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 11.5, marginLeft: 8, ...Typography.mono('regular') }}>{item.detail}</Text>}
-            </View>
-            <Meter ratio={ratio} emphasis={emphasis} delay={delay} />
-        </View>
-    );
-}
-
-function ScreenChart({ node, data, nested }: { node: PluginScreenChartNode; data: unknown; nested: boolean }) {
-    const { theme } = useUnistyles();
-    const reduceMotion = useReducedMotion();
-    // The plugin declares what the number means; this decides what it can look
-    // like at this width. An arc and a donut are dashboard shapes, and a phone
-    // is not a dashboard.
-    // ponytail: window width, not the card's. Plugin screens own the content
-    // area today; measure the card with onLayout if one ever renders in a
-    // narrow column on a wide screen.
-    const wide = useWindowDimensions().width >= 700;
-    const series = asChartSeries(resolvePath(data, node.path));
-    const title = node.title === undefined ? undefined : bindText(resolvePluginText(node.title), data);
-    const empty = node.emptyText === undefined ? t('plugins.nothingToShow') : bindText(resolvePluginText(node.emptyText), data);
-    // Empty says so in one quiet line. A full card drawn around "nothing yet"
-    // spends the same space as real data. Inside a section the owning title
-    // already carries the context, so an empty chart leaves no trace at all.
-    if (series.length === 0 && nested && title !== undefined) return null;
-    if (series.length === 0) return <View style={{ marginBottom: nested ? 8 : 14 }}>
-        {title !== undefined && <SectionLabel style={{ marginBottom: 4, marginTop: nested ? 10 : 0 }}>{title}</SectionLabel>}
-        <Text style={{ color: theme.colors.textSecondary, fontSize: 13 }}>{empty}</Text>
-    </View>;
-    const total = series.reduce((sum, item) => sum + item.value, 0);
-    const summary = `${title ?? 'Chart'}: ${series.map((item) => `${item.label} ${node.variant === 'ring' ? `${Math.round(item.value / total * 100)} percent` : chartValue(item)}${item.detail === undefined ? '' : ` ${item.detail}`}`).join(', ')}`;
-    const card: ViewStyle = nested
-        ? { marginBottom: 4 }
-        : { ...cardStyle(theme), marginBottom: 14, padding: 16 };
-    const heading = title === undefined ? null : (
-        <SectionLabel style={{ marginBottom: 12, marginTop: nested ? 10 : 0 }}>{title}</SectionLabel>
-    );
-
-    // One value against its ceiling. A two-slice donut says the same thing with
-    // a second slice that carries no information of its own.
-    if (node.variant === 'gauge') {
-        const hero = series[0]!;
-        const ratio = Math.max(0, Math.min(1, total === 0 ? 0 : hero.value / total));
-        return <View accessible accessibilityRole="progressbar" accessibilityLabel={summary}
-            accessibilityValue={{ min: 0, max: 100, now: Math.round(ratio * 100) }} style={card}>
-            {heading}
-            {!wide && <MeterRow item={hero} ratio={ratio} emphasis={1} delay={0} hero />}
-            {wide && <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16 }}>
-                {/* The arc is the picture and the number beside it is the
-                    value; printing it inside the arc as well said it twice. */}
-                <View style={{ width: 84, height: 84 }}>
-                    <GaugeArc ratio={ratio} size={84} color={theme.colors.accent} track={withAlpha(theme.colors.accent, 0.1)} />
-                </View>
-                <View style={{ flex: 1, minWidth: 0 }}>
-                    <SectionLabel numberOfLines={1}>{hero.label}</SectionLabel>
-                    <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 28, letterSpacing: -0.8, marginTop: 2, ...Typography.mono('semiBold') }}>{chartValue(hero)}</Text>
-                    {hero.detail !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12, marginTop: 2, ...Typography.mono('regular') }}>{hero.detail}</Text>}
-                </View>
-            </View>}
-        </View>;
-    }
-
-    // Time reads left to right. Ranking a series of days destroys the shape.
-    if (node.variant === 'column') {
-        const peak = Math.max(...series.map((item) => item.value));
-        const last = series.length - 1;
-        const peakIndex = series.findIndex((item) => item.value === peak);
-        return <View accessible accessibilityRole="image" accessibilityLabel={summary} style={card}>
-            {heading}
-            <View style={{ flexDirection: 'row', alignItems: 'flex-end', height: wide ? 104 : 64, gap: 6 }}>
-                {series.map((item, index) => (
-                    <View key={`${item.label}-${index}`} style={{ flex: 1, alignItems: 'center', justifyContent: 'flex-end', height: '100%' }}>
-                        {(index === last || index === peakIndex) && <Text numberOfLines={1} style={{ color: index === last ? theme.colors.text : theme.colors.textSecondary, fontSize: 11, marginBottom: 4, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>}
-                        <AnimatedColumn ratio={peak === 0 ? 0 : item.value / peak} delay={index * 45}
-                            color={index === last ? theme.colors.accent : withAlpha(theme.colors.accent, 0.28)} track="transparent" />
-                    </View>
-                ))}
-            </View>
-            <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: theme.colors.divider }} />
-            <View style={{ flexDirection: 'row', gap: 6, marginTop: 8 }}>
-                {series.map((item, index) => (
-                    <Text key={`${item.label}-${index}-label`} numberOfLines={1}
-                        style={{ flex: 1, textAlign: 'center', color: index === last ? theme.colors.text : theme.colors.textSecondary, fontSize: 11 }}>{item.label}</Text>
-                ))}
-            </View>
-        </View>;
-    }
-    if (node.variant === 'ring') {
-        // First slice is the hero: its value/label sit in the donut center.
-        const hero = series[0]!;
-        const sliceColor = (item: PluginChartItem, index: number) => item.tone === 'secondary'
-            ? theme.colors.surfaceHighest
-            : item.tone !== undefined ? chartFill(theme, item.tone) : rampFill(theme, index, series.length);
-        const slices = series.map((item, index) => ({ label: item.label, value: item.value, color: sliceColor(item, index) }));
-        if (!wide) {
-            // The remainder slice is exactly what the empty part of a meter
-            // already draws, so used/left collapses to a single row.
-            const parts = series.filter((item) => item.tone !== 'secondary');
-            return <View accessible accessibilityRole="image" accessibilityLabel={summary} style={{ ...cardStyle(theme), marginBottom: 14, padding: 16 }}>
-                {title !== undefined && <SectionLabel style={{ marginBottom: 12 }}>{title}</SectionLabel>}
-                <View style={{ gap: 12 }}>
-                    {parts.map((item, index) => (
-                        <MeterRow key={`${item.label}-${index}`} item={item} ratio={total === 0 ? 0 : item.value / total}
-                            emphasis={1 - index * 0.18} delay={index * 45} hero={parts.length === 1} />
-                    ))}
-                </View>
-            </View>;
-        }
-        return <View accessible accessibilityRole="image" accessibilityLabel={summary}
-            style={{ ...cardStyle(theme), marginBottom: 14, padding: 16 }}>
-            {title !== undefined && <SectionLabel style={{ marginBottom: 12 }}>{title}</SectionLabel>}
-            <View style={{ alignItems: 'center' }}>
-                <View style={{ width: 132, height: 132 }}>
-                    <PolarChart data={slices} labelKey="label" valueKey="value" colorKey="color" containerStyle={{ width: 132, height: 132 }}>
-                        <Pie.Chart innerRadius="74%" startAngle={-90}>
-                            {() => <Pie.Slice {...(reduceMotion ? {} : { animate: { type: 'timing', duration: 500, easing: Easing.bezier(0.23, 1, 0.32, 1) } })} />}
-                        </Pie.Chart>
-                    </PolarChart>
-                    <View pointerEvents="none" style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, alignItems: 'center', justifyContent: 'center' }}>
-                        <Text style={{ color: theme.colors.text, fontSize: 24, letterSpacing: -0.5, ...Typography.mono('semiBold') }}>{chartValue(hero)}</Text>
-                        <Text style={{ color: theme.colors.textSecondary, fontSize: 11, marginTop: 1 }}>{hero.label}</Text>
-                    </View>
-                </View>
-            </View>
-            {/* Two slices are Left/Used: the centre already names both. */}
-            {series.length >= 3 && <View style={{ marginTop: 14 }}>
-                {series.map((item, index) => (
-                    <View key={`${item.label}-${index}-legend`} style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 4 }}>
-                        <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: sliceColor(item, index) }} />
-                        <Text numberOfLines={1} style={{ flex: 1, color: theme.colors.textSecondary, fontSize: 12 }}>{item.label}</Text>
-                        <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 12, ...Typography.mono('regular') }}>{chartValue(item)}</Text>
-                    </View>
-                ))}
-            </View>}
-        </View>;
-    }
-    const max = Math.max(...series.map((item) => item.value));
-    return <View style={card} accessible accessibilityRole="image" accessibilityLabel={summary}>
-        {heading}
-        <View style={{ gap: 12 }}>
-            {series.map((item, index) => (
-                <MeterRow key={`${item.label}-${index}`} item={item} ratio={max === 0 ? 0 : item.value / max}
-                    emphasis={1 - index * 0.18} delay={index * 45} />
-            ))}
-        </View>
-    </View>;
-}
 
 function ScreenTextField(props: { label: string; value: string; placeholder?: string; onChangeText: (next: string) => void }) {
     const { theme } = useUnistyles();
@@ -627,7 +397,7 @@ function ScreenNode(props: {
             );
         }
         case 'chart':
-            return <ScreenChart node={node} data={data} nested={props.nested === true} />;
+            return <DeclarativeScreenChart node={node} data={data} nested={props.nested === true} />;
         case 'divider':
             return <View style={{ height: 1, backgroundColor: theme.colors.divider, marginVertical: 12 }} />;
         case 'empty':

--- a/apps/mobile/sources/plugins/DeclarativeScreenChart.tsx
+++ b/apps/mobile/sources/plugins/DeclarativeScreenChart.tsx
@@ -1,0 +1,260 @@
+import * as React from 'react';
+import { StyleSheet, Text, View, useWindowDimensions, type ViewStyle } from 'react-native';
+import { Canvas, Path, Skia } from '@shopify/react-native-skia';
+import type { PluginScreenChartNode, PluginScreenTone } from '@muxr/contract';
+import { PolarChart, Pie } from 'victory-native';
+import Animated, {
+    Easing,
+    useAnimatedStyle,
+    useDerivedValue,
+    useReducedMotion,
+    useSharedValue,
+    withDelay,
+    withTiming,
+} from 'react-native-reanimated';
+import { useUnistyles } from 'react-native-unistyles';
+import { Meter, SectionLabel, cardStyle, withAlpha } from '@/components/ui';
+import { Typography } from '@/constants/Typography';
+import { t } from '@/text';
+import type { Theme } from '@/theme';
+import { asChartSeries, type PluginChartItem } from './chartModel';
+import { toneColor } from './pluginTone';
+import { bindText, resolvePath } from './screenModel';
+import { resolvePluginText } from './pluginText';
+
+/** Chart fills: untoned series get the accent, never a per-index rainbow. */
+function chartFill(theme: Theme, tone: PluginScreenTone | undefined): string {
+    return tone === undefined ? theme.colors.accent : toneColor(theme, tone);
+}
+
+/**
+ * Rank by depth of one hue, never by a categorical rainbow: borrowing the
+ * status colours for slice three and four is what makes a chart look cheap, and
+ * it spends red on a series that is not in trouble.
+ */
+function rampFill(theme: Theme, index: number, count: number): string {
+    const step = count <= 1 ? 0 : index / (count - 1);
+    return withAlpha(theme.colors.accent, 1 - step * 0.62);
+}
+
+/**
+ * Open-bottom arc, so the gap reads as the scale's start and end rather than as
+ * a slice that was left out of a pie.
+ */
+function GaugeArc({ ratio, size, color, track }: { ratio: number; size: number; color: string; track: string }) {
+    const reduceMotion = useReducedMotion();
+    const sweep = useSharedValue(reduceMotion ? ratio : 0);
+    React.useEffect(() => {
+        sweep.value = reduceMotion ? ratio : withTiming(ratio, { duration: 620, easing: Easing.bezier(0.23, 1, 0.32, 1) });
+    }, [ratio, reduceMotion, sweep]);
+    const stroke = size * 0.085;
+    const radius = (size - stroke) / 2;
+    const box = Skia.XYWHRect(stroke / 2, stroke / 2, radius * 2, radius * 2);
+    const START = 135;
+    const SPAN = 270;
+    const trackPath = React.useMemo(() => {
+        const path = Skia.Path.Make();
+        path.addArc(box, START, SPAN);
+        return path;
+    }, [box]);
+    const valuePath = useDerivedValue(() => {
+        const path = Skia.Path.Make();
+        path.addArc(box, START, Math.max(0.001, SPAN * sweep.value));
+        return path;
+    });
+    return (
+        <Canvas style={{ width: size, height: size }}>
+            <Path path={trackPath} color={track} style="stroke" strokeWidth={stroke} strokeCap="round" />
+            <Path path={valuePath} color={color} style="stroke" strokeWidth={stroke} strokeCap="round" />
+        </Canvas>
+    );
+}
+
+function AnimatedColumn({ ratio, color, delay }: { ratio: number; color: string; delay: number }) {
+    const reduceMotion = useReducedMotion();
+    const height = useSharedValue(reduceMotion ? ratio : 0);
+    React.useEffect(() => {
+        height.value = reduceMotion ? ratio : withDelay(delay, withTiming(ratio, { duration: 480, easing: Easing.bezier(0.23, 1, 0.32, 1) }));
+    }, [delay, ratio, reduceMotion, height]);
+    // Floored so an idle day stays a visible baseline instead of disappearing.
+    const animated = useAnimatedStyle(() => ({ height: `${Math.max(2, Math.min(1, height.value) * 100)}%` }));
+    // No track behind the column: seven filled boxes with lighter boxes inside
+    // read as blocks, not as a shape you can compare across days.
+    return (
+        <View style={{ width: '100%', flex: 1, justifyContent: 'flex-end' }}>
+            <Animated.View style={[{ width: '100%', borderTopLeftRadius: 3, borderTopRightRadius: 3, backgroundColor: color }, animated]} />
+        </View>
+    );
+}
+
+function chartValue(item: PluginChartItem): string {
+    return item.valueLabel ?? String(item.value);
+}
+
+/**
+ * Label, number, bar, qualifier. A ranked series, a gauge and a ring all reduce
+ * to this, which is why a phone can decline three desktop chart shapes and lose
+ * no information: an arc and a bar encode the same scalar, and a donut's legend
+ * has to reprint every value anyway.
+ */
+function MeterRow({ item, ratio, emphasis, delay, hero }: { item: PluginChartItem; ratio: number; emphasis: number; delay: number; hero?: boolean }) {
+    const { theme } = useUnistyles();
+    return (
+        <View>
+            <View style={{ flexDirection: 'row', alignItems: 'baseline', marginBottom: 5 }}>
+                <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 13, flex: 1, marginRight: 12 }}>{item.label}</Text>
+                <Text style={{ color: item.tone === undefined || item.tone === 'secondary' ? theme.colors.text : toneColor(theme, item.tone), fontSize: hero === true ? 20 : 12.5, letterSpacing: hero === true ? -0.4 : 0, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>
+                {item.detail !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 11.5, marginLeft: 8, ...Typography.mono('regular') }}>{item.detail}</Text>}
+            </View>
+            <Meter ratio={ratio} emphasis={emphasis} delay={delay} />
+        </View>
+    );
+}
+
+export function DeclarativeScreenChart({
+    node,
+    data,
+    nested,
+}: {
+    node: PluginScreenChartNode;
+    data: unknown;
+    nested: boolean;
+}) {
+    const { theme } = useUnistyles();
+    const reduceMotion = useReducedMotion();
+    // The plugin declares what the number means; this decides what it can look
+    // like at this width. An arc and a donut are dashboard shapes, and a phone
+    // is not a dashboard.
+    // ponytail: window width, not the card's. Plugin screens own the content
+    // area today; measure the card with onLayout if one ever renders in a
+    // narrow column on a wide screen.
+    const wide = useWindowDimensions().width >= 700;
+    const series = asChartSeries(resolvePath(data, node.path));
+    const title = node.title === undefined ? undefined : bindText(resolvePluginText(node.title), data);
+    const empty = node.emptyText === undefined ? t('plugins.nothingToShow') : bindText(resolvePluginText(node.emptyText), data);
+    // Empty says so in one quiet line. A full card drawn around "nothing yet"
+    // spends the same space as real data. Inside a section the owning title
+    // already carries the context, so an empty chart leaves no trace at all.
+    if (series.length === 0 && nested && title !== undefined) return null;
+    if (series.length === 0) return <View style={{ marginBottom: nested ? 8 : 14 }}>
+        {title !== undefined && <SectionLabel style={{ marginBottom: 4, marginTop: nested ? 10 : 0 }}>{title}</SectionLabel>}
+        <Text style={{ color: theme.colors.textSecondary, fontSize: 13 }}>{empty}</Text>
+    </View>;
+    const total = series.reduce((sum, item) => sum + item.value, 0);
+    const summary = `${title ?? 'Chart'}: ${series.map((item) => `${item.label} ${node.variant === 'ring' ? `${Math.round(item.value / total * 100)} percent` : chartValue(item)}${item.detail === undefined ? '' : ` ${item.detail}`}`).join(', ')}`;
+    const card: ViewStyle = nested
+        ? { marginBottom: 4 }
+        : { ...cardStyle(theme), marginBottom: 14, padding: 16 };
+    const heading = title === undefined ? null : (
+        <SectionLabel style={{ marginBottom: 12, marginTop: nested ? 10 : 0 }}>{title}</SectionLabel>
+    );
+
+    // One value against its ceiling. A two-slice donut says the same thing with
+    // a second slice that carries no information of its own.
+    if (node.variant === 'gauge') {
+        const hero = series[0]!;
+        const ratio = Math.max(0, Math.min(1, total === 0 ? 0 : hero.value / total));
+        return <View accessible accessibilityRole="progressbar" accessibilityLabel={summary}
+            accessibilityValue={{ min: 0, max: 100, now: Math.round(ratio * 100) }} style={card}>
+            {heading}
+            {!wide && <MeterRow item={hero} ratio={ratio} emphasis={1} delay={0} hero />}
+            {wide && <View style={{ flexDirection: 'row', alignItems: 'center', gap: 16 }}>
+                {/* The arc is the picture and the number beside it is the
+                    value; printing it inside the arc as well said it twice. */}
+                <View style={{ width: 84, height: 84 }}>
+                    <GaugeArc ratio={ratio} size={84} color={theme.colors.accent} track={withAlpha(theme.colors.accent, 0.1)} />
+                </View>
+                <View style={{ flex: 1, minWidth: 0 }}>
+                    <SectionLabel numberOfLines={1}>{hero.label}</SectionLabel>
+                    <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 28, letterSpacing: -0.8, marginTop: 2, ...Typography.mono('semiBold') }}>{chartValue(hero)}</Text>
+                    {hero.detail !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12, marginTop: 2, ...Typography.mono('regular') }}>{hero.detail}</Text>}
+                </View>
+            </View>}
+        </View>;
+    }
+
+    // Time reads left to right. Ranking a series of days destroys the shape.
+    if (node.variant === 'column') {
+        const peak = Math.max(...series.map((item) => item.value));
+        const last = series.length - 1;
+        const peakIndex = series.findIndex((item) => item.value === peak);
+        return <View accessible accessibilityRole="image" accessibilityLabel={summary} style={card}>
+            {heading}
+            <View style={{ flexDirection: 'row', alignItems: 'flex-end', height: wide ? 104 : 64, gap: 6 }}>
+                {series.map((item, index) => (
+                    <View key={`${item.label}-${index}`} style={{ flex: 1, alignItems: 'center', justifyContent: 'flex-end', height: '100%' }}>
+                        {(index === last || index === peakIndex) && <Text numberOfLines={1} style={{ color: index === last ? theme.colors.text : theme.colors.textSecondary, fontSize: 11, marginBottom: 4, ...Typography.mono('semiBold') }}>{chartValue(item)}</Text>}
+                        <AnimatedColumn ratio={peak === 0 ? 0 : item.value / peak} delay={index * 45}
+                            color={index === last ? theme.colors.accent : withAlpha(theme.colors.accent, 0.28)} />
+                    </View>
+                ))}
+            </View>
+            <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: theme.colors.divider }} />
+            <View style={{ flexDirection: 'row', gap: 6, marginTop: 8 }}>
+                {series.map((item, index) => (
+                    <Text key={`${item.label}-${index}-label`} numberOfLines={1}
+                        style={{ flex: 1, textAlign: 'center', color: index === last ? theme.colors.text : theme.colors.textSecondary, fontSize: 11 }}>{item.label}</Text>
+                ))}
+            </View>
+        </View>;
+    }
+    if (node.variant === 'ring') {
+        // First slice is the hero: its value/label sit in the donut center.
+        const hero = series[0]!;
+        const sliceColor = (item: PluginChartItem, index: number) => item.tone === 'secondary'
+            ? theme.colors.surfaceHighest
+            : item.tone !== undefined ? chartFill(theme, item.tone) : rampFill(theme, index, series.length);
+        const slices = series.map((item, index) => ({ label: item.label, value: item.value, color: sliceColor(item, index) }));
+        if (!wide) {
+            // The remainder slice is exactly what the empty part of a meter
+            // already draws, so used/left collapses to a single row.
+            const parts = series.filter((item) => item.tone !== 'secondary');
+            return <View accessible accessibilityRole="image" accessibilityLabel={summary} style={{ ...cardStyle(theme), marginBottom: 14, padding: 16 }}>
+                {title !== undefined && <SectionLabel style={{ marginBottom: 12 }}>{title}</SectionLabel>}
+                <View style={{ gap: 12 }}>
+                    {parts.map((item, index) => (
+                        <MeterRow key={`${item.label}-${index}`} item={item} ratio={total === 0 ? 0 : item.value / total}
+                            emphasis={1 - index * 0.18} delay={index * 45} hero={parts.length === 1} />
+                    ))}
+                </View>
+            </View>;
+        }
+        return <View accessible accessibilityRole="image" accessibilityLabel={summary}
+            style={{ ...cardStyle(theme), marginBottom: 14, padding: 16 }}>
+            {title !== undefined && <SectionLabel style={{ marginBottom: 12 }}>{title}</SectionLabel>}
+            <View style={{ alignItems: 'center' }}>
+                <View style={{ width: 132, height: 132 }}>
+                    <PolarChart data={slices} labelKey="label" valueKey="value" colorKey="color" containerStyle={{ width: 132, height: 132 }}>
+                        <Pie.Chart innerRadius="74%" startAngle={-90}>
+                            {() => <Pie.Slice {...(reduceMotion ? {} : { animate: { type: 'timing', duration: 500, easing: Easing.bezier(0.23, 1, 0.32, 1) } })} />}
+                        </Pie.Chart>
+                    </PolarChart>
+                    <View pointerEvents="none" style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, alignItems: 'center', justifyContent: 'center' }}>
+                        <Text style={{ color: theme.colors.text, fontSize: 24, letterSpacing: -0.5, ...Typography.mono('semiBold') }}>{chartValue(hero)}</Text>
+                        <Text style={{ color: theme.colors.textSecondary, fontSize: 11, marginTop: 1 }}>{hero.label}</Text>
+                    </View>
+                </View>
+            </View>
+            {/* Two slices are Left/Used: the centre already names both. */}
+            {series.length >= 3 && <View style={{ marginTop: 14 }}>
+                {series.map((item, index) => (
+                    <View key={`${item.label}-${index}-legend`} style={{ flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 4 }}>
+                        <View style={{ width: 8, height: 8, borderRadius: 4, backgroundColor: sliceColor(item, index) }} />
+                        <Text numberOfLines={1} style={{ flex: 1, color: theme.colors.textSecondary, fontSize: 12 }}>{item.label}</Text>
+                        <Text numberOfLines={1} style={{ color: theme.colors.text, fontSize: 12, ...Typography.mono('regular') }}>{chartValue(item)}</Text>
+                    </View>
+                ))}
+            </View>}
+        </View>;
+    }
+    const max = Math.max(...series.map((item) => item.value));
+    return <View style={card} accessible accessibilityRole="image" accessibilityLabel={summary}>
+        {heading}
+        <View style={{ gap: 12 }}>
+            {series.map((item, index) => (
+                <MeterRow key={`${item.label}-${index}`} item={item} ratio={max === 0 ? 0 : item.value / max}
+                    emphasis={1 - index * 0.18} delay={index * 45} />
+            ))}
+        </View>
+    </View>;
+}

--- a/apps/mobile/sources/plugins/primitiveRegistry.tsx
+++ b/apps/mobile/sources/plugins/primitiveRegistry.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { PRIMITIVE_SPECS, type PluginNativeContribution, type PluginNativeSlot, type PluginPrimitive } from '@muxr/contract';
-import type { PluginSlotContexts } from './slotTypes';
+import { PRIMITIVE_SPECS, type PluginPrimitive } from '@muxr/contract';
+import type { PrimitiveProps } from './primitiveTypes';
 import { CapabilityButton } from './primitives/CapabilityButton';
 import { CollectionView } from './primitives/CollectionView';
 import { RealtimeSessionOverlay } from './primitives/RealtimeSessionOverlay';
@@ -8,12 +8,6 @@ import { DictateButton } from './primitives/DictateButton';
 import { TreeSheet } from './primitives/TreeSheet';
 import { ItemList } from './primitives/ItemList';
 
-export type PrimitiveProps = {
-    pluginId: string;
-    manifestHash: string;
-    contribution: PluginNativeContribution;
-    context: PluginSlotContexts[PluginNativeSlot];
-};
 
 type PrimitiveRenderer = (props: PrimitiveProps) => React.ReactNode;
 

--- a/apps/mobile/sources/plugins/primitiveTypes.ts
+++ b/apps/mobile/sources/plugins/primitiveTypes.ts
@@ -1,0 +1,9 @@
+import type { PluginNativeContribution, PluginNativeSlot } from '@muxr/contract';
+import type { PluginSlotContexts } from './slotTypes';
+
+export type PrimitiveProps = {
+    pluginId: string;
+    manifestHash: string;
+    contribution: PluginNativeContribution;
+    context: PluginSlotContexts[PluginNativeSlot];
+};

--- a/apps/mobile/sources/plugins/primitives/CapabilityButton.tsx
+++ b/apps/mobile/sources/plugins/primitives/CapabilityButton.tsx
@@ -5,7 +5,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import { useRealtimeSessionState } from '@/realtime/realtimeSessionState';
 import { RealtimeGlyph } from '@/realtime/RealtimeGlyph';
 import { withAlpha } from '@/components/ui';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { capabilityFor } from '../capabilityRegistry';
 import { resolvePluginText } from '../pluginText';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/CollectionView.tsx
+++ b/apps/mobile/sources/plugins/primitives/CollectionView.tsx
@@ -12,7 +12,7 @@ import { StatusDot } from '@/components/StatusDot';
 import { Typography } from '@/constants/Typography';
 import { layout } from '@/components/layout';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { asPluginCollection, type PluginCollectionGroup, type PluginCollectionItem } from '../collectionModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/DictateButton.tsx
+++ b/apps/mobile/sources/plugins/primitives/DictateButton.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useUnistyles } from 'react-native-unistyles';
 import { BubblePressable } from '@/components/BubblePressable';
 import { useDictation } from '@/utils/dictation';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { t } from '@/text';
 
 export function DictateButton({ context }: PrimitiveProps) {

--- a/apps/mobile/sources/plugins/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/primitives/ItemList.tsx
@@ -11,7 +11,7 @@ import { Modal } from '@/modal';
 import { sync } from '@/sync/sync';
 import { Typography } from '@/constants/Typography';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { asPluginItemList, type PluginItemListAction, type PluginItemListItem, type PluginItemListModel } from '../itemListModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
+++ b/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
@@ -9,7 +9,7 @@ import { sync } from '@/sync/sync';
 import { OptionSheet } from '@/components/OptionSheet';
 import { StatusDot } from '@/components/StatusDot';
 import { hapticsError, hapticsLight } from '@/components/haptics';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import type { PluginSlotContexts } from '../slotTypes';
 import { asPluginTree, type PluginTreeNode } from '../treeModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';

--- a/apps/mobile/sources/sync/serverConfig.ts
+++ b/apps/mobile/sources/sync/serverConfig.ts
@@ -4,32 +4,3 @@ import { DEFAULT_CONNECTION } from '../state/connectionSettings';
 export function getServerUrl(): string {
     return relayControlUrl(DEFAULT_CONNECTION.relayUrl);
 }
-
-export function setServerUrl(_url: string | null): void {}
-
-export function getLogServerUrl(): string | null {
-    return null;
-}
-
-export function setLogServerUrl(_url: string | null): void {}
-
-export function isUsingCustomServer(): boolean {
-    return false;
-}
-
-export function getServerInfo(): { hostname: string; port?: number; isCustom: boolean } {
-    try {
-        const parsed = new URL(getServerUrl());
-        return {
-            hostname: parsed.hostname,
-            port: parsed.port ? Number.parseInt(parsed.port, 10) : undefined,
-            isCustom: false,
-        };
-    } catch {
-        return { hostname: '127.0.0.1', port: 8792, isCustom: false };
-    }
-}
-
-export function validateServerUrl(_url: string): { valid: boolean; error?: string } {
-    return { valid: true };
-}

--- a/apps/mobile/sources/terminal/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/TerminalScreen.tsx
@@ -43,8 +43,7 @@ import { recentTerminalLinks, subscribeTerminalLinks, viewportTerminalLinks } fr
 import { openExternalUrl } from '@/utils/openExternalUrl';
 import { resolvePluginText } from '@/plugins/pluginText';
 import { randomUUID } from 'expo-crypto';
-import { getCachedConnectionSettings } from '@/state/connectionSettings';
-import { getCachedHostedGrant } from '@/state/hostedE2ee';
+import { useDeviceAuthority } from '@/hooks/useDeviceAuthority';
 
 /**
  * The floating tools trigger: a small icon inside a target big enough to hit and
@@ -85,8 +84,8 @@ function loopbackPort(url: string): number | undefined {
 
 export const TerminalScreen = React.memo((props: { id: string }) => {
     const { theme } = useUnistyles();
-    const activeGrant = Platform.OS === 'web' ? getCachedHostedGrant(getCachedConnectionSettings().machineId) : undefined;
-    const canControl = Platform.OS !== 'web' || activeGrant?.authority === 'control';
+    const { authority, loading: authorityLoading } = useDeviceAuthority();
+    const canControl = authority === 'control' && !authorityLoading;
     const insets = useSafeAreaInsets();
     // Keyboard height already covers the home indicator, so keeping the bottom
     // inset while it is up double-pads the composer.

--- a/apps/mobile/sources/utils/consoleLogging.ts
+++ b/apps/mobile/sources/utils/consoleLogging.ts
@@ -11,26 +11,24 @@
  * ├─ consoleOutputEnabled = true? (default for dev/preview, or toggled on)
  * │  ├─ call original console method ✅
  * │  ├─ capture to in-app buffer ✅
- * │  └─ send to remote log server (if configured) ✅
  * │
  * └─ console.error / console.warn (always, regardless of flag)
  *    ├─ call original console method ✅
  *    ├─ capture to in-app buffer ✅
- *    └─ send to remote log server (if configured) ✅
  */
 
 import { log } from '@/log';
 import { MAX_APP_LOG_ENTRIES } from '@/log';
-import { getLogServerUrl } from '@/sync/serverConfig';
 import { loadLocalSettings } from '@/sync/persistence';
 import { loadAppConfig } from '@/sync/appConfig';
-import { Platform } from 'react-native';
 import { serializeForLogs } from '@/utils/truncateForLogs';
 
-let logBuffer: any[] = []
+type ConsoleLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
+type ConsoleLogEntry = { timestamp: string; level: ConsoleLevel; message: string };
+
+let logBuffer: ConsoleLogEntry[] = []
 const MAX_BUFFER_SIZE = MAX_APP_LOG_ENTRIES
 let isConsolePatched = false
-let remoteLogServerUrl: string | null = null
 let consoleOutputEnabled = false
 let originalConsole: {
   log: typeof console.log,
@@ -52,7 +50,6 @@ export function initConsoleLogging() {
     return
   }
 
-  remoteLogServerUrl = getLogServerUrl();
 
   // Determine initial state: user setting > build variant default > off
   try {
@@ -73,7 +70,7 @@ export function initConsoleLogging() {
 
   log.setConsoleCaptureEnabled(true)
 
-  function formatArgs(args: any[]): string {
+  function formatArgs(args: unknown[]): string {
     return args.map(a => {
       if (a === null || a === undefined) return String(a)
       if (typeof a !== 'object') return serializeForLogs(a)
@@ -81,29 +78,12 @@ export function initConsoleLogging() {
     }).join(' ')
   }
 
-  function sendLog(level: string, formatted: string) {
-    if (!remoteLogServerUrl) {
-      return
-    }
-
-    void fetch(remoteLogServerUrl + '/logs', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        timestamp: new Date().toISOString(),
-        level,
-        message: formatted,
-        source: 'mobile',
-        platform: Platform.OS,
-      })
-    }).catch(() => {})
-  }
 
   // Patch console methods
   ;(['log', 'info', 'warn', 'error', 'debug'] as const).forEach(level => {
     const alwaysPassThrough = level === 'error' || level === 'warn'
 
-    console[level] = (...args: any[]) => {
+    console[level] = (...args: unknown[]) => {
       // Full short-circuit: when off, skip everything for log/info/debug
       if (!consoleOutputEnabled && !alwaysPassThrough) {
         return
@@ -126,7 +106,6 @@ export function initConsoleLogging() {
         logBuffer.shift()
       }
 
-      sendLog(level, formatted)
     }
   })
 

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -143,6 +143,7 @@ export {
     PRIMITIVE_SPECS,
     PLUGIN_CONTEXT_REQUESTS,
     capUtf8Bytes,
+    boundRpcDisplay,
     pluginCompatibilityError,
     sanitizeDisplayText,
 } from './plugins.js';

--- a/packages/contract/src/manifest.ts
+++ b/packages/contract/src/manifest.ts
@@ -14,7 +14,6 @@ import type {
     PluginScreenButtonNode,
     PluginScreenContribution,
     PluginScreenNode,
-    PluginScreenRowAction,
     PluginScreenRowNode,
     PluginScreenTone,
 } from './plugins.js';
@@ -306,7 +305,7 @@ function parseScreenNode(item: Record<string, unknown>, depth: number, budget: {
                         ? { type: 'plugin.call' as const, contributionId: id(item.source.contributionId) }
                         : (() => { throw new Error('invalid plugin screen tree source'); })(),
                 }),
-                ...(item.action === undefined ? {} : { action: parseScreenRowAction(item.action) }),
+                ...(item.action === undefined ? {} : { action: parsePluginAction(item.action) }),
             };
         case 'list': {
             if (!Array.isArray(item.rows) || item.rows.length > MAX_ROWS) throw new Error('invalid plugin screen list rows');
@@ -340,13 +339,10 @@ function parseScreenRow(row: Record<string, unknown>): PluginScreenRowNode {
         title: pluginText(row.title, 80),
         ...(row.subtitle === undefined ? {} : { subtitle: pluginText(row.subtitle, MAX_TEXT) }),
         ...(row.value === undefined ? {} : { value: pluginText(row.value, MAX_TEXT) }),
-        ...(row.action === undefined ? {} : { action: parseScreenRowAction(row.action) }),
+        ...(row.action === undefined ? {} : { action: parsePluginAction(row.action) }),
     };
 }
 
-function parseScreenRowAction(value: unknown): PluginScreenRowAction {
-    return parsePluginAction(value);
-}
 
 function actionString(value: unknown, max: number, label: string): string {
     if (typeof value !== 'string') throw new Error(`invalid plugin action ${label}`);

--- a/packages/contract/src/plugins.ts
+++ b/packages/contract/src/plugins.ts
@@ -677,6 +677,21 @@ export function sanitizeDisplayText(text: string): string {
     return text.replace(DISPLAY_CONTROL, '');
 }
 
+/** Bound and sanitize untrusted plugin results before they cross a UI boundary. */
+export function boundRpcDisplay(value: unknown, depth = 0): unknown {
+    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
+    if (value === null) return null;
+    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
+    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
+    if (typeof value !== 'object') return value;
+    const out: Record<string, unknown> = Object.create(null);
+    for (const [key, entry] of Object.entries(value)) {
+        const bounded = boundRpcDisplay(entry, depth + 1);
+        if (bounded !== undefined) out[key] = bounded;
+    }
+    return out;
+}
+
 /** v1 is deliberately tiny: one static surface and one context-bound action. */
 export interface PluginManifestV1 {
     schemaVersion: 1;

--- a/scripts/checkNoSecrets.mjs
+++ b/scripts/checkNoSecrets.mjs
@@ -32,7 +32,9 @@ const forbiddenWebLiterals = [process.env.EXPO_PUBLIC_MUXR_TOKEN]
 const findings = [];
 for (const relativePath of files) {
     const path = join(root, relativePath);
-    if (!existsSync(path) || statSync(path).size > 20 * 1024 * 1024) continue;
+    if (!existsSync(path)) continue;
+    const info = statSync(path);
+    if (!info.isFile() || info.size > 20 * 1024 * 1024) continue;
     if (/\.(?:png|jpe?g|gif|webp|wasm|lock|ico|ttf|woff2)$/.test(relativePath)) continue;
     const text = readFileSync(path, 'utf8');
     for (const [name, pattern] of patterns) {

--- a/scripts/checkPackageSmoke.mjs
+++ b/scripts/checkPackageSmoke.mjs
@@ -7,6 +7,7 @@ import {
     mkdtempSync,
     readFileSync,
     readdirSync,
+    realpathSync,
     rmSync,
     statSync,
     symlinkSync,
@@ -17,11 +18,13 @@ import { dirname, join } from 'node:path';
 import { packageInfoFromPath, packagePathFromInput } from './packageAudit.mjs';
 
 const root = process.cwd();
-const scratch = mkdtempSync(join(tmpdir(), 'muxr-package-smoke-'));
+const scratch = realpathSync(mkdtempSync(join(tmpdir(), 'muxr-package-smoke-')));
 const tarDir = join(scratch, 'tar');
 const installDir = join(scratch, 'install');
 const home = join(scratch, 'home');
 const binDir = join(scratch, 'bin');
+const psBin = existsSync('/usr/bin/ps') ? '/usr/bin/ps' : '/bin/ps';
+const canRunLinuxTtySmoke = process.platform === 'linux' && existsSync('/usr/bin/script');
 const fakeState = join(scratch, 'herdr-installed');
 const fakeServerState = join(scratch, 'herdr-server-running');
 const fakeLog = join(scratch, 'herdr.log');
@@ -102,10 +105,11 @@ function cliEnv(targetHome = home, extra = {}) {
         ...inherited,
         HOME: targetHome,
         PATH: `${binDir}:${dirname(process.execPath)}`,
-        MUXR_PS_BIN: '/usr/bin/ps',
+        MUXR_PS_BIN: psBin,
         HERDR_BIN: join(binDir, 'herdr'),
         FAKE_HERDR_STATE: fakeState,
         FAKE_HERDR_SERVER_STATE: fakeServerState,
+        MUXR_PLATFORM: 'linux',
         FAKE_HERDR_LOG: fakeLog,
         MUXR_NO_SERVICE_COMMANDS: '1',
         MUXR_SKIP_HOSTED_AUTH: '1',
@@ -121,18 +125,15 @@ function cliEnvWithoutHerdr(targetHome, extra = {}) {
 }
 
 function stopRelayFor(dataDir) {
-    const marker = `MUXR_RELAY_DATA_DIR=${dataDir}`;
-    for (const name of readdirSync('/proc')) {
-        if (!/^\d+$/.test(name)) continue;
-        try {
-            if (!readFileSync(`/proc/${name}/environ`).toString().split('\0').includes(marker)) continue;
-            process.kill(Number(name), 'SIGTERM');
-        } catch {}
-    }
+    const pidPath = join(dataDir, 'relay.pid');
+    if (!existsSync(pidPath)) return;
+    const pid = Number(readFileSync(pidPath, 'utf8').trim());
+    if (!Number.isSafeInteger(pid) || pid <= 1) return;
+    try { process.kill(pid, 'SIGTERM'); } catch {}
 }
 
 function signalNodeDescendant(parentPid) {
-    const rows = run('/usr/bin/ps', ['-eo', 'pid=,ppid=,comm=']).stdout.trim().split('\n').map((line) => {
+    const rows = run(psBin, ['-eo', 'pid=,ppid=,comm=']).stdout.trim().split('\n').map((line) => {
         const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
         return match ? { pid: Number(match[1]), parent: Number(match[2]), command: match[3] } : undefined;
     }).filter(Boolean);
@@ -151,6 +152,7 @@ function signalNodeDescendant(parentPid) {
     assert.ok(node, 'could not find the CLI node process under the test PTY');
     process.kill(node.pid, 'SIGINT');
 }
+
 
 async function runTty(command, env, inputAfter, timeoutMs = 20_000, completionMarker, scriptEcho = 'never', inputMarker = 'OpenAI API key for Live Voice') {
     assert.ok(existsSync('/usr/bin/script'), 'util-linux script is required for the Linux TTY smoke');
@@ -281,9 +283,9 @@ try {
         env: { ...process.env, npm_config_cache: join(scratch, 'npm-cache') },
     });
     const cli = join(installDir, 'node_modules', '.bin', 'muxr');
-    const installedPackage = join(installDir, 'node_modules', '@trymuxr', 'cli');
+    const installedPackage = realpathSync(join(installDir, 'node_modules', '@trymuxr', 'cli'));
     const installedPlugins = join(installedPackage, 'plugins');
-    if (existsSync('/usr/bin/script')) {
+    if (canRunLinuxTtySmoke) {
         const uiFlow = join(scratch, 'setup-ui-flow.mjs');
         writeFileSync(uiFlow, `import {withFullscreen, setupStep, outro, select} from ${JSON.stringify(`file://${join(installedPackage, 'setup-ui.mjs')}`)};\nif (process.argv[2] === 'full') await withFullscreen(async () => { setupStep(1, 5, 'Check this machine'); outro('Setup receipt'); return 0; });\nelse await withFullscreen(async () => { await select('Choose connection', [{value:'lan',title:'LAN',description:'same network'}]); return 0; });\n`);
         const fullUiEnv = { ...process.env, TERM: 'xterm-256color' };
@@ -402,15 +404,17 @@ try {
     assert.ok(installedUpdate.compareVersions('1.0.0-beta.10', '1.0.0-beta.9') > 0);
     assert.ok(installedUpdate.compareVersions('1.0.0-beta.9', '1.0.0-beta.10') < 0);
     assert.ok(installedUpdate.compareVersions('1.0.0', '1.0.0-rc.1') > 0);
-    const promptSmokePath = join(scratch, 'prompt-smoke.mjs');
-    const setupUiUrl = new URL(`file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'setup-ui.mjs')}`).href;
-    writeFileSync(promptSmokePath, `import { prompt } from ${JSON.stringify(setupUiUrl)};\nconst answer = await prompt('Cancel prompt');\nif (answer !== undefined) process.exitCode = 1;\n`);
-    const promptSmoke = await runTty(`${process.execPath} ${promptSmokePath}`, cliEnv(), '\u0003', 20_000, undefined, 'never', 'Cancel prompt');
-    assert.equal(promptSmoke.code, 0, promptSmoke.output);
-    assert.doesNotMatch(promptSmoke.output, /unsettled top-level await|SyntaxError/);
-    const menuCancel = await runTty(cli, cliEnv(), '\u0003', 20_000, undefined, 'never', 'What would you like to do?');
-    assert.ok(menuCancel.code === 0 || menuCancel.code === 130, menuCancel.output);
-    assert.doesNotMatch(menuCancel.output, /Get started\s+ muxr setup/, 'cancelling the menu printed command help');
+    if (canRunLinuxTtySmoke) {
+        const promptSmokePath = join(scratch, 'prompt-smoke.mjs');
+        const setupUiUrl = new URL(`file://${join(installDir, 'node_modules', '@trymuxr', 'cli', 'setup-ui.mjs')}`).href;
+        writeFileSync(promptSmokePath, `import { prompt } from ${JSON.stringify(setupUiUrl)};\nconst answer = await prompt('Cancel prompt');\nif (answer !== undefined) process.exitCode = 1;\n`);
+        const promptSmoke = await runTty(`${process.execPath} ${promptSmokePath}`, cliEnv(), '\u0003', 20_000, undefined, 'never', 'Cancel prompt');
+        assert.equal(promptSmoke.code, 0, promptSmoke.output);
+        assert.doesNotMatch(promptSmoke.output, /unsettled top-level await|SyntaxError/);
+        const menuCancel = await runTty(cli, cliEnv(), '\u0003', 20_000, undefined, 'never', 'What would you like to do?');
+        assert.ok(menuCancel.code === 0 || menuCancel.code === 130, menuCancel.output);
+        assert.doesNotMatch(menuCancel.output, /Get started\s+ muxr setup/, 'cancelling the menu printed command help');
+    }
     const inspectHome = join(scratch, 'inspect-home');
     mkdirSync(inspectHome, { recursive: true });
     const inspectBefore = filesSnapshot(inspectHome);
@@ -528,9 +532,11 @@ try {
     const updateLog = join(scratch, 'update.log');
     writeFileSync(updateNpm, '#!/bin/sh\nif [ "$1" = view ]; then printf \'"%s"\\n\' "${MUXR_UPDATE_LATEST:-9.9.9}"; exit 0; fi\nif [ "$1 $2" = "root --global" ]; then printf "%s\\n" "$MUXR_UPDATE_NPM_ROOT"; exit 0; fi\nif [ "$1" = install ]; then printf "%s\\n" "$*" >> "$MUXR_UPDATE_LOG"; exit 0; fi\nexit 1\n', { mode: 0o755 });
     const updateEnv = { ...env, MUXR_NPM_BIN: updateNpm, MUXR_UPDATE_LOG: updateLog, MUXR_UPDATE_NPM_ROOT: join(installDir, 'node_modules') };
-    const cancelledUpdate = await runTty(`${cli} update`, updateEnv, '\r', 20_000, undefined, 'never', 'Apply this update?');
-    assert.equal(cancelledUpdate.code, 0, cancelledUpdate.output);
-    assert.ok(!existsSync(updateLog), 'pressing Enter applied the update');
+    if (canRunLinuxTtySmoke) {
+        const cancelledUpdate = await runTty(`${cli} update`, updateEnv, '\r', 20_000, undefined, 'never', 'Apply this update?');
+        assert.equal(cancelledUpdate.code, 0, cancelledUpdate.output);
+        assert.ok(!existsSync(updateLog), 'pressing Enter applied the update');
+    }
     assert.match(run(cli, ['update', '--yes'], { cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '0.0.1' } }).stdout, /newer than npm latest/);
     assert.ok(!existsSync(updateLog), 'updater installed a registry downgrade');
     assert.match(run(cli, ['update', '--check'], { cwd: installDir, env: updateEnv }).stdout, /9\.9\.9 is available/);
@@ -697,6 +703,9 @@ try {
     assert.equal(readFileSync(join(relayHome, '.config', 'systemd', 'user', 'muxr.service'), 'utf8'), relayUnitBeforeList, 'machine listing rewrote the relay service');
     relayService.kill('SIGTERM');
     await new Promise((resolve) => relayService.once('exit', resolve));
+    for (let attempt = 0; attempt < 30 && await fetch(`http://127.0.0.1:${relayServicePort}/health`).then((response) => response.ok).catch(() => false); attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
     if (await fetch(`http://127.0.0.1:${relayServicePort}/health`).then((response) => response.ok).catch(() => false)) throw new Error('relay-only service left its relay child running');
     const relayUpdateLog = join(scratch, 'relay-update.log');
     const herdrBeforeRelayUpdate = existsSync(fakeLog) ? readFileSync(fakeLog, 'utf8') : '';

--- a/scripts/packageLifecycleSmoke.mjs
+++ b/scripts/packageLifecycleSmoke.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { gzipSync } from 'node:zlib';
-import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
@@ -246,12 +246,12 @@ try {
     const outside = join(scratch, 'outside'); mkdirSync(outside);
     rmSync(extensionRoot, { recursive: true, force: true }); symlinkSync(outside, extensionRoot, 'dir');
     await assert.rejects(runPackage('install', ['npm:pkg@1.0.0', '--yes']), /extensions.*directory/);
-    rmSync(extensionRoot, { force: true }); writeFileSync(extensionRoot, 'not a directory');
+    unlinkSync(extensionRoot); writeFileSync(extensionRoot, 'not a directory');
     await assert.rejects(runPackage('install', ['npm:pkg@1.0.0', '--yes']), /extensions.*directory/);
     rmSync(extensionRoot, { force: true }); mkdirSync(extensionRoot);
     symlinkSync(outside, join(extensionRoot, '.provenance'), 'dir');
     await assert.rejects(runPackage('install', ['npm:pkg@1.0.0', '--yes']), /provenance.*directory/);
-    rmSync(join(extensionRoot, '.provenance'), { force: true }); mkdirSync(join(extensionRoot, '.provenance'));
+    unlinkSync(join(extensionRoot, '.provenance')); mkdirSync(join(extensionRoot, '.provenance'));
     rmSync(join(extensionRoot, '.locks'), { recursive: true, force: true });
     symlinkSync(outside, join(extensionRoot, '.locks'), 'dir');
     await assert.rejects(runPackage('install', ['npm:pkg@1.0.0', '--yes']), /locks.*directory/);

--- a/scripts/plugin.mjs
+++ b/scripts/plugin.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { homedir, tmpdir } from 'node:os';
 
-import { MAX_PLUGIN_CONTEXT_BYTES, MAX_RPC_ARRAY_ENTRIES, MAX_RPC_DISPLAY_DEPTH, MAX_RPC_INPUT_BYTES, MAX_RPC_RESULT_STRING_BYTES, MAX_RPC_STDOUT_BYTES, capUtf8Bytes, parseManifest, sanitizeDisplayText } from '@muxr/contract';
+import { MAX_PLUGIN_CONTEXT_BYTES, MAX_RPC_INPUT_BYTES, MAX_RPC_STDOUT_BYTES, boundRpcDisplay, parseManifest } from '@muxr/contract';
 
 const id = (value) => typeof value === 'string' && /^[a-z0-9][a-z0-9._-]{0,63}$/.test(value);
 const fail = (message) => { throw new Error(message); };
@@ -165,19 +165,6 @@ function boundedJson(value, fallback, maxBytes, label) {
     return serialized;
 }
 
-function boundRpcDisplay(value, depth = 0) {
-    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
-    if (value === null) return null;
-    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
-    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
-    if (typeof value !== 'object') return value;
-    const out = Object.create(null);
-    for (const [key, entry] of Object.entries(value)) {
-        const bounded = boundRpcDisplay(entry, depth + 1);
-        if (bounded !== undefined) out[key] = bounded;
-    }
-    return out;
-}
 
 function runRpcCall(checked, contributionId, inputJson, contextJson) {
     const rpcs = checked.manifest.contributions.filter((entry) => 'type' in entry && entry.type === 'rpc');

--- a/scripts/up.mjs
+++ b/scripts/up.mjs
@@ -79,7 +79,7 @@ let exitCode = 0;
 
 function killChildren(signal = 'SIGTERM') {
     for (const child of children) {
-        if (child.exitCode === null && !child.killed) child.kill(signal);
+        if (child.exitCode === null) child.kill(signal);
     }
 }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "thermo-nuclear-code-quality-review": {
+      "source": "cursor/plugins",
+      "sourceType": "github",
+      "skillPath": "cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md",
+      "computedHash": "9052b01b46b1d8dbf94c45f9313ec1983443f9a460e83d49cdc7fe0f640ca476"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

This is an end-to-end thermonuclear maintainability audit of the current repository, not a review of one feature diff. The audit covered the application runtimes (`mobile`, `host`, `relay`, `probe`), shared packages (`contract`, `crypto`, `wire`), bundled plugins, native mobile modules, operational/package scripts, and demo tooling: 593 source files and roughly 94k lines.

Priority order was structural correctness and ownership, then spaghetti/branching debt, then lower-impact cleanup. Risky security-sensitive decompositions remain explicitly listed below instead of being mixed into this PR without dedicated coverage.

## What changed

### Structural correctness

- Fixed process-tree shutdown escalation: a previously-signalled child was incorrectly skipped during the later `SIGKILL` pass because `ChildProcess.killed` means “a signal was sent”, not “the process exited”.
- Made package lifecycle/smoke cleanup deterministic through relay pid files, canonical temporary paths, platform-stable process discovery, Linux-only TTY checks, symlink-safe cleanup, and bounded relay shutdown waits.
- Made the tracked/package secret scanner skip non-file symlink targets instead of trying to read a linked directory.
- Canonicalized plugin executable/provenance roots before authority comparison. This fixes `/var` versus `/private/var` aliases on macOS without weakening the pinned-root invariant.

### Canonical ownership

- Moved untrusted plugin-result bounding/sanitization into `@muxr/contract`; host execution and the plugin CLI now use one implementation.
- Replaced the host’s bespoke basename implementation with `node:path`.
- Removed an identity manifest-action wrapper.
- Removed dead server-configuration setters/fallbacks and the unreachable remote-log transport they kept alive.
- Centralized generated-avatar props and hashing across all four renderers, removing four copies and `ComponentType<any>`.
- Centralized reactive device-authority policy and migrated every control-producing mobile surface to the same fail-closed hook.

### Decomposition and dependency direction

- Extracted HomeDock environment/machine/project/worktree/agent policy into `useHomeDockEnvironment`.
  - `HomeDock.tsx`: 1,150 → 937 lines.
  - Removed three unused Zustand subscriptions, dead `supportsWorktree` branches, duplicate agent-correction effects, and a one-value picker dispatcher.
- Extracted declarative chart rendering and its Skia/Victory/animation dependencies.
  - `DeclarativeScreen.tsx`: 946 → 716 lines.
- Moved primitive, markdown, and native-menu contracts into type-only modules. The audited TS/TSX/MJS relative-import graph now has zero strongly connected components; it had three cycles before this change.
- Included the installed thermonuclear audit skill and lock metadata.

## Validation

- `yarn run check`: **30/30 checks passed**.
  - workspace and mobile typechecks
  - wire build
  - 165 Vitest flows
  - crypto, host-domain, contract, relay, and layout checks
  - pairing/revocation/relay/voice/preview/Herdr/worktree E2E flows
  - package install/lifecycle smokes
  - core-purity and secret policies
- Focused `pluginCatalog.test.ts`: **19/19 passed**.
- Import-cycle scan: **0 cycles** after the type-boundary changes.
- `git diff --check`: passed.

## Remaining prioritized audit findings

These are real findings, but combining them with this PR would materially increase correctness/security risk.

### P0 — host session source is one enormous mutable closure

`apps/host/src/herdr/herdrSessionSource.ts` is 1,973 lines; `createHerdrSessionSource` spans lines 253–1973. It owns discovery projections, lifecycle epochs, status watches, attention, attachments, snapshots, agent start/stop, plugin refresh, plugin calls, streams, and the returned `SessionSource` implementation. Next change should extract projection/lifecycle and plugin execution controllers behind the existing `SessionSource` contract, with current integration flows retained.

### P0 — relay composition and self-host HTTP authority are fused

`apps/relay/src/relay.ts` is 1,097 lines; `startRelay` spans lines 115–1062. Roughly 480 lines of enrollment, tickets, pairing, grants, device revocation, push, and static-web HTTP policy sit inline with WebSocket routing and process lifetime. This is security-sensitive. Decompose by authority domain only after adding flow coverage for each extracted endpoint group; a giant context-object move would merely relocate the complexity.

### P1 — local setup is an operational monolith

`scripts/local-setup.mjs` is 2,895 lines with about 545 branch points. Installation, service repair, daemon definitions, hosted auth, self-host state, ingress, pairing, device rotation, account commands, uninstall, and doctor repairs share one module. Split around the existing command entry points and preserve state formats/atomic-write ordering.

### P1 — mobile sync admission has avoidable head-of-line blocking

`PluginExecutionGate.drain` in `apps/mobile/sources/sync/sync.ts` returns when the queue head has reached its per-plugin cap, even when an unrelated plugin behind it could use free global capacity. Fix this together with a single flow-level scheduling test and consolidation of the adjacent global-only gate; changing rate-limit scheduling without coverage does not belong in this structural PR.

### P1 — terminal and Android voice surfaces remain oversized

- `TerminalScreen.tsx`: 935 lines with one component spanning lines 86–935; terminal channel lifecycle, sibling navigation, links, attachments, gesture state, tool menus, status, and rendering are fused.
- `VoiceOverlayService.kt`: 604 lines, including a 350-line companion object combining static bridge API, notification state, and service coordination. The foreground-service-before-mic invariant makes casual decomposition unsafe.

### P2 — provider adapters duplicate a runtime

The xAI, OpenAI, and Gemini streaming plugins repeat tool declarations, prompt policy, key loading, Herdr execution, client-frame handling, audio chunking, refusal parsing, and lifecycle plumbing. Their per-plugin-root installation boundary prevents a naive sibling import. A shared runtime needs an explicit packaging/isolation design rather than copy-paste cleanup in this PR.

## Scope discipline

No feature behavior, protocol, persistence format, voice provider policy, responsive asset, or UI vocabulary was intentionally changed. The PR deletes duplicate/dead ownership, establishes focused module boundaries, and fixes issues directly demonstrated by the repository suite.