### PR TITLE
fix: preserve Play tracks during promotion

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -70,8 +70,10 @@ platform :android do
       skip_upload_apk: true,
       skip_upload_aab: true,
       skip_upload_metadata: true,
+      skip_upload_changelogs: true,
       skip_upload_images: true,
-      skip_upload_screenshots: true
+      skip_upload_screenshots: true,
+      deactivate_on_promote: false
     )
   end
 
@@ -107,8 +109,10 @@ platform :android do
       skip_upload_apk: true,
       skip_upload_aab: true,
       skip_upload_metadata: true,
+      skip_upload_changelogs: true,
       skip_upload_images: true,
-      skip_upload_screenshots: true
+      skip_upload_screenshots: true,
+      deactivate_on_promote: false
     )
   end
 end


### PR DESCRIPTION
Fix exact-binary track promotion so Fastlane does not upload malformed changelog metadata and does not deactivate Internal testing when copying the tested release to Closed or Production. Ruby syntax and diff checks pass.