### PR TITLE
fix(mobile): reuse relay control channel for voice

### DIFF
--- a/apps/mobile/sources/plugins/openPluginStream.ts
+++ b/apps/mobile/sources/plugins/openPluginStream.ts
@@ -1,20 +1,15 @@
 import {
-    decodePayload,
-    encodePayload,
     issueWsTicket,
     newRealtimeChannel,
-    nextRequestId,
     parseRealtimeClientFrame,
     parseRealtimeHostFrame,
     realtimeSocketUrl,
     ticketSocketUrl,
-    type ClientFrame,
-    type ClientRequest,
     type Envelope,
-    type HostFrame,
     type PluginStreamCapability,
     type RealtimeClientFrame,
     type RealtimeHostFrame,
+    type RequestParams,
 } from '@muxr/contract';
 import { getCachedConnectionSettings } from '@/state/connectionSettings';
 import {
@@ -94,98 +89,15 @@ export async function refreshPluginStreamSnapshot(snapshot: PluginStreamSnapshot
     };
 }
 
-/** One pinned control request; it never consults or refreshes global machine state. */
-async function requestPinnedStream(snapshot: PluginStreamSnapshot, channel: string, sessionId?: string): Promise<void> {
-    const hosted = snapshot.grant === undefined ? undefined : new DeviceV2Crypto(snapshot.grant);
-    const legacyToken = snapshot.mode === 'local' && snapshot.token.startsWith('acctok_');
-    const url = snapshot.token === '' || legacyToken
-        ? `${snapshot.relayUrl}?role=client&machineId=${encodeURIComponent(snapshot.machineId)}${snapshot.token === '' ? '' : `&token=${encodeURIComponent(snapshot.token)}`}`
-        : ticketSocketUrl(snapshot.relayUrl, await issueWsTicket({
-            relayUrl: snapshot.relayUrl,
-            credential: snapshot.token,
-            machineId: snapshot.machineId,
-            role: 'client',
-            transport: 'relay',
-        }), 'relay');
-    const requestId = nextRequestId('voice');
-    await new Promise<void>((resolve, reject) => {
-        const socket = new WebSocket(url);
-        let seq = 0;
-        let done = false;
-        const finish = (error?: Error): void => {
-            if (done) return;
-            done = true;
-            clearTimeout(timer);
-            socket.onopen = null;
-            socket.onmessage = null;
-            socket.onerror = null;
-            socket.onclose = null;
-            socket.close();
-            if (error === undefined) resolve(); else reject(error);
-        };
-        const send = (frame: ClientFrame, streamId = 'machine'): void => {
-            seq += 1;
-            const sealed = hosted?.seal('session', streamId, encodePayload(frame));
-            socket.send(JSON.stringify({
-                header: {
-                    machineId: snapshot.machineId,
-                    ...(streamId === 'machine' ? {} : { sessionId: streamId }),
-                    ...(sealed === undefined ? {} : {
-                        senderId: hosted!.grant.deviceId,
-                        recipientId: snapshot.machineId,
-                        channel: 'session' as const,
-                        streamId,
-                        keyVersion: hosted!.grant.keyVersion,
-                    }),
-                    seq: sealed?.sequence ?? seq,
-                    at: Date.now(),
-                },
-                payload: sealed?.payload ?? encodePayload(frame),
-            } satisfies Envelope));
-        };
-        const timer = setTimeout(() => finish(new Error('stream control request timed out')), 20_000);
-        socket.onopen = () => {
-            send({ type: 'client.hello', clientId: nextRequestId('voice-client') });
-            send({
-                type: 'plugin.stream',
-                requestId,
-                params: {
-                    pluginId: snapshot.pluginId,
-                    manifestHash: snapshot.manifestHash,
-                    contributionId: snapshot.contributionId,
-                    channel,
-                    ...(sessionId === undefined ? {} : { sessionId }),
-                },
-            } as ClientRequest, sessionId);
-        };
-        socket.onerror = () => finish(new Error('stream control connection failed'));
-        socket.onclose = () => finish(new Error('stream control connection closed'));
-        socket.onmessage = (event) => {
-            void (async () => {
-                try {
-                    const envelope = JSON.parse(String(event.data)) as Envelope;
-                    if (envelope.header.machineId !== snapshot.machineId) return;
-                    const streamId = envelope.header.streamId ?? envelope.header.sessionId ?? 'machine';
-                    const plaintext = hosted === undefined ? envelope.payload : (() => {
-                        if (envelope.header.senderId !== snapshot.machineId || envelope.header.recipientId !== '*'
-                            || envelope.header.channel !== 'session' || envelope.header.streamId !== streamId
-                            || envelope.header.keyVersion !== hosted.grant.keyVersion) throw new Error('stream: invalid hosted control context');
-                        return hosted.open('session', streamId, envelope.payload, envelope.header.seq);
-                    })();
-                    const frame = decodePayload<HostFrame>(await plaintext);
-                    if (frame.type !== 'result' || frame.requestId !== requestId) return;
-                    if (frame.ok) finish();
-                    else finish(new Error(frame.error));
-                } catch { finish(new Error('stream control frame rejected')); }
-            })();
-        };
-    });
-}
-
 /** Resolve a semantic stream capability without ever naming a provider/plugin id. */
 export async function openPluginStream(
     capability: string,
-    options: { sessionId?: string; machineId?: string; snapshot?: PluginStreamSnapshot } = {},
+    options: {
+        sessionId?: string;
+        machineId?: string;
+        snapshot?: PluginStreamSnapshot;
+        requestControl: (params: RequestParams<'plugin.stream'>) => Promise<unknown>;
+    },
 ): Promise<PluginStream> {
     const snapshot = options.snapshot ?? await capturePluginStreamSnapshot(
         capability,
@@ -195,7 +107,17 @@ export async function openPluginStream(
     const grant = snapshot.grant;
     const hosted = grant === undefined ? undefined : new DeviceV2Crypto(grant);
     const channel = newRealtimeChannel();
-    await requestPinnedStream(snapshot, channel, options.sessionId);
+    if (getCachedConnectionSettings().machineId !== snapshot.machineId) throw new Error('End voice before switching computers.');
+    // Reuse the main relay client: a second socket receives the same encrypted broadcasts
+    // and can lose the shared replay race before its plugin.stream result arrives.
+    await options.requestControl({
+        pluginId: snapshot.pluginId,
+        manifestHash: snapshot.manifestHash,
+        contributionId: snapshot.contributionId,
+        channel,
+        ...(options.sessionId === undefined ? {} : { sessionId: options.sessionId }),
+    });
+    if (getCachedConnectionSettings().machineId !== snapshot.machineId) throw new Error('End voice before switching computers.');
 
     const relayUrl = snapshot.relayUrl;
     const url = grant !== undefined

--- a/apps/mobile/sources/voice/realtimeSession.spec.ts
+++ b/apps/mobile/sources/voice/realtimeSession.spec.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     })),
     liveAudio: { init: vi.fn(async () => true), start: vi.fn(async () => true), stop: vi.fn(async () => true), on: vi.fn() },
     vad: { claimVadCapture: vi.fn(() => null as string[] | null) },
+    controlRequest: vi.fn(async () => undefined),
     pcm: {
         startRealtimePcm: vi.fn(() => true),
         playRealtimePcm: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock('@/plugins/openPluginStream', () => ({
 vi.mock('react-native-live-audio-stream', () => ({ default: mocks.liveAudio }));
 vi.mock('@/../modules/voice-overlay', () => mocks.pcm);
 vi.mock('@/voice/vadStandby', () => mocks.vad);
+vi.mock('@/sync/sync', () => ({ sync: { request: mocks.controlRequest } }));
 
 import { startRealtimeSession } from './realtimeSession';
 
@@ -96,7 +98,13 @@ describe('generic realtime stream session', () => {
         await vi.waitFor(() => expect(mocks.openStream).toHaveBeenCalledWith('voice.session', {
             sessionId: 's1',
             snapshot: expect.objectContaining({ machineId: 'machine-a', relayUrl: 'wss://relay-a', pluginId: 'voice-a' }),
+            requestControl: expect.any(Function),
         }));
+        const requestControl = mocks.openStream.mock.calls[0]?.[1].requestControl as (params: Record<string, unknown>) => Promise<unknown>;
+        await requestControl({ pluginId: 'voice-a', manifestHash: 'manifest-a', contributionId: 'session', channel: 'rs_voice' });
+        expect(mocks.controlRequest).toHaveBeenCalledWith('plugin.stream', {
+            pluginId: 'voice-a', manifestHash: 'manifest-a', contributionId: 'session', channel: 'rs_voice',
+        });
 
         handle.speak('agent finished');
         stream.frames.forEach((listener) => listener({ type: 'realtime.ready', inputRate: 24_000, outputRate: 24_000 }));

--- a/apps/mobile/sources/voice/realtimeSession.ts
+++ b/apps/mobile/sources/voice/realtimeSession.ts
@@ -15,6 +15,7 @@ import {
     type PluginStream,
 } from '@/plugins/openPluginStream';
 import { claimVadCapture } from '@/voice/vadStandby';
+import { sync } from '@/sync/sync';
 
 export type RealtimeStatus = 'connecting' | 'connected' | 'thinking' | 'speaking' | 'disconnected';
 
@@ -124,6 +125,7 @@ export function startRealtimeSession(options: {
             const next = await openPluginStream('voice.session', {
                 sessionId: target.sessionId,
                 snapshot,
+                requestControl: (params) => sync.request('plugin.stream', params),
             });
             if (stopped) {
                 next.close();


### PR DESCRIPTION
## Summary
- route `plugin.stream` control through the existing authenticated sync client
- keep realtime media on its separate stream transport
- cover the control-request wiring in the existing realtime flow test

## Evidence
- `yarn run check` — 30/30 passed
- API 36 production-config emulator reached Listening without `stream control frame rejected`
- microphone FGS type `0x80`, active unsilenced AudioRecord, communication speaker route
- stop restored normal audio, removed recording, and safely downgraded/removed the shared service

## Release note
This must land before creating the next Android/iOS internal candidates; historical store builds do not contain the fix.