### PR TITLE
refactor: centralize shared ownership contracts

### DIFF
--- a/apps/host/src/domain/atomicWriteJson.ts
+++ b/apps/host/src/domain/atomicWriteJson.ts
@@ -1,5 +1,5 @@
 import { mkdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 /** Atomic JSON write: temp file in the same directory, then rename. */
 export async function atomicWriteJson(filePath: string, value: unknown): Promise<void> {
@@ -8,9 +8,4 @@ export async function atomicWriteJson(filePath: string, value: unknown): Promise
     const body = `${JSON.stringify(value)}\n`;
     await writeFile(tempPath, body, { encoding: 'utf8', mode: 0o600 });
     await rename(tempPath, filePath);
-}
-
-function basename(filePath: string): string {
-    const index = filePath.lastIndexOf('/');
-    return index === -1 ? filePath : filePath.slice(index + 1);
 }

--- a/apps/host/src/herdr/pluginCatalog.test.ts
+++ b/apps/host/src/herdr/pluginCatalog.test.ts
@@ -2,9 +2,9 @@ import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { pluginInvalidationFrame, PluginCatalog, PluginRefreshGate, WriteReplayFence, Semaphore, boundRpcDisplay, rpcReplayKey, runPluginProcess, type HerdrPlugin } from './pluginCatalog.js';
+import { pluginInvalidationFrame, PluginCatalog, PluginRefreshGate, WriteReplayFence, Semaphore, rpcReplayKey, runPluginProcess, type HerdrPlugin } from './pluginCatalog.js';
 import { buildPluginPublicContext } from './pluginPublicContext.js';
-import { MAX_RPC_RESULT_STRING_BYTES, parseManifest, parsePluginAction, pluginCompatibilityError } from '@muxr/contract';
+import { MAX_RPC_RESULT_STRING_BYTES, boundRpcDisplay, parseManifest, parsePluginAction, pluginCompatibilityError } from '@muxr/contract';
 
 function plugin(root: string, actions: HerdrPlugin['actions'] = []): HerdrPlugin {
     return {

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -6,14 +6,11 @@ import { homedir } from 'node:os';
 import { isAbsolute, join, relative, resolve } from 'node:path';
 import type { PluginsInvalidatedFrame, PluginContextRequest, PluginManifestV1, PluginRpcMode, PluginSource, PluginSummary } from '@muxr/contract';
 import {
-    MAX_RPC_ARRAY_ENTRIES,
-    MAX_RPC_DISPLAY_DEPTH,
-    MAX_RPC_RESULT_STRING_BYTES,
     MAX_RPC_STDERR_BYTES,
     MAX_RPC_STDOUT_BYTES,
     PLUGIN_CALL_DEADLINE_MS,
     PLUGIN_CALL_KILL_GRACE_MS,
-    capUtf8Bytes,
+    boundRpcDisplay,
     isValidPluginId,
     parseManifest,
     sanitizeDisplayText,
@@ -420,29 +417,6 @@ function safeText(value: string, max: number): string[] {
     catch { return []; }
 }
 
-/**
- * Cap every string in an RPC result before it reaches mobile. The 64 KiB stdout
- * limit bounds total transport; this bounds each transported string to the same
- * 64 KiB ceiling (never splitting a code point) and strips
- * controls/bidi/zero-width. JSON null is preserved (a null result stays a
- * successful null, and nulls survive inside arrays/objects). Subtrees past the
- * depth cap are dropped, never returned raw. Output objects are null-prototype
- * so plugin-chosen keys like `__proto__` become plain data instead of prototype
- * assignments.
- */
-export function boundRpcDisplay(value: unknown, depth = 0): unknown {
-    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
-    if (value === null) return null;
-    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
-    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
-    if (typeof value !== 'object') return value;
-    const out: Record<string, unknown> = Object.create(null);
-    for (const [key, entry] of Object.entries(value)) {
-        const bounded = boundRpcDisplay(entry, depth + 1);
-        if (bounded !== undefined) out[key] = bounded;
-    }
-    return out;
-}
 
 export interface RunPluginProcessOptions {
     pluginId: string;

--- a/apps/mobile/sources/components/Avatar.tsx
+++ b/apps/mobile/sources/components/Avatar.tsx
@@ -6,13 +6,9 @@ import { AvatarGradient } from "./AvatarGradient";
 import { AvatarBrutalist } from "./AvatarBrutalist";
 import { useSetting } from '@/sync/storage';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import type { GeneratedAvatarProps } from './generatedAvatar';
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
+interface AvatarProps extends GeneratedAvatarProps {
     flavor?: string | null;
     clientId?: string | null;
     imageUrl?: string | null;
@@ -93,7 +89,7 @@ export const Avatar = React.memo((props: AvatarProps) => {
 
     // Original generated avatar logic
     // Determine which avatar variant to render
-    let AvatarComponent: React.ComponentType<any>;
+    let AvatarComponent: React.ComponentType<GeneratedAvatarProps>;
     if (avatarStyle === 'pixelated') {
         AvatarComponent = AvatarSkia;
     } else if (avatarStyle === 'brutalist') {

--- a/apps/mobile/sources/components/AvatarBrutalist.tsx
+++ b/apps/mobile/sources/components/AvatarBrutalist.tsx
@@ -1,14 +1,8 @@
 import * as React from "react";
 import { View } from "react-native";
 import { Image } from "expo-image";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
-interface AvatarBrutalistProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const abstractImages = [
     require('@/assets/images/brutalist/Abstract-1.png'),
@@ -450,28 +444,19 @@ const colorPairs = [
     { tint: '#84E600', background: '#C026D3' }  // Lime → Magenta
 ];
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
-export const AvatarBrutalist = React.memo((props: AvatarBrutalistProps) => {
+export const AvatarBrutalist = React.memo((props: GeneratedAvatarProps) => {
     const { id, size = 32, square = false, monochrome = false } = props;
 
-    const imageIndex = hashCode(id) % allImages.length;
-    const colorIndex = hashCode(id + 'color') % colorPairs.length;
+    const imageIndex = avatarHash(id) % allImages.length;
+    const colorIndex = avatarHash(`${id}color`) % colorPairs.length;
 
     const imageSource = allImages[imageIndex];
     const colorPair = colorPairs[colorIndex];
     const tintColor = monochrome ? '#999999' : colorPair.tint;
     const backgroundColor = monochrome ? '#F0F0F0' : colorPair.background;
 
-    const dimension = square ? size : size;
+    const dimension = size;
     const borderRadius = square ? 0 : size / 2;
 
     return (

--- a/apps/mobile/sources/components/AvatarGradient.tsx
+++ b/apps/mobile/sources/components/AvatarGradient.tsx
@@ -1,16 +1,7 @@
 import * as React from "react";
 import { Image } from "expo-image";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
-// Copy hashCode function for consistency with Avatar.tsx
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 // Array of all 100 gradient images
 const gradientImages = [
@@ -116,19 +107,12 @@ const gradientImages = [
     require('@/assets/images/gradients/100.png'),
 ];
 
-interface AvatarGradientProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
-export const AvatarGradient = React.memo((props: AvatarGradientProps) => {
+export const AvatarGradient = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     
     // Use hashCode to get consistent gradient index
-    const imageIndex = hashCode(id) % 100;
+    const imageIndex = avatarHash(id) % 100;
     const gradientImage = gradientImages[imageIndex];
     
     return (

--- a/apps/mobile/sources/components/AvatarSkia.tsx
+++ b/apps/mobile/sources/components/AvatarSkia.tsx
@@ -1,18 +1,10 @@
 import * as React from "react";
 import { Canvas, Rect, Group, Skia } from "@shopify/react-native-skia";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
 const ELEMENTS = 64;
 const GRID_SIZE = 8; // 8x8 grid
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 function getRandomColor(number: number, colors?: string[], range?: number): string {
     if (colors && range) {
@@ -32,7 +24,7 @@ function hslToGrayscale(hslColor: string): string {
 }
 
 function generateColors(name: string, colors?: string[], monochrome?: boolean): string[] {
-    const numFromName = hashCode(name);
+    const numFromName = avatarHash(name);
     const range = colors?.length;
 
     const colorList = Array.from({ length: ELEMENTS }, (_, i) => {
@@ -43,18 +35,11 @@ function generateColors(name: string, colors?: string[], monochrome?: boolean): 
     return colorList;
 }
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const colors = ['#0a0310', '#49007e', '#ff005b', '#ff7d10', '#ffb238'];
 const grayscaleColors = ['#070707', '#242424', '#575757', '#979797', '#bbbbbb'];
 
-export const AvatarSkia = React.memo((props: AvatarProps) => {
+export const AvatarSkia = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     
     const defaultColors = monochrome ? grayscaleColors : colors;

--- a/apps/mobile/sources/components/AvatarSkia.web.tsx
+++ b/apps/mobile/sources/components/AvatarSkia.web.tsx
@@ -1,18 +1,10 @@
 import * as React from "react";
 import { View } from "react-native";
+import { avatarHash, type GeneratedAvatarProps } from './generatedAvatar';
 
 const ELEMENTS = 64;
 const GRID_SIZE = 8; // 8x8 grid
 
-function hashCode(str: string): number {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-        const char = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-    return Math.abs(hash);
-}
 
 function getRandomColor(number: number, colors?: string[], range?: number): string {
     if (colors && range) {
@@ -32,7 +24,7 @@ function hslToGrayscale(hslColor: string): string {
 }
 
 function generateColors(name: string, colors?: string[], monochrome?: boolean): string[] {
-    const numFromName = hashCode(name);
+    const numFromName = avatarHash(name);
     const range = colors?.length;
 
     const colorList = Array.from({ length: ELEMENTS }, (_, i) => {
@@ -43,18 +35,11 @@ function generateColors(name: string, colors?: string[], monochrome?: boolean): 
     return colorList;
 }
 
-interface AvatarProps {
-    id: string;
-    title?: boolean;
-    square?: boolean;
-    size?: number;
-    monochrome?: boolean;
-}
 
 const colors = ['#0a0310', '#49007e', '#ff005b', '#ff7d10', '#ffb238'];
 const grayscaleColors = ['#070707', '#242424', '#575757', '#979797', '#bbbbbb'];
 
-export const AvatarSkia = React.memo((props: AvatarProps) => {
+export const AvatarSkia = React.memo((props: GeneratedAvatarProps) => {
     const { id, square, size = 48, monochrome } = props;
     const defaultColors = monochrome ? grayscaleColors : colors;
     const pixelColors = React.useMemo(() => generateColors(id, defaultColors, monochrome), [id, defaultColors]);

--- a/apps/mobile/sources/components/HomeDock.tsx
+++ b/apps/mobile/sources/components/HomeDock.tsx
@@ -17,7 +17,8 @@ import Animated, {
 import { MobileGlassSurface } from './MobileGlass';
 import { OptionSheet } from './OptionSheet';
 import { BubblePressable } from './BubblePressable';
-import { NativeSettingsMenu, type NativeSettingsMenuGroup } from './NativeSettingsMenu';
+import { NativeSettingsMenu } from './NativeSettingsMenu';
+import type { NativeSettingsMenuGroup } from './NativeSettingsMenu.types';
 import { AgentInputAttachmentStrip } from './AgentInputAttachmentStrip';
 import { Typography } from '@/constants/Typography';
 import { layout } from './layout';

--- a/apps/mobile/sources/components/NativeSettingsMenu.android.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.android.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DropdownMenu, DropdownMenuItem } from '@expo/ui/jetpack-compose';
 import { View } from 'react-native';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 export function NativeSettingsMenu({ groups, children, style, flat = false }: NativeSettingsMenuProps) {
     return (

--- a/apps/mobile/sources/components/NativeSettingsMenu.ios.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.ios.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button, Host, HStack, Menu, Spacer } from '@expo/ui/swift-ui';
 import { contentShape, frame, opacity, shapes, tint } from '@expo/ui/swift-ui/modifiers';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 const systemImage = (name: string) => (
     name as React.ComponentProps<typeof Button>['systemImage']

--- a/apps/mobile/sources/components/NativeSettingsMenu.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.tsx
@@ -1,27 +1,7 @@
 import * as React from 'react';
-import { Platform, type StyleProp, type ViewStyle } from 'react-native';
+import { Platform } from 'react-native';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
-export type NativeSettingsMenuOption = {
-    key: string;
-    label: string;
-};
-
-export type NativeSettingsMenuGroup = {
-    key: string;
-    label: string;
-    systemImage?: string;
-    options: NativeSettingsMenuOption[];
-    selectedKey: string | null | undefined;
-    onSelect: (key: string) => void;
-};
-
-export type NativeSettingsMenuProps = {
-    groups: NativeSettingsMenuGroup[];
-    children: React.ReactNode;
-    style?: StyleProp<ViewStyle>;
-    /** Render all options directly in the root menu instead of nesting by group. */
-    flat?: boolean;
-};
 
 const NativeSettingsMenuImpl = Platform.select<React.ComponentType<NativeSettingsMenuProps>>({
     ios: require('./NativeSettingsMenu.ios').NativeSettingsMenu,

--- a/apps/mobile/sources/components/NativeSettingsMenu.types.ts
+++ b/apps/mobile/sources/components/NativeSettingsMenu.types.ts
@@ -1,0 +1,24 @@
+import type * as React from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export type NativeSettingsMenuOption = {
+    key: string;
+    label: string;
+};
+
+export type NativeSettingsMenuGroup = {
+    key: string;
+    label: string;
+    systemImage?: string;
+    options: NativeSettingsMenuOption[];
+    selectedKey: string | null | undefined;
+    onSelect: (key: string) => void;
+};
+
+export type NativeSettingsMenuProps = {
+    groups: NativeSettingsMenuGroup[];
+    children: React.ReactNode;
+    style?: StyleProp<ViewStyle>;
+    /** Render all options directly in the root menu instead of nesting by group. */
+    flat?: boolean;
+};

--- a/apps/mobile/sources/components/NativeSettingsMenu.web.tsx
+++ b/apps/mobile/sources/components/NativeSettingsMenu.web.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import type { NativeSettingsMenuProps } from './NativeSettingsMenu';
+import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 export function NativeSettingsMenu({ children, style }: NativeSettingsMenuProps) {
     return <View style={style}>{children}</View>;

--- a/apps/mobile/sources/components/generatedAvatar.ts
+++ b/apps/mobile/sources/components/generatedAvatar.ts
@@ -1,0 +1,17 @@
+export interface GeneratedAvatarProps {
+    id: string;
+    title?: boolean;
+    square?: boolean;
+    size?: number;
+    monochrome?: boolean;
+}
+
+/** Stable seed shared by every generated avatar renderer. */
+export function avatarHash(value: string): number {
+    let hash = 0;
+    for (let index = 0; index < value.length; index += 1) {
+        hash = ((hash << 5) - hash) + value.charCodeAt(index);
+        hash &= hash;
+    }
+    return Math.abs(hash);
+}

--- a/apps/mobile/sources/components/markdown/MarkdownView.tsx
+++ b/apps/mobile/sources/components/markdown/MarkdownView.tsx
@@ -1,4 +1,5 @@
-import { MarkdownSpan, parseMarkdown } from './parseMarkdown';
+import { parseMarkdown } from './parseMarkdown';
+import type { MarkdownSpan } from './markdownTypes';
 import * as React from 'react';
 import { Image, Pressable, View, Platform } from 'react-native';
 import { HorizontalScrollView } from '../HorizontalScrollView';

--- a/apps/mobile/sources/components/markdown/markdownTypes.ts
+++ b/apps/mobile/sources/components/markdown/markdownTypes.ts
@@ -1,0 +1,40 @@
+export type MarkdownBlock = {
+    type: 'text';
+    content: MarkdownSpan[];
+} | {
+    type: 'header';
+    level: 1 | 2 | 3 | 4 | 5 | 6;
+    content: MarkdownSpan[];
+} | {
+    type: 'list';
+    items: { depth: number; spans: MarkdownSpan[] }[];
+} | {
+    type: 'numbered-list';
+    items: { number: number; depth: number; spans: MarkdownSpan[] }[];
+} | {
+    type: 'code-block';
+    language: string | null;
+    content: string;
+} | {
+    type: 'mermaid';
+    content: string;
+} | {
+    type: 'horizontal-rule';
+} | {
+    type: 'options';
+    items: string[];
+} | {
+    type: 'table';
+    headers: MarkdownSpan[][];
+    rows: MarkdownSpan[][][];
+} | {
+    type: 'image';
+    alt: string;
+    url: string;
+};
+
+export type MarkdownSpan = {
+    styles: ('italic' | 'bold' | 'semibold' | 'code')[];
+    text: string;
+    url: string | null;
+};

--- a/apps/mobile/sources/components/markdown/parseMarkdown.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdown.ts
@@ -1,45 +1,5 @@
 import { parseMarkdownBlock } from "./parseMarkdownBlock"
 
-export type MarkdownBlock = {
-    type: 'text'
-    content: MarkdownSpan[]
-} | {
-    type: 'header'
-    level: 1 | 2 | 3 | 4 | 5 | 6
-    content: MarkdownSpan[]
-} | {
-    type: 'list',
-    items: { depth: number, spans: MarkdownSpan[] }[]
-} | {
-    type: 'numbered-list',
-    items: { number: number, depth: number, spans: MarkdownSpan[] }[]
-} | {
-    type: 'code-block',
-    language: string | null,
-    content: string
-} | {
-    type: 'mermaid',
-    content: string
-} | {
-    type: 'horizontal-rule'
-} | {
-    type: 'options',
-    items: string[]
-} | {
-    type: 'table',
-    headers: MarkdownSpan[][],
-    rows: MarkdownSpan[][][]
-} | {
-    type: 'image',
-    alt: string,
-    url: string
-}
-
-export type MarkdownSpan = {
-    styles: ('italic' | 'bold' | 'semibold' | 'code')[],
-    text: string,
-    url: string | null
-}
 
 export function parseMarkdown(markdown: string) {
     return parseMarkdownBlock(markdown);

--- a/apps/mobile/sources/components/markdown/parseMarkdownBlock.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdownBlock.ts
@@ -1,4 +1,4 @@
-import type { MarkdownBlock, MarkdownSpan } from "./parseMarkdown";
+import type { MarkdownBlock, MarkdownSpan } from "./markdownTypes";
 import { parseMarkdownSpans } from "./parseMarkdownSpans";
 
 // Split a pipe-delimited table row into cells, stripping only the leading/trailing

--- a/apps/mobile/sources/components/markdown/parseMarkdownSpans.ts
+++ b/apps/mobile/sources/components/markdown/parseMarkdownSpans.ts
@@ -1,4 +1,4 @@
-import type { MarkdownSpan } from "./parseMarkdown";
+import type { MarkdownSpan } from "./markdownTypes";
 
 // Updated pattern to handle nested markdown and asterisks
 const pattern = /(\*\*(.*?)(?:\*\*|$))|(\*(.*?)(?:\*|$))|(\[([^\]]+)\](?:\(([^)]+)\))?)|(`(.*?)(?:`|$))/g;

--- a/apps/mobile/sources/plugins/primitiveRegistry.tsx
+++ b/apps/mobile/sources/plugins/primitiveRegistry.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { PRIMITIVE_SPECS, type PluginNativeContribution, type PluginNativeSlot, type PluginPrimitive } from '@muxr/contract';
-import type { PluginSlotContexts } from './slotTypes';
+import { PRIMITIVE_SPECS, type PluginPrimitive } from '@muxr/contract';
+import type { PrimitiveProps } from './primitiveTypes';
 import { CapabilityButton } from './primitives/CapabilityButton';
 import { CollectionView } from './primitives/CollectionView';
 import { RealtimeSessionOverlay } from './primitives/RealtimeSessionOverlay';
@@ -8,12 +8,6 @@ import { DictateButton } from './primitives/DictateButton';
 import { TreeSheet } from './primitives/TreeSheet';
 import { ItemList } from './primitives/ItemList';
 
-export type PrimitiveProps = {
-    pluginId: string;
-    manifestHash: string;
-    contribution: PluginNativeContribution;
-    context: PluginSlotContexts[PluginNativeSlot];
-};
 
 type PrimitiveRenderer = (props: PrimitiveProps) => React.ReactNode;
 

--- a/apps/mobile/sources/plugins/primitiveTypes.ts
+++ b/apps/mobile/sources/plugins/primitiveTypes.ts
@@ -1,0 +1,9 @@
+import type { PluginNativeContribution, PluginNativeSlot } from '@muxr/contract';
+import type { PluginSlotContexts } from './slotTypes';
+
+export type PrimitiveProps = {
+    pluginId: string;
+    manifestHash: string;
+    contribution: PluginNativeContribution;
+    context: PluginSlotContexts[PluginNativeSlot];
+};

--- a/apps/mobile/sources/plugins/primitives/CapabilityButton.tsx
+++ b/apps/mobile/sources/plugins/primitives/CapabilityButton.tsx
@@ -5,7 +5,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import { useRealtimeSessionState } from '@/realtime/realtimeSessionState';
 import { RealtimeGlyph } from '@/realtime/RealtimeGlyph';
 import { withAlpha } from '@/components/ui';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { capabilityFor } from '../capabilityRegistry';
 import { resolvePluginText } from '../pluginText';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/CollectionView.tsx
+++ b/apps/mobile/sources/plugins/primitives/CollectionView.tsx
@@ -12,7 +12,7 @@ import { StatusDot } from '@/components/StatusDot';
 import { Typography } from '@/constants/Typography';
 import { layout } from '@/components/layout';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { asPluginCollection, type PluginCollectionGroup, type PluginCollectionItem } from '../collectionModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/DictateButton.tsx
+++ b/apps/mobile/sources/plugins/primitives/DictateButton.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useUnistyles } from 'react-native-unistyles';
 import { BubblePressable } from '@/components/BubblePressable';
 import { useDictation } from '@/utils/dictation';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { t } from '@/text';
 
 export function DictateButton({ context }: PrimitiveProps) {

--- a/apps/mobile/sources/plugins/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/primitives/ItemList.tsx
@@ -11,7 +11,7 @@ import { Modal } from '@/modal';
 import { sync } from '@/sync/sync';
 import { Typography } from '@/constants/Typography';
 import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import { asPluginItemList, type PluginItemListAction, type PluginItemListItem, type PluginItemListModel } from '../itemListModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';
 import { pluginSnapshot } from '../pluginStore';

--- a/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
+++ b/apps/mobile/sources/plugins/primitives/TreeSheet.tsx
@@ -9,7 +9,7 @@ import { sync } from '@/sync/sync';
 import { OptionSheet } from '@/components/OptionSheet';
 import { StatusDot } from '@/components/StatusDot';
 import { hapticsError, hapticsLight } from '@/components/haptics';
-import type { PrimitiveProps } from '../primitiveRegistry';
+import type { PrimitiveProps } from '../primitiveTypes'
 import type { PluginSlotContexts } from '../slotTypes';
 import { asPluginTree, type PluginTreeNode } from '../treeModel';
 import { dispatchPluginAction, validatePluginAction } from '../pluginActions';

--- a/apps/mobile/sources/sync/serverConfig.ts
+++ b/apps/mobile/sources/sync/serverConfig.ts
@@ -4,32 +4,3 @@ import { DEFAULT_CONNECTION } from '../state/connectionSettings';
 export function getServerUrl(): string {
     return relayControlUrl(DEFAULT_CONNECTION.relayUrl);
 }
-
-export function setServerUrl(_url: string | null): void {}
-
-export function getLogServerUrl(): string | null {
-    return null;
-}
-
-export function setLogServerUrl(_url: string | null): void {}
-
-export function isUsingCustomServer(): boolean {
-    return false;
-}
-
-export function getServerInfo(): { hostname: string; port?: number; isCustom: boolean } {
-    try {
-        const parsed = new URL(getServerUrl());
-        return {
-            hostname: parsed.hostname,
-            port: parsed.port ? Number.parseInt(parsed.port, 10) : undefined,
-            isCustom: false,
-        };
-    } catch {
-        return { hostname: '127.0.0.1', port: 8792, isCustom: false };
-    }
-}
-
-export function validateServerUrl(_url: string): { valid: boolean; error?: string } {
-    return { valid: true };
-}

--- a/apps/mobile/sources/utils/consoleLogging.ts
+++ b/apps/mobile/sources/utils/consoleLogging.ts
@@ -11,26 +11,24 @@
  * ├─ consoleOutputEnabled = true? (default for dev/preview, or toggled on)
  * │  ├─ call original console method ✅
  * │  ├─ capture to in-app buffer ✅
- * │  └─ send to remote log server (if configured) ✅
  * │
  * └─ console.error / console.warn (always, regardless of flag)
  *    ├─ call original console method ✅
  *    ├─ capture to in-app buffer ✅
- *    └─ send to remote log server (if configured) ✅
  */
 
 import { log } from '@/log';
 import { MAX_APP_LOG_ENTRIES } from '@/log';
-import { getLogServerUrl } from '@/sync/serverConfig';
 import { loadLocalSettings } from '@/sync/persistence';
 import { loadAppConfig } from '@/sync/appConfig';
-import { Platform } from 'react-native';
 import { serializeForLogs } from '@/utils/truncateForLogs';
 
-let logBuffer: any[] = []
+type ConsoleLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
+type ConsoleLogEntry = { timestamp: string; level: ConsoleLevel; message: string };
+
+let logBuffer: ConsoleLogEntry[] = []
 const MAX_BUFFER_SIZE = MAX_APP_LOG_ENTRIES
 let isConsolePatched = false
-let remoteLogServerUrl: string | null = null
 let consoleOutputEnabled = false
 let originalConsole: {
   log: typeof console.log,
@@ -52,7 +50,6 @@ export function initConsoleLogging() {
     return
   }
 
-  remoteLogServerUrl = getLogServerUrl();
 
   // Determine initial state: user setting > build variant default > off
   try {
@@ -73,7 +70,7 @@ export function initConsoleLogging() {
 
   log.setConsoleCaptureEnabled(true)
 
-  function formatArgs(args: any[]): string {
+  function formatArgs(args: unknown[]): string {
     return args.map(a => {
       if (a === null || a === undefined) return String(a)
       if (typeof a !== 'object') return serializeForLogs(a)
@@ -81,29 +78,12 @@ export function initConsoleLogging() {
     }).join(' ')
   }
 
-  function sendLog(level: string, formatted: string) {
-    if (!remoteLogServerUrl) {
-      return
-    }
-
-    void fetch(remoteLogServerUrl + '/logs', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        timestamp: new Date().toISOString(),
-        level,
-        message: formatted,
-        source: 'mobile',
-        platform: Platform.OS,
-      })
-    }).catch(() => {})
-  }
 
   // Patch console methods
   ;(['log', 'info', 'warn', 'error', 'debug'] as const).forEach(level => {
     const alwaysPassThrough = level === 'error' || level === 'warn'
 
-    console[level] = (...args: any[]) => {
+    console[level] = (...args: unknown[]) => {
       // Full short-circuit: when off, skip everything for log/info/debug
       if (!consoleOutputEnabled && !alwaysPassThrough) {
         return
@@ -126,7 +106,6 @@ export function initConsoleLogging() {
         logBuffer.shift()
       }
 
-      sendLog(level, formatted)
     }
   })
 

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -143,6 +143,7 @@ export {
     PRIMITIVE_SPECS,
     PLUGIN_CONTEXT_REQUESTS,
     capUtf8Bytes,
+    boundRpcDisplay,
     pluginCompatibilityError,
     sanitizeDisplayText,
 } from './plugins.js';

--- a/packages/contract/src/manifest.ts
+++ b/packages/contract/src/manifest.ts
@@ -14,7 +14,6 @@ import type {
     PluginScreenButtonNode,
     PluginScreenContribution,
     PluginScreenNode,
-    PluginScreenRowAction,
     PluginScreenRowNode,
     PluginScreenTone,
 } from './plugins.js';
@@ -306,7 +305,7 @@ function parseScreenNode(item: Record<string, unknown>, depth: number, budget: {
                         ? { type: 'plugin.call' as const, contributionId: id(item.source.contributionId) }
                         : (() => { throw new Error('invalid plugin screen tree source'); })(),
                 }),
-                ...(item.action === undefined ? {} : { action: parseScreenRowAction(item.action) }),
+                ...(item.action === undefined ? {} : { action: parsePluginAction(item.action) }),
             };
         case 'list': {
             if (!Array.isArray(item.rows) || item.rows.length > MAX_ROWS) throw new Error('invalid plugin screen list rows');
@@ -340,13 +339,10 @@ function parseScreenRow(row: Record<string, unknown>): PluginScreenRowNode {
         title: pluginText(row.title, 80),
         ...(row.subtitle === undefined ? {} : { subtitle: pluginText(row.subtitle, MAX_TEXT) }),
         ...(row.value === undefined ? {} : { value: pluginText(row.value, MAX_TEXT) }),
-        ...(row.action === undefined ? {} : { action: parseScreenRowAction(row.action) }),
+        ...(row.action === undefined ? {} : { action: parsePluginAction(row.action) }),
     };
 }
 
-function parseScreenRowAction(value: unknown): PluginScreenRowAction {
-    return parsePluginAction(value);
-}
 
 function actionString(value: unknown, max: number, label: string): string {
     if (typeof value !== 'string') throw new Error(`invalid plugin action ${label}`);

--- a/packages/contract/src/plugins.ts
+++ b/packages/contract/src/plugins.ts
@@ -677,6 +677,21 @@ export function sanitizeDisplayText(text: string): string {
     return text.replace(DISPLAY_CONTROL, '');
 }
 
+/** Bound and sanitize untrusted plugin results before they cross a UI boundary. */
+export function boundRpcDisplay(value: unknown, depth = 0): unknown {
+    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
+    if (value === null) return null;
+    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
+    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
+    if (typeof value !== 'object') return value;
+    const out: Record<string, unknown> = Object.create(null);
+    for (const [key, entry] of Object.entries(value)) {
+        const bounded = boundRpcDisplay(entry, depth + 1);
+        if (bounded !== undefined) out[key] = bounded;
+    }
+    return out;
+}
+
 /** v1 is deliberately tiny: one static surface and one context-bound action. */
 export interface PluginManifestV1 {
     schemaVersion: 1;

--- a/scripts/plugin.mjs
+++ b/scripts/plugin.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { homedir, tmpdir } from 'node:os';
 
-import { MAX_PLUGIN_CONTEXT_BYTES, MAX_RPC_ARRAY_ENTRIES, MAX_RPC_DISPLAY_DEPTH, MAX_RPC_INPUT_BYTES, MAX_RPC_RESULT_STRING_BYTES, MAX_RPC_STDOUT_BYTES, capUtf8Bytes, parseManifest, sanitizeDisplayText } from '@muxr/contract';
+import { MAX_PLUGIN_CONTEXT_BYTES, MAX_RPC_INPUT_BYTES, MAX_RPC_STDOUT_BYTES, boundRpcDisplay, parseManifest } from '@muxr/contract';
 
 const id = (value) => typeof value === 'string' && /^[a-z0-9][a-z0-9._-]{0,63}$/.test(value);
 const fail = (message) => { throw new Error(message); };
@@ -165,19 +165,6 @@ function boundedJson(value, fallback, maxBytes, label) {
     return serialized;
 }
 
-function boundRpcDisplay(value, depth = 0) {
-    if (typeof value === 'string') return capUtf8Bytes(sanitizeDisplayText(value), MAX_RPC_RESULT_STRING_BYTES);
-    if (value === null) return null;
-    if (depth >= MAX_RPC_DISPLAY_DEPTH) return undefined;
-    if (Array.isArray(value)) return value.slice(0, MAX_RPC_ARRAY_ENTRIES).map((entry) => boundRpcDisplay(entry, depth + 1));
-    if (typeof value !== 'object') return value;
-    const out = Object.create(null);
-    for (const [key, entry] of Object.entries(value)) {
-        const bounded = boundRpcDisplay(entry, depth + 1);
-        if (bounded !== undefined) out[key] = bounded;
-    }
-    return out;
-}
 
 function runRpcCall(checked, contributionId, inputJson, contextJson) {
     const rpcs = checked.manifest.contributions.filter((entry) => 'type' in entry && entry.type === 'rpc');

--- a/scripts/up.mjs
+++ b/scripts/up.mjs
@@ -79,7 +79,7 @@ let exitCode = 0;
 
 function killChildren(signal = 'SIGTERM') {
     for (const child of children) {
-        if (child.exitCode === null && !child.killed) child.kill(signal);
+        if (child.exitCode === null) child.kill(signal);
     }
 }
 


### PR DESCRIPTION
## Summary

Low-risk ownership and deduplication lane split from #124 after review. Rebuilt directly on `eb018d1` / current `main`; excludes responsive work, device-authority policy, provenance changes, audit skill files, and package-smoke changes from the superseded branch.

- move plugin result bounding/sanitization into `@muxr/contract` so host and CLI share one implementation
- delete dead server configuration setters and unreachable remote logging transport
- use `node:path.basename` instead of a bespoke host helper
- remove the manifest row-action identity wrapper
- centralize generated-avatar props/hash and remove `ComponentType<any>`
- move markdown, primitive, and native-menu contracts into type-only modules, eliminating the detected relative-import cycles
- allow process shutdown escalation to signal a still-running child even after an earlier signal was sent

## Scope

No HomeDock/chart extraction and no `useDeviceAuthority` migration. Those overlap #123 and are intentionally absent. No plugin provenance semantics changed.

## Validation

- `yarn run check` — **30/30 passed** on current main
- `yarn workspace @muxr/mobile typecheck` — passed
- `git diff --check` — passed

Supersedes the low-risk portion of #124.