### PR TITLE
fix(host): canonicalize plugin provenance root

### DIFF
--- a/apps/host/src/herdr/pluginCatalog.test.ts
+++ b/apps/host/src/herdr/pluginCatalog.test.ts
@@ -214,17 +214,24 @@ describe('plugin catalog flow', () => {
         expect(() => catalog.action(changed.pluginId, changed.manifestHash!, 'missing')).toThrow('unavailable or changed');
 
         const muxrHome = await realpath(await mkdtemp(join(tmpdir(), 'muxr-home-')));
+        const aliasParent = await realpath(await mkdtemp(join(tmpdir(), 'muxr-home-alias-')));
+        const muxrHomeAlias = join(aliasParent, 'home');
+        await symlink(muxrHome, muxrHomeAlias, 'dir');
         const extensionRoot = join(muxrHome, 'extensions');
         const managedRoot = join(extensionRoot, 'example.muxr-ui');
         await mkdir(managedRoot, { recursive: true });
         await writeFile(join(managedRoot, 'muxr-ui.json'), JSON.stringify({ schemaVersion: 1, pluginId: 'example.muxr-ui', contributions: [] }));
         await mkdir(join(extensionRoot, '.provenance'));
         await writeFile(join(extensionRoot, '.provenance', 'example.muxr-ui.json'), JSON.stringify({ schemaVersion: 1, pluginId: 'example.muxr-ui', root: managedRoot, name: 'pkg', version: '1.0.0', integrity: 'sha512-abc' }));
-        const previousHome = process.env.MUXR_HOME; process.env.MUXR_HOME = muxrHome;
+        const previousHome = process.env.MUXR_HOME;
+        process.env.MUXR_HOME = muxrHomeAlias;
         try {
             await catalog.refresh([plugin(managedRoot, [action])]);
             const npm = catalog.list(() => true)[0]!;
             expect(npm.source).toEqual({ kind: 'npm', name: 'pkg', version: '1.0.0', integrity: 'sha512-abc' });
+            await writeFile(join(extensionRoot, '.provenance', 'example.muxr-ui.json'), JSON.stringify({ schemaVersion: 1, pluginId: 'example.muxr-ui', root: `${managedRoot}/.`, name: 'pkg', version: '1.0.0', integrity: 'sha512-abc' }));
+            await catalog.refresh([plugin(managedRoot, [action])]);
+            expect(catalog.list(() => true)[0]!.source).toEqual({ kind: 'local' });
             await writeFile(join(extensionRoot, '.provenance', 'example.muxr-ui.json'), JSON.stringify({ schemaVersion: 1, pluginId: 'example.muxr-ui', root: managedRoot, name: 'pkg', version: '2.0.0', integrity: 'sha512-def' }));
             await catalog.refresh([plugin(managedRoot, [action])]);
             const rotated = catalog.list(() => true)[0]!;

--- a/apps/host/src/herdr/pluginCatalog.ts
+++ b/apps/host/src/herdr/pluginCatalog.ts
@@ -352,12 +352,14 @@ type NpmProvenance = { schemaVersion: 1; pluginId: string; root: string; name: s
 function npmProvenance(plugin: HerdrPlugin, pluginRoot?: string): PluginSource | undefined {
     let root;
     try { root = pluginRoot ?? realpathSync(plugin.plugin_root); } catch { return undefined; }
-    const expectedRoot = resolve(process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr'), 'extensions');
+    const expectedRootPath = resolve(process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr'), 'extensions');
+    let expectedRoot: string;
     try {
-        const extensionStat = lstatSync(expectedRoot);
+        const extensionStat = lstatSync(expectedRootPath);
         if (extensionStat.isSymbolicLink() || !extensionStat.isDirectory()) return undefined;
-        const provenanceStat = lstatSync(join(expectedRoot, '.provenance'));
+        const provenanceStat = lstatSync(join(expectedRootPath, '.provenance'));
         if (provenanceStat.isSymbolicLink() || !provenanceStat.isDirectory()) return undefined;
+        expectedRoot = realpathSync(expectedRootPath);
     } catch { return undefined; }
     const rel = relative(expectedRoot, root);
     if (rel === '' || rel.startsWith('..') || isAbsolute(rel) || rel.includes('\\') || rel.split(/[\\/]/).length !== 1 || rel !== plugin.plugin_id) return undefined;

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -80,9 +80,11 @@ function ensureManagedDirectory(path, label) {
 }
 function validRoot(root, base = extensionHome()) {
     if (!isManagedDirectory(base)) return undefined;
-    let real;
-    try { real = realpathSync(root); } catch { return undefined; }
-    const expected = resolve(base);
+    let real, expected;
+    try {
+        real = realpathSync(root);
+        expected = realpathSync(base);
+    } catch { return undefined; }
     const rel = relative(expected, real);
     if (rel === '' || rel.startsWith('..') || isAbsolute(rel) || rel.includes('\\') || rel.split('/').length !== 1) return undefined;
     return real;
@@ -97,7 +99,9 @@ function nofollowJson(path, maxBytes = 8192) {
 }
 function validNpmProvenance(plugin) {
     const root = validRoot(plugin.plugin_root);
-    if (!root || !isManagedDirectory(provenanceHome()) || !plugin.plugin_id || !ID_RE.test(plugin.plugin_id) || root !== join(resolve(extensionHome()), plugin.plugin_id)) return undefined;
+    let expectedRoot;
+    try { expectedRoot = join(realpathSync(extensionHome()), plugin.plugin_id); } catch { return undefined; }
+    if (!root || !isManagedDirectory(provenanceHome()) || !plugin.plugin_id || !ID_RE.test(plugin.plugin_id) || root !== expectedRoot) return undefined;
     const value = nofollowJson(join(provenanceHome(), `${plugin.plugin_id}.json`));
     if (!value || value.schemaVersion !== 1 || value.pluginId !== plugin.plugin_id || value.root !== root || typeof value.name !== 'string' || typeof value.version !== 'string' || typeof value.integrity !== 'string' || value.name.length > 200 || value.version.length > 80 || value.integrity.length > 200 || !NPM_NAME_RE.test(value.name) || !VERSION_RE.test(value.version) || !INTEGRITY_RE.test(value.integrity)) return undefined;
     return value;
@@ -106,7 +110,12 @@ function sourceFor(plugin) {
     const npm = validNpmProvenance(plugin);
     return npm ? { kind: 'npm', name: npm.name, version: npm.version, integrity: npm.integrity } : plugin.source ?? { kind: 'local' };
 }
-function isNpmRoot(plugin) { return validRoot(plugin?.plugin_root) !== undefined && resolve(plugin.plugin_root) === join(resolve(extensionHome()), plugin.plugin_id); }
+function isNpmRoot(plugin) {
+    const root = validRoot(plugin?.plugin_root);
+    if (root === undefined || typeof plugin?.plugin_id !== 'string') return false;
+    try { return root === join(realpathSync(extensionHome()), plugin.plugin_id); }
+    catch { return false; }
+}
 
 function lockPath(id) { return join(extensionHome(), '.locks', `${id}.lock`); }
 function ownerIsLive(path) {
@@ -436,7 +445,7 @@ export async function runPackage(command, args = []) {
         return withRegistryLock(id, async () => {
             const plugin = pluginFor(herdrPlugins(), id); if (!plugin) fail(`plugin is not installed: ${requested}`); const npm = validNpmProvenance(plugin); const action = npm ? 'unlink then remove managed npm materialization' : plugin.source?.kind === 'github' ? 'uninstall' : 'unlink';
             if (!await confirm(yes, `Remove ${id} (${action})?`)) return 0;
-            if (npm) { runHerdr(['plugin', 'unlink', id]); const root = validRoot(plugin.plugin_root); if (!root || root !== join(resolve(extensionHome()), id)) fail('refusing to remove an untrusted npm materialization path'); rmSync(root, { recursive: true, force: true }); removeProvenance(id); }
+            if (npm) { runHerdr(['plugin', 'unlink', id]); const root = validRoot(plugin.plugin_root); if (!root || !isNpmRoot(plugin)) fail('refusing to remove an untrusted npm materialization path'); rmSync(root, { recursive: true, force: true }); removeProvenance(id); }
             else runHerdr(['plugin', action === 'uninstall' ? 'uninstall' : 'unlink', id]);
             process.stdout.write(`removed ${id}\n`); return 0;
         });

--- a/scripts/packageLifecycleSmoke.mjs
+++ b/scripts/packageLifecycleSmoke.mjs
@@ -196,6 +196,30 @@ try {
     assert.equal(existsSync(provenancePath), false, 'remove left npm provenance behind');
     assert.equal(existsSync(statePath) && readFileSync(statePath, 'utf8') !== '', false);
 
+    // A symlinked parent must not make host/package ownership disagree. The
+    // stored provenance root stays canonical and exact while list/update/remove
+    // resolve the already-owner-checked extensions directory to the same root.
+    const directMuxrHome = process.env.MUXR_HOME;
+    const aliasedHome = join(scratch, 'home-alias');
+    symlinkSync(home, aliasedHome, 'dir');
+    process.env.MUXR_HOME = join(aliasedHome, '.muxr');
+    try {
+        assert.equal(await runPackage('install', ['npm:pkg@1.0.0', '--yes']), 0);
+        const canonicalAliasRoot = realpathSync(join(process.env.MUXR_HOME, 'extensions'));
+        const aliasMaterialized = join(canonicalAliasRoot, 'test.npm');
+        const aliasProvenance = join(canonicalAliasRoot, '.provenance', 'test.npm.json');
+        const aliasListed = await captureOutput(() => runPackage('list'));
+        assert.equal(aliasListed.value, 0);
+        assert.match(aliasListed.output, /test\.npm\t1\.0\.0\tenabled\t\{"kind":"npm"/);
+        assert.equal(await runPackage('update', ['npm:pkg@2.0.0', '--yes']), 0);
+        assert.equal(JSON.parse(readFileSync(aliasProvenance, 'utf8')).version, '2.0.0');
+        assert.equal(await runPackage('remove', ['test.npm', '--yes']), 0);
+        assert.equal(existsSync(aliasMaterialized), false, 'aliased remove left npm materialization behind');
+        assert.equal(existsSync(aliasProvenance), false, 'aliased remove left npm provenance behind');
+    } finally {
+        process.env.MUXR_HOME = directMuxrHome;
+    }
+
     await assert.rejects(runPackage('install', ['npm:pkg@9.9.9', '--yes']), /unsafe|package/);
     assert.equal(existsSync(materialized), false);
 


### PR DESCRIPTION
## Summary

Security-reviewed provenance fix rebuilt on current `main`.

On macOS and other symlink-parent layouts, the configured extensions directory can use one path while `realpath` returns another. Host validation and `muxr package` now canonicalize the already-owner-checked extensions root before containment comparison, so host and package list/update/remove agree on npm ownership.

The stored provenance `root` remains an **exact string pin** against the canonical executable root; it is not canonicalized or relaxed.

## Security invariants

- extensions and `.provenance` must still be real directories, not symlinks
- plugin root must still be exactly one child named by plugin id
- provenance files still use `O_NOFOLLOW`, size bounds, and schema validation
- `parsed.root !== executableRoot` still fails closed
- a same-directory spelling such as `canonicalRoot/.` is explicitly tested and rejected
- package removal reuses the same canonical ownership check before deleting materialization

## Coverage

- platform-independent symlink-parent host provenance flow
- package install → list → update → remove through an aliased parent
- materialization and provenance removal assertions
- exact stored-root mismatch rejection

## Release note

Affected macOS installs whose prior approval hash was calculated through a `/var` alias may see a safe one-time plugin re-approval because the corrected source identity can change the manifest approval hash.

## Validation

- `yarn vitest run apps/host/src/herdr/pluginCatalog.test.ts` — **19/19 passed**
- `node scripts/packageLifecycleSmoke.mjs` — passed, including aliased lifecycle
- `yarn run check` — **30/30 passed** on exact rerun; the first run hit the unrelated attachment-watcher timing flake and its focused rerun passed
- `git diff --check` — passed

Supersedes the provenance portion of #124.