### PR TITLE
Finish live self-host collaboration setup

### DIFF
--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -401,6 +401,7 @@ if (requestedMode !== undefined && requestedMode !== 'hosted' && requestedMode !
 }
 const mode = requestedMode ?? (hostedAuth !== undefined ? 'hosted' : selfhostAuth !== undefined ? 'selfhost' : useFake ? 'local' : undefined);
 if (mode === undefined) throw new Error('no hosted auth state; set MUXR_MODE=local explicitly for development');
+const peerRelayUrl = mode === 'selfhost' ? selfhostAuth?.relayUrl ?? relayUrl : relayUrl;
 const token = env('MUXR_RELAY_TOKEN') ?? (mode === 'hosted' ? hostedAuth?.credential : mode === 'selfhost' ? selfhostAuth?.machineCredential ?? selfhostAuth?.mintSecret : undefined);
 if (mode === 'hosted' && hostedAuth === undefined) {
     process.stderr.write('hosted mode requires muxr setup/login state; run `muxr doctor`\n');
@@ -545,7 +546,7 @@ async function main(): Promise<void> {
                 machineId,
                 machineName,
                 platform: process.platform === 'darwin' ? 'macOS' : process.platform === 'win32' ? 'Windows' : process.platform === 'linux' ? 'Linux' : process.platform,
-                relayUrl,
+                relayUrl: peerRelayUrl,
                 crypto: cryptoAdapter,
                 authority: new HttpPeerAuthority({
                     kind: mode,

--- a/apps/host/src/peer/authority.ts
+++ b/apps/host/src/peer/authority.ts
@@ -60,7 +60,8 @@ export class HttpPeerAuthority implements PeerAuthority {
     }
 
     private async issueSelfhost(input: Parameters<PeerAuthority['issuePeer']>[0]): Promise<IssuedPeer> {
-        const listed = await this.json('/v1/selfhost/peers', { method: 'GET' }) as { peers?: unknown };
+        const peersPath = `/v1/selfhost/peers?machine=${encodeURIComponent(this.options.machineId)}`;
+        const listed = await this.json(peersPath, { method: 'GET' }) as { peers?: unknown };
         const existing = Array.isArray(listed.peers)
             ? listed.peers.find((value) => {
                 const peer = value as Record<string, unknown>;
@@ -68,7 +69,7 @@ export class HttpPeerAuthority implements PeerAuthority {
             }) as Record<string, unknown> | undefined
             : undefined;
         if (existing !== undefined && typeof existing.deviceId === 'string') {
-            const rotated = await this.json(`/v1/selfhost/peers/${encodeURIComponent(existing.deviceId)}/rotate`, {
+            const rotated = await this.json(`/v1/selfhost/peers/${encodeURIComponent(existing.deviceId)}/rotate?machine=${encodeURIComponent(this.options.machineId)}`, {
                 method: 'POST',
                 body: JSON.stringify({
                     credential_expires_at: input.credentialExpiresAt,
@@ -79,7 +80,7 @@ export class HttpPeerAuthority implements PeerAuthority {
             if (typeof rotated.device_credential !== 'string') throw new Error('selfhost peer authority returned an invalid recovery response');
             return this.issued(existing.deviceId, rotated.device_credential, input);
         }
-        const result = await this.json('/v1/selfhost/peers', {
+        const result = await this.json(peersPath, {
             method: 'POST',
             body: JSON.stringify({
                 device_public_key: input.peerPublicKey,
@@ -168,7 +169,7 @@ export class HttpPeerAuthority implements PeerAuthority {
             });
             return;
         }
-        await this.json(`/v1/selfhost/peers/${encodeURIComponent(peerDeviceId)}/grant`, {
+        await this.json(`/v1/selfhost/peers/${encodeURIComponent(peerDeviceId)}/grant?machine=${encodeURIComponent(this.options.machineId)}`, {
             method: 'POST', body: JSON.stringify({ grant, key_version: keyVersion }),
         });
     }
@@ -178,7 +179,7 @@ export class HttpPeerAuthority implements PeerAuthority {
             await this.json(`/v1/devices/${encodeURIComponent(peerDeviceId)}/revoke`, { method: 'POST' }, true);
             return;
         }
-        await this.json(`/v1/selfhost/peers/${encodeURIComponent(peerDeviceId)}`, { method: 'DELETE' }, true);
+        await this.json(`/v1/selfhost/peers/${encodeURIComponent(peerDeviceId)}?machine=${encodeURIComponent(this.options.machineId)}`, { method: 'DELETE' }, true);
     }
 
     async publishRotation(keyVersion: number, grants: MachineRotationGrant[]): Promise<void> {

--- a/apps/host/src/peer/outboundPeerService.ts
+++ b/apps/host/src/peer/outboundPeerService.ts
@@ -267,7 +267,8 @@ export class OutboundPeerService {
         const base = name(relationship.machineName, 'Peer computer');
         const used = new Set(this.options.store.list().peers.flatMap((entry) => {
             const stored = this.options.store.relationship(entry.relationshipId);
-            return stored?.direction === 'outbound' && stored.relationshipId !== relationship.relationshipId && stored.machineAlias
+            return stored?.direction === 'outbound' && stored.state !== 'revoked'
+                && stored.relationshipId !== relationship.relationshipId && stored.machineAlias
                 ? [key(stored.machineAlias)] : [];
         }));
         let alias = base;

--- a/apps/host/src/peer/peerFlow.test.ts
+++ b/apps/host/src/peer/peerFlow.test.ts
@@ -292,6 +292,12 @@ describe('host peer collaboration flow', () => {
             channel: 'session', streamId: 'machine', keyVersion: 1,
         }, newV2ReplayTracker())).toBe('peer-result');
 
+        await sourceRuntime.store.putRelationship({
+            ...outbound,
+            relationshipId: 'revoked-old-build-mac',
+            state: 'revoked',
+            machineAlias: 'Build Mac',
+        });
         const listed = await call(sourceRuntime, 'peer.remote.list', { relationshipId: installed.relationshipId });
         expect(listed).toEqual({ machineAlias: 'Build Mac', sessions: [{ sessionId: 'muxr-session-ios', agentAlias: 'iOS builder' }] });
         const promptMutation = fresh('prompt-once');
@@ -765,6 +771,52 @@ describe('host peer collaboration flow', () => {
             globalThis.fetch = originalFetch;
             await new Promise<void>((resolve) => server.close(() => resolve()));
         }
+    });
+
+    it('scopes self-host peer authority calls to the target machine', async () => {
+        const calls: string[] = [];
+        const peerPublicKey = generateKeyPair().publicKey;
+        let lists = 0;
+        const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+            const url = new URL(String(input));
+            const method = init?.method ?? 'GET';
+            calls.push(`${method} ${url.pathname}${url.search}`);
+            let body: Record<string, unknown> = { ok: true };
+            if (url.pathname === '/v1/selfhost/peers' && method === 'GET') {
+                body = { peers: lists++ === 0 ? [] : [{ deviceId: 'peer-device', publicKey: peerPublicKey }] };
+            } else if (url.pathname === '/v1/selfhost/peers' && method === 'POST') {
+                body = { device_id: 'peer-device', device_credential: 'peer-credential' };
+            } else if (url.pathname.endsWith('/rotate')) {
+                body = { device_credential: 'rotated-credential' };
+            }
+            return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+        }) as typeof fetch;
+        const authority = new HttpPeerAuthority({
+            kind: 'selfhost', controlUrl: 'https://relay.test', machineId: 'target-machine', credential: 'owner-secret', fetch: fetchImpl,
+        });
+        const input = {
+            peerPublicKey,
+            sourceMachineId: 'source-machine',
+            sourceName: 'Linux builder',
+            capabilities: [...DEFAULT_PEER_CAPABILITIES],
+            credentialExpiresAt: Date.now() + 60_000,
+            refreshAfter: Date.now() + 30_000,
+        };
+        await authority.issuePeer(input);
+        await authority.issuePeer(input);
+        await authority.uploadGrant('peer-device', 'sealed-peer-grant', 2);
+        await authority.revokePeer('peer-device');
+        await authority.publishRotation(3, [{ deviceId: 'peer-device', devicePublicKey: peerPublicKey, grant: 'rotated-grant' }]);
+
+        expect(calls).toEqual([
+            'GET /v1/selfhost/peers?machine=target-machine',
+            'POST /v1/selfhost/peers?machine=target-machine',
+            'GET /v1/selfhost/peers?machine=target-machine',
+            'POST /v1/selfhost/peers/peer-device/rotate?machine=target-machine',
+            'POST /v1/selfhost/peers/peer-device/grant?machine=target-machine',
+            'DELETE /v1/selfhost/peers/peer-device?machine=target-machine',
+            'POST /v1/selfhost/machines/target-machine/grants',
+        ]);
     });
 
     it('uses deployed hosted pair-session, device revoke, and rotation APIs', async () => {

--- a/apps/mobile/sources/collaboration/scopedMachineClient.ts
+++ b/apps/mobile/sources/collaboration/scopedMachineClient.ts
@@ -1,6 +1,8 @@
 import type { PeerRequestMap, PeerRequestType } from '@muxr/contract';
 import { MuxrClient, MuxrRequestError } from '@/client/muxrClient';
 import type { StoredHostedGrant } from '@/state/hostedE2ee';
+import { getCachedConnectionSettings } from '@/state/connectionSettings';
+import { sync } from '@/sync/sync';
 import { PeerHostResponseError } from './computerCollaboration';
 
 /** Request one paired machine without changing the app's active connection. */
@@ -9,6 +11,13 @@ export async function requestPairedMachine<T extends PeerRequestType>(
     type: T,
     params: PeerRequestMap[T]['params'],
 ): Promise<PeerRequestMap[T]['result']> {
+    if (getCachedConnectionSettings().machineId === grant.machineId) {
+        try { return await sync.request(type, params, 12_000); }
+        catch (cause) {
+            if (cause instanceof MuxrRequestError) throw new PeerHostResponseError(cause.message, cause.code);
+            throw cause;
+        }
+    }
     let permanentError: string | undefined;
     let ticketRejected = false;
     const client = new MuxrClient({

--- a/apps/relay/src/relay.ts
+++ b/apps/relay/src/relay.ts
@@ -679,7 +679,13 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
             if (config.localAuthority && localPairing !== undefined && req.method === 'POST'
                 && url.pathname === '/v1/selfhost/peers') {
                 const authority = await resolveAuthority(req);
-                if (authority.machine === undefined) { writeJsonError(res, 403, 'peer issuance requires target machine authority'); return; }
+                if (!authority.owner && authority.machine === undefined) { writeJsonError(res, 403, 'peer issuance requires owner or target machine authority'); return; }
+                const requestedSlug = url.searchParams.get('machine')?.trim() ?? '';
+                if (authority.machine !== undefined && requestedSlug !== '' && requestedSlug !== authority.machine.slug) {
+                    writeJsonError(res, 403, 'machine credential cannot issue for another machine'); return;
+                }
+                const machineSlug = authority.machine?.slug ?? requestedSlug;
+                if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(machineSlug)) { writeJsonError(res, 400, 'machine is required'); return; }
                 const body = (await readJsonBody(req).catch(() => undefined)) as Record<string, unknown> | undefined;
                 const publicKey = typeof body?.device_public_key === 'string' ? body.device_public_key : '';
                 const name = typeof body?.device_name === 'string' ? body.device_name.trim() : '';
@@ -695,7 +701,7 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                     return;
                 }
                 const issued = await localPairing.issuePeer({
-                    machineSlug: authority.machine.slug,
+                    machineSlug,
                     publicKey,
                     name,
                     capabilities,
@@ -731,21 +737,33 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                 const action = peerAuthorityMatch[2];
                 if (req.method === 'POST' && action === 'grant') {
                     const authority = await resolveAuthority(req);
-                    if (authority.machine === undefined) { writeJsonError(res, 403, 'peer grant refresh requires target machine authority'); return; }
+                    if (!authority.owner && authority.machine === undefined) { writeJsonError(res, 403, 'peer grant refresh requires owner or target machine authority'); return; }
+                    const requestedSlug = url.searchParams.get('machine')?.trim() ?? '';
+                    if (authority.machine !== undefined && requestedSlug !== '' && requestedSlug !== authority.machine.slug) {
+                        writeJsonError(res, 403, 'machine credential cannot refresh another machine'); return;
+                    }
+                    const machineSlug = authority.machine?.slug ?? requestedSlug;
+                    if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(machineSlug)) { writeJsonError(res, 400, 'machine is required'); return; }
                     const body = (await readJsonBody(req).catch(() => undefined)) as Record<string, unknown> | undefined;
                     const grant = typeof body?.grant === 'string' ? body.grant : '';
                     const keyVersion = body?.key_version;
                     if (grant === '' || grant.length > 16 * 1024 || typeof keyVersion !== 'number'
-                        || !(await localPairing.storePeerGrant(deviceId, authority.machine.slug, grant, keyVersion))) {
+                        || !(await localPairing.storePeerGrant(deviceId, machineSlug, grant, keyVersion))) {
                         writeJsonError(res, 409, 'peer_grant_invalid'); return;
                     }
-                    closePeers({ accountId: `local:${authority.machine.slug}`, deviceId }, 'peer grant refreshed');
+                    closePeers({ accountId: `local:${machineSlug}`, deviceId }, 'peer grant refreshed');
                     writeJson(res, 200, { ok: true, key_version: keyVersion });
                     return;
                 }
                 if (req.method === 'POST' && action === 'rotate') {
                     const authority = await resolveAuthority(req);
-                    if (authority.machine === undefined) { writeJsonError(res, 403, 'peer credential rotation requires target machine authority'); return; }
+                    if (!authority.owner && authority.machine === undefined) { writeJsonError(res, 403, 'peer credential rotation requires owner or target machine authority'); return; }
+                    const requestedSlug = url.searchParams.get('machine')?.trim() ?? '';
+                    if (authority.machine !== undefined && requestedSlug !== '' && requestedSlug !== authority.machine.slug) {
+                        writeJsonError(res, 403, 'machine credential cannot rotate another machine'); return;
+                    }
+                    const machineSlug = authority.machine?.slug ?? requestedSlug;
+                    if (!/^[a-z0-9][a-z0-9-]{0,62}$/.test(machineSlug)) { writeJsonError(res, 400, 'machine is required'); return; }
                     const body = (await readJsonBody(req).catch(() => undefined)) as Record<string, unknown> | undefined;
                     const expiresAt = body?.credential_expires_at;
                     const refreshAfter = body?.refresh_after;
@@ -753,13 +771,13 @@ export async function startRelay(options: RelayOptions): Promise<RelayHandle> {
                         || refreshAfter !== undefined && (typeof refreshAfter !== 'number' || !Number.isFinite(refreshAfter))) {
                         writeJsonError(res, 400, 'invalid peer credential lifetime'); return;
                     }
-                    const rotated = await localPairing.rotatePeerCredential(deviceId, authority.machine.slug, {
+                    const rotated = await localPairing.rotatePeerCredential(deviceId, machineSlug, {
                         ...(expiresAt === undefined ? {} : { expiresAt }),
                         ...(refreshAfter === undefined ? {} : { refreshAfter }),
                         ...(typeof body?.authority_id === 'string' && body.authority_id !== '' ? { authorityId: body.authority_id.slice(0, 256) } : {}),
                     });
                     if (rotated === undefined) { writeJsonError(res, 404, 'peer_not_found'); return; }
-                    revokePeers({ accountId: `local:${authority.machine.slug}`, deviceId });
+                    revokePeers({ accountId: `local:${machineSlug}`, deviceId });
                     writeJson(res, 200, {
                         device_credential: rotated.credential,
                         credential_version: rotated.credentialVersion,

--- a/scripts/local-setup.mjs
+++ b/scripts/local-setup.mjs
@@ -1302,13 +1302,25 @@ function validMachineCrypto(value, expected) {
                 ? grant : undefined;
         } catch { return undefined; }
     };
-    const validDevice = (device) => typeof device === 'object' && device !== null
-        && typeof device.deviceId === 'string' && device.deviceId.length > 0
-        && validBase64(device.devicePublicKey, 32)
-        && validBase64(device.ingressKey, 32)
-        && typeof device.expiresAt === 'string' && Number.isFinite(Date.parse(device.expiresAt))
-        && (device.kind === undefined || device.kind === 'browser')
-        && (device.authority === undefined || device.authority === 'control' || device.authority === 'observe');
+    const validCapabilities = (capabilities) => Array.isArray(capabilities) && capabilities.length > 0 && capabilities.length <= 6
+        && new Set(capabilities).size === capabilities.length
+        && capabilities.every((capability) => ['list', 'read', 'status', 'watch', 'prompt', 'start'].includes(capability));
+    const validDevice = (device) => {
+        if (typeof device !== 'object' || device === null) return false;
+        const peer = device.kind === 'peer';
+        return typeof device.deviceId === 'string' && device.deviceId.length > 0
+            && validBase64(device.devicePublicKey, 32)
+            && validBase64(device.ingressKey, 32)
+            && typeof device.expiresAt === 'string' && Number.isFinite(Date.parse(device.expiresAt))
+            && (device.kind === undefined || device.kind === 'browser' || peer)
+            && (peer ? device.authority === undefined && validBase64(device.dataKey, 32) && validCapabilities(device.capabilities)
+                : device.dataKey === undefined && device.capabilities === undefined && device.allowedCwds === undefined
+                    && (device.authority === undefined || device.authority === 'control' || device.authority === 'observe'))
+            && (!peer || (device.capabilities.includes('start')
+                ? Array.isArray(device.allowedCwds) && device.allowedCwds.length > 0
+                    && device.allowedCwds.every((cwd) => typeof cwd === 'string' && cwd !== '')
+                : device.allowedCwds === undefined));
+    };
     if (!keys || !Number.isInteger(value.keyVersion) || value.keyVersion < 1
         || !Array.isArray(value.devices) || !value.devices.every(validDevice)
         || new Set(value.devices.map((device) => device.deviceId)).size !== value.devices.length) return false;
@@ -1317,21 +1329,25 @@ function validMachineCrypto(value, expected) {
     if (!validBase64(pending.dataKey, 32) || !Array.isArray(pending.devices) || !pending.devices.every(validDevice)
         || new Set(pending.devices.map((device) => device.deviceId)).size !== pending.devices.length
         || !Array.isArray(pending.grants) || pending.grants.length !== pending.devices.length) return false;
-    const selfhost = pending.kind === 'selfhost-revoke-v1';
-    if (expected === 'hosted' ? selfhost : !selfhost) return false;
-    const versionValid = selfhost
-        ? Number.isInteger(pending.previousKeyVersion) && Number.isInteger(pending.keyVersion)
-            && pending.keyVersion === pending.previousKeyVersion + 1
-            && (value.keyVersion === pending.previousKeyVersion || value.keyVersion === pending.keyVersion)
-            && typeof pending.revokedDeviceId === 'string' && typeof pending.revokedDeviceName === 'string'
-        : pending.kind === undefined && Number.isInteger(pending.keyVersion) && pending.keyVersion === value.keyVersion + 1;
-    if (!versionValid) return false;
+    const kind = pending.kind;
+    const peer = kind === 'peer-revoke-v1';
+    const selfhost = kind === 'selfhost-revoke-v1';
+    if (kind !== undefined && !peer && !selfhost) return false;
+    if (kind === undefined && expected !== 'hosted') return false;
+    if (selfhost && expected !== 'selfhost') return false;
+    if (peer && pending.authorityKind !== expected) return false;
+    const version = pending.keyVersion;
+    if (kind === undefined ? !Number.isInteger(version) || version !== value.keyVersion + 1
+        : !Number.isInteger(pending.previousKeyVersion) || !Number.isInteger(version)
+            || version !== pending.previousKeyVersion + 1
+            || value.keyVersion !== pending.previousKeyVersion && value.keyVersion !== version
+            || typeof pending.revokedDeviceId !== 'string' || typeof pending.revokedDeviceName !== 'string') return false;
     const byId = new Map(pending.devices.map((device) => [device.deviceId, device]));
     const expectedKeys = new Set(pending.devices.map((device) => device.devicePublicKey));
     const seen = new Set();
     return pending.grants.every((entry) => {
         if (typeof entry !== 'object' || entry === null) return false;
-        const deviceKey = selfhost ? byId.get(entry.deviceId)?.devicePublicKey : entry.device_public_key;
+        const deviceKey = kind === undefined ? entry.device_public_key : byId.get(entry.deviceId)?.devicePublicKey ?? entry.devicePublicKey;
         const grant = parseGrant(entry.grant);
         if (typeof deviceKey !== 'string' || !expectedKeys.has(deviceKey) || seen.has(deviceKey) || grant === undefined
             || grant.sender !== value.boxPublicKey || grant.signer !== value.signingPublicKey) return false;
@@ -1953,6 +1969,8 @@ export async function runSelfHost(args = []) {
         state.mintSecret = secretRaw;
         state.relayUrl = advertise.url;
         state.relayLocation = 'local';
+        delete state.machineCredential;
+        delete state.credentialExpiresAt;
         state.relayRole = managedRelay ? 'shared' : 'single-machine';
         state.connectionMode = connectionMode;
         state.webEnabled = web;


### PR DESCRIPTION
Fixes the blockers found in the real Android/Linux/VPS collaboration journey after v0.1.19:

- reuse the active mobile socket instead of racing it with a second credential-identical client
- allow local self-host owner credentials to issue, refresh, and rotate target-scoped peers
- advertise the public self-host relay URL in installed peer bundles
- drop stale remote machine credentials when switching to a local relay
- accept peer devices and peer-revocation recovery in CLI state validation
- let human machine aliases be reused after revocation

Verification:
- strict typecheck
- focused collaboration/peer flows: 6/6
- full suite: 30/30
- real Android emulator + Linux + fresh Hetzner self-host relay: Computers connected
- muxr peers list/status/read/prompt/watch exercised through the ordinary local CLI
- revocation stopped access immediately and fully removed the peer
- final adversarial Fable review running on exact commit 87654b39