### PR TITLE
fix: show OMP in new agent catalog

### DIFF
--- a/apps/host/src/agent/domain/agentKinds.test.ts
+++ b/apps/host/src/agent/domain/agentKinds.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { agentKindsFromManifests } from './agentKinds.js';
+
+describe('agentKindsFromManifests', () => {
+    it('includes hook-only agents missing from Herdr screen manifests', () => {
+        expect(agentKindsFromManifests([{ agent: 'opencode' }, { agent: 'pi' }])).toEqual([
+            'omp',
+            'mastracode',
+            'opencode',
+            'pi',
+        ]);
+    });
+});

--- a/apps/host/src/agent/domain/agentKinds.ts
+++ b/apps/host/src/agent/domain/agentKinds.ts
@@ -1,0 +1,10 @@
+const AGENT_KINDS_WITHOUT_SCREEN_MANIFESTS = ['omp', 'mastracode'] as const;
+
+export function agentKindsFromManifests(manifests: readonly { agent?: string }[]): string[] {
+    return [...new Set([
+        ...AGENT_KINDS_WITHOUT_SCREEN_MANIFESTS,
+        ...manifests
+            .map((manifest) => manifest.agent?.trim())
+            .filter((agent): agent is string => agent !== undefined && /^[a-z][a-z0-9_-]{0,31}$/.test(agent)),
+    ])].slice(0, 64);
+}

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -64,10 +64,12 @@ import {
 } from '../domain/layout.js';
 import { rollupLifecycle } from '../domain/lifecycle.js';
 import { reportAgentOutcome } from '../application/reportAgentOutcome.js';
+import { agentKindsFromManifests } from '../domain/agentKinds.js';
 
 const PLUGIN_CALL_QUEUE_TIMEOUT_MS = 8_000;
 const MAX_PLUGIN_INVOCATIONS_PER_SCOPE = 64;
 const MAX_PLUGIN_INVOCATIONS_TOTAL = 1_024;
+
 const moduleRoot = dirname(fileURLToPath(import.meta.url));
 function bundledPluginsDirectory(start: string): string | undefined {
     let dir = start;
@@ -1565,10 +1567,10 @@ export async function createHerdrSessionSource(
 
         async agentKinds(): Promise<string[]> {
             const result = await client.call<{ manifests?: Array<{ agent?: string }> }>('server.agent_manifests', {});
-            return [...new Set((result.manifests ?? [])
-                .map((manifest) => manifest.agent?.trim())
-                .filter((agent): agent is string => agent !== undefined && /^[a-z][a-z0-9_-]{0,31}$/.test(agent)))]
-                .slice(0, 64);
+            // Herdr's endpoint lists screen-detection manifests, not every
+            // launchable integration. OMP and MastraCode report state through
+            // hooks, so include them before probing the host PATH.
+            return agentKindsFromManifests(result.manifests ?? []);
         },
 
         async installedAgentKinds(kinds: readonly string[]): Promise<string[]> {


### PR DESCRIPTION
## What

Include hook-driven OMP and MastraCode integrations in the host agent catalog even though Herdr's `server.agent_manifests` endpoint only lists screen-detection manifests.

## Why

OMP is installed and launchable but was absent from the New agent picker because it reports lifecycle state through hooks rather than a screen manifest.

## Verify

```bash
npx vitest run apps/host/src/agent/domain/agentKinds.test.ts
```

1/1 passed. The full typecheck is currently blocked by pre-existing unresolved `@muxr/contract/{shared,peer,control-plane}` package exports in `packages/crypto`.