### PR TITLE
release: promote tested Android builds to Closed

### DIFF
--- a/.github/workflows/mobile-closed.yml
+++ b/.github/workflows/mobile-closed.yml
@@ -1,0 +1,118 @@
+name: mobile closed testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      internal_run_id:
+        description: Successful Android mobile internal workflow run for this exact main commit
+        required: true
+        type: string
+      version:
+        description: Tested marketing version, for example 0.1.12
+        required: true
+        type: string
+      android_version_code:
+        description: Exact versionCode completed on Play Internal
+        required: true
+        type: string
+
+concurrency:
+  group: mobile-closed
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tested build identifiers
+        env:
+          INTERNAL_RUN_ID: ${{ inputs.internal_run_id }}
+          APP_VERSION: ${{ inputs.version }}
+          ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+        run: |
+          [[ "$INTERNAL_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$ANDROID_VERSION_CODE" =~ ^[1-9][0-9]*$ ]]
+
+  provenance:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prove the Internal run and exact Android build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INTERNAL_RUN_ID: ${{ inputs.internal_run_id }}
+          APP_VERSION: ${{ inputs.version }}
+          ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$INTERNAL_RUN_ID" > "$RUNNER_TEMP/internal-run.json"
+          jq -e --arg sha "$GITHUB_SHA" '
+            .event == "workflow_dispatch"
+            and .name == "mobile internal testing"
+            and .head_branch == "main"
+            and .head_sha == $sha
+            and .status == "completed"
+            and .conclusion == "success"
+          ' "$RUNNER_TEMP/internal-run.json"
+          mkdir -p "$RUNNER_TEMP/internal-artifact"
+          gh run download "$INTERNAL_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name eas-cloud-result-android \
+            --dir "$RUNNER_TEMP/internal-artifact"
+          jq -e \
+            --arg sha "$GITHUB_SHA" \
+            --arg version "$APP_VERSION" \
+            --arg android "$ANDROID_VERSION_CODE" '
+              length == 1
+              and .[0].platform == "ANDROID"
+              and .[0].gitCommitHash == $sha
+              and .[0].appVersion == $version
+              and .[0].appBuildVersion == $android
+              and (.[0].id | length > 0)
+              and (.[0].submissions | length > 0)
+            ' "$RUNNER_TEMP/internal-artifact/result.json"
+
+  promote:
+    needs: [validate, provenance]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: stores
+    env:
+      PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+      ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - name: Prove the exact build is on Play Internal
+        run: bundle exec fastlane android verify_internal
+      - name: Promote the exact build to Play Closed testing
+        run: bundle exec fastlane android promote_closed
+      - name: Prove the exact build is on Play Closed testing
+        run: bundle exec fastlane android verify_closed
+
+  summary:
+    if: always()
+    needs: [validate, provenance, promote]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write Closed testing summary
+        env:
+          RESULT: ${{ needs.promote.result }}
+          APP_VERSION: ${{ inputs.version }}
+          ANDROID_VERSION_CODE: ${{ inputs.android_version_code }}
+        run: |
+          {
+            echo "## Mobile Closed testing"
+            echo
+            echo "Version: $APP_VERSION"
+            echo "Android versionCode: $ANDROID_VERSION_CODE"
+            echo "Result: $RESULT"
+            echo "Source: exact Play Internal release; no rebuild"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-internal.yml
+++ b/.github/workflows/mobile-internal.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           yarn build
           yarn workspace @muxr/mobile typecheck
-          yarn workspace @muxr/mobile vitest run sources/auth/accountSession.integration.spec.ts sources/sync/sessionSync.integration.spec.ts
+          yarn workspace @muxr/mobile vitest run sources/account/application/accountSession.integration.spec.ts sources/catalog/application/sessionSync.integration.spec.ts
           node scripts/diagnostics/application/checkMobileCommerceBuilds.mjs
           node scripts/diagnostics/application/checkNoSecrets.mjs
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -19,6 +19,10 @@ Runs are serialized so two manual releases cannot race. Build progress and logs 
 
 The `stores` GitHub environment owns `EXPO_TOKEN` (preferred) or `EXPO_STATE_JSON` and `PLAY_SERVICE_ACCOUNT_JSON`. EAS owns the production signing credentials and App Store Connect submission key. Keep all credential material out of the repository.
 
+## Mobile Closed testing
+
+Run `.github/workflows/mobile-closed.yml` with the successful Android internal workflow run, marketing version, and exact Android version code. The workflow proves the Internal run succeeded on the same `main` commit, verifies the recorded EAS build and submission identifiers, confirms the version is available on Play Internal, then promotes that existing release to the `alpha` Closed-testing track. It verifies Closed-track availability after promotion and never rebuilds or uploads another binary.
+
 ## Mobile production promotion
 
 Run `.github/workflows/mobile-production.yml` with the successful all-platform internal workflow run, exact Android version code, and exact iOS build number. The production workflow proves that run succeeded on the same `main` commit and that its recorded artifacts match every supplied version before the protected `production` approval gate opens.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,6 +58,41 @@ platform :android do
     UI.user_error!("Play Internal does not contain versionCode #{expected}") unless versions.include?(expected)
   end
 
+  desc "Promote an existing Play Internal build to Closed testing"
+  lane :promote_closed do
+    upload_to_play_store(
+      package_name: "com.trymuxr.app",
+      json_key_data: ENV.fetch("PLAY_SERVICE_ACCOUNT_JSON"),
+      track: "internal",
+      track_promote_to: "alpha",
+      version_code: ENV.fetch("ANDROID_VERSION_CODE"),
+      track_promote_release_status: "completed",
+      skip_upload_apk: true,
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+
+  desc "Prove the promoted build is completed on Play Closed testing"
+  lane :verify_closed do
+    expected = Integer(ENV.fetch("ANDROID_VERSION_CODE"))
+    versions = []
+    10.times do |attempt|
+      versions = google_play_track_version_codes(
+        package_name: "com.trymuxr.app",
+        json_key_data: ENV.fetch("PLAY_SERVICE_ACCOUNT_JSON"),
+        track: "alpha"
+      ).map(&:to_i)
+      break if versions.include?(expected)
+
+      UI.message("Play Closed has not exposed versionCode #{expected}; retry #{attempt + 1}/10")
+      sleep 15
+    end
+    UI.user_error!("Play Closed does not contain versionCode #{expected}") unless versions.include?(expected)
+  end
+
   desc "Promote an existing Play Internal build to Production"
   lane :promote_production do
     fraction = Integer(ENV.fetch("ROLLOUT_PERCENT", "10")) / 100.0


### PR DESCRIPTION
## Summary
- fixes the Internal release gate paths after the bounded-context move
- adds exact-binary Play Internal → Closed (`alpha`) promotion
- proves workflow-run, commit, version, EAS build, submission, and Play-track provenance
- documents the no-rebuild Closed-testing lane

## Verification
- targeted account/session-sync release flows pass
- mobile commerce and secret release gates pass
- Fastfile and workflow YAML parse successfully
- `git diff --check` passes