### PR TITLE
fix: stabilize mobile reconnects under agent load

### DIFF
--- a/apps/mobile/sources/app/_layout.tsx
+++ b/apps/mobile/sources/app/_layout.tsx
@@ -22,7 +22,7 @@ import { SidebarNavigator } from '@/herd/ui';
 import sodium from '@/encryption/libsodium.lib';
 import { View, Platform, AppState, Pressable, Text } from 'react-native';
 import { ModalProvider } from '@/modal';
-import { syncRestore } from '@/catalog/sync';
+import { syncReconnect, syncRestore } from '@/catalog/sync';
 import { FaviconPermissionIndicator } from '@/components/web/FaviconPermissionIndicator';
 import { CommandPaletteProvider } from '@/components/CommandPalette/CommandPaletteProvider';
 import { StatusBarProvider } from '@/components/StatusBarProvider';
@@ -313,6 +313,17 @@ export default function RootLayout() {
             }, 100);
         }
     }, [initState]);
+
+    React.useEffect(() => {
+        if (initState?.credentials === undefined || Platform.OS === 'web') return;
+        let previous = AppState.currentState;
+        const subscription = AppState.addEventListener('change', (next) => {
+            const resumed = next === 'active' && previous !== 'active';
+            previous = next;
+            if (resumed) void syncReconnect().catch(() => undefined);
+        });
+        return () => subscription.remove();
+    }, [initState?.credentials]);
 
     const handledNotificationIds = React.useRef<Set<string>>(new Set());
     const handleNotificationResponse = React.useCallback(async (response: Notifications.NotificationResponse | null) => {

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
@@ -26,7 +26,7 @@ import {
 } from '@muxr/contract';
 import { DeviceV2Crypto, refreshHostedGrant, type StoredHostedGrant } from '../application/hostedE2ee';
 
-/** `stale`: socket is up but the host stopped answering requests (host process gone). */
+/** `stale`: host liveness is unproven because a request timed out without newer authenticated host traffic. */
 export type ConnectionState = 'connecting' | 'open' | 'closed' | 'stale';
 
 export interface MuxrClientOptions {
@@ -68,6 +68,7 @@ function requestFailure(type: RequestType, error: string, code?: string): MuxrRe
 type EventListener = (sessionId: string, event: SessionEvent) => void;
 type StateListener = (state: ConnectionState) => void;
 type PluginInvalidationListener = (frame: Extract<HostFrame, { type: 'plugins.invalidated' }>) => void;
+const MAX_PENDING_REQUESTS = 128;
 
 export class MuxrClient {
     private socket: WebSocket | undefined;
@@ -81,6 +82,8 @@ export class MuxrClient {
     private readonly clientId = nextRequestId('client');
     private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
     private reconnectAttempt = 0;
+    /** Valid host traffic observed on the current socket. Request timers use it as a liveness fence. */
+    private hostFrameRevision = 0;
 
     state: ConnectionState = 'closed';
 
@@ -98,7 +101,12 @@ export class MuxrClient {
     }
 
     private async open(): Promise<void> {
-        if (this.closed) return;
+        if (this.closed || (this.socket !== undefined
+            && (this.socket.readyState === WebSocket.CONNECTING || this.socket.readyState === WebSocket.OPEN))) return;
+        if (this.reconnectTimer !== undefined) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+        }
         this.setState('connecting');
         const { machineId, token } = this.options;
         let relayUrl = this.options.relayUrl;
@@ -124,6 +132,7 @@ export class MuxrClient {
                     transport: 'relay',
                 }), 'relay');
         } catch (error) {
+            if (this.closed || this.socket !== undefined) return;
             const rejected = error instanceof WsTicketError && (error.status === 401 || error.status === 403);
             const expired = error instanceof Error && /grant expired/i.test(error.message);
             const permanent = expired || rejected && this.hosted?.grant.source === 'selfhost';
@@ -144,10 +153,15 @@ export class MuxrClient {
             }
             return;
         }
+        if (this.closed || this.socket !== undefined) return;
         const socket = new WebSocket(url);
         this.socket = socket;
 
         socket.onopen = () => {
+            if (this.socket !== socket) {
+                socket.close();
+                return;
+            }
             this.reconnectAttempt = 0;
             // The relay accepts a client peer even when no machine is attached,
             // so socket open is not "connected". Stay `connecting` until the
@@ -155,25 +169,40 @@ export class MuxrClient {
             // the host answers client.hello immediately when it is alive.
             this.send({ type: 'client.hello', clientId: this.clientId });
         };
-        socket.onmessage = (message: MessageEvent) => { void this.handleMessage(String(message.data)); };
-        socket.onerror = () => socket.close();
-        socket.onclose = () => {
-            this.setState('closed');
-            if (this.closed) return;
-            const base = this.options.reconnectDelayMs ?? 1500;
-            this.reconnectTimer = setTimeout(() => this.connect(), Math.min(base * 2 ** this.reconnectAttempt++, 30_000));
+        socket.onmessage = (message: MessageEvent) => {
+            if (this.socket === socket) void this.handleMessage(String(message.data));
         };
+        socket.onerror = () => socket.close();
+        socket.onclose = () => this.retireSocket(socket);
     }
 
     close(): void {
         this.closed = true;
-        if (this.reconnectTimer !== undefined) clearTimeout(this.reconnectTimer);
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = undefined;
+        this.rejectPending('client closed');
+        const socket = this.socket;
+        this.socket = undefined;
+        socket?.close();
+        this.setState('closed');
+    }
+
+    private rejectPending(message: string): void {
         for (const pending of this.pending.values()) {
             clearTimeout(pending.timer);
-            pending.reject(new Error('client closed'));
+            pending.reject(new Error(message));
         }
         this.pending.clear();
-        this.socket?.close();
+    }
+
+    private retireSocket(socket: WebSocket): void {
+        if (this.socket !== socket) return;
+        this.socket = undefined;
+        this.rejectPending('connection lost');
+        this.setState('closed');
+        if (this.closed) return;
+        const base = this.options.reconnectDelayMs ?? 1500;
+        this.reconnectTimer = setTimeout(() => this.connect(), Math.min(base * 2 ** this.reconnectAttempt++, 30_000));
     }
 
     onEvent(listener: EventListener): () => void {
@@ -197,18 +226,26 @@ export class MuxrClient {
                 reject(new MuxrRequestError(`${type} requires an authenticated encrypted channel`, 'e2ee-required'));
                 return;
             }
-            if (this.socket === undefined || this.socket.readyState !== 1) {
+            const socket = this.socket;
+            if (socket === undefined || socket.readyState !== WebSocket.OPEN) {
                 reject(new Error('not connected'));
                 return;
             }
+            if (this.pending.size >= MAX_PENDING_REQUESTS) {
+                reject(new Error('too many pending requests'));
+                return;
+            }
             const requestId = nextRequestId('rn');
+            const hostFrameRevision = this.hostFrameRevision;
             const timer = setTimeout(() => {
                 this.pending.delete(requestId);
-                // Demote from `connecting` too: the relay accepts the socket
-                // with no machine attached, and only an answered request ever
-                // proves otherwise — otherwise the app pins on "connecting"
-                // forever. `closed` is excluded; onclose already owns that.
-                if (this.state !== 'closed') this.setState('stale');
+                // A timed-out request proves staleness only when no authenticated
+                // host traffic arrived after it began. Replace that half-open route.
+                if (this.socket === socket && this.hostFrameRevision === hostFrameRevision && this.state !== 'closed') {
+                    this.setState('stale');
+                    this.retireSocket(socket);
+                    socket.close();
+                }
                 // Overwhelmingly the cause is a machineId mismatch: the relay
                 // buffers frames for a machine that never connects, so the
                 // request just never comes back. Name the id being addressed.
@@ -287,6 +324,7 @@ export class MuxrClient {
 
         // Socket open only proves the relay accepted us; the first frame that
         // survives the machine's E2EE context proves the host is really there.
+        this.hostFrameRevision += 1;
         if (this.state !== 'open') this.setState('open');
 
         if (frame.type === 'result') {

--- a/apps/mobile/sources/terminal/application/OpenTerminal.ts
+++ b/apps/mobile/sources/terminal/application/OpenTerminal.ts
@@ -205,6 +205,7 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
                     transport: 'terminal',
                     channel,
                 }), 'terminal');
+        if (closedByUser || socket !== undefined) return;
         const next = new WebSocket(url);
         socket = next;
         let opened = false;

--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -243,7 +243,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
 
     React.useEffect(() => {
         const subscription = AppState.addEventListener('change', (next) => {
-            if (next === 'active') channelRef.current?.reconnect();
+            if (next === 'active') channelRef.current?.repaint();
         });
         return () => subscription.remove();
     }, []);

--- a/scripts/diagnostics/application/connectionLoad.integration.test.ts
+++ b/scripts/diagnostics/application/connectionLoad.integration.test.ts
@@ -1,0 +1,239 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import WebSocket from 'ws';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MuxrClient } from '../../../apps/mobile/sources/pairing/infrastructure/muxrClient.js';
+import { startRelay, type RelayHandle } from '../../../apps/relay/src/relay.js';
+import { createFakeSessionSource } from '../../../apps/host/src/agent/index.js';
+import { startHost, type Host } from '../../../apps/host/src/host.js';
+
+const hostedMocks = vi.hoisted(() => ({
+    refreshHostedGrant: vi.fn(async () => undefined as never),
+}));
+
+vi.mock('../../../apps/mobile/sources/pairing/application/hostedE2ee.js', () => ({
+    refreshHostedGrant: hostedMocks.refreshHostedGrant,
+    DeviceV2Crypto: class {
+        constructor(readonly grant: unknown) {}
+    },
+}));
+
+const delay = (ms: number): Promise<void> => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setTimeout(resolve, ms);
+    return promise;
+};
+
+const waitForState = (client: MuxrClient, expected: typeof client.state): Promise<void> => {
+    if (client.state === expected) return Promise.resolve();
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const off = client.onStateChange((state) => {
+        if (state !== expected) return;
+        off();
+        resolve();
+    });
+    return promise;
+};
+
+describe('connection stability under agent load', () => {
+    let relay: RelayHandle | undefined;
+    let host: Host | undefined;
+    let client: MuxrClient | undefined;
+    let dataDir: string | undefined;
+
+    afterEach(async () => {
+        client?.close();
+        await host?.close();
+        await relay?.close();
+        if (dataDir !== undefined) await rm(dataDir, { recursive: true, force: true });
+        vi.unstubAllGlobals();
+        hostedMocks.refreshHostedGrant.mockReset();
+        hostedMocks.refreshHostedGrant.mockResolvedValue(undefined as never);
+    });
+
+    it('keeps reconnect truth and sync healthy with five active agents', async () => {
+        vi.stubGlobal('WebSocket', WebSocket);
+        dataDir = await mkdtemp(join(tmpdir(), 'muxr-connection-load-'));
+        relay = await startRelay({
+            port: 0,
+            host: '127.0.0.1',
+            config: {
+                dataDir,
+                authMode: 'permissive',
+                e2eeMode: 'off',
+                localAuthority: false,
+                developmentApi: true,
+                advertiseMdns: false,
+            },
+        });
+        const port = relay.port;
+        const source = createFakeSessionSource();
+        for (let index = 0; index < 5; index += 1) await source.start({ cwd: dataDir });
+        const list = source.list.bind(source);
+        source.list = async (options) => {
+            // Real clock delay reproduces the measured host snapshot latency;
+            // fake timers cannot drive ws and the HTTP server event loops.
+            await delay(105);
+            return list(options);
+        };
+        const hostOpened = Promise.withResolvers<void>();
+        host = startHost({
+            relayUrl: `ws://127.0.0.1:${port}`,
+            machineId: 'load-machine',
+            source,
+            domain: { unread: { acknowledge: () => undefined, noteActivity: () => undefined } } as never,
+            onStateChange: (state) => {
+                if (state === 'open') hostOpened.resolve();
+            },
+        });
+        await hostOpened.promise;
+
+        client = new MuxrClient({
+            mode: 'local',
+            relayUrl: `ws://127.0.0.1:${port}`,
+            machineId: 'load-machine',
+            requestTimeoutMs: 500,
+            reconnectDelayMs: 20,
+        });
+        const states: string[] = [];
+        client.onStateChange((state) => states.push(state));
+        const initiallyOpened = waitForState(client, 'open');
+        client.connect();
+        await initiallyOpened;
+
+        const interrupted = client.request('session.list', {}).catch((error: unknown) => error);
+        const clientClosed = waitForState(client, 'closed');
+        await relay.close();
+        await clientClosed;
+        const clientReopened = waitForState(client, 'open');
+        relay = await startRelay({
+            port,
+            host: '127.0.0.1',
+            config: {
+                dataDir,
+                authMode: 'permissive',
+                e2eeMode: 'off',
+                localAuthority: false,
+                developmentApi: true,
+                advertiseMdns: false,
+            },
+        });
+        const reconnectStart = states.length;
+        await clientReopened;
+        await interrupted;
+        expect(states.slice(reconnectStart)).not.toContain('stale');
+
+        const catalogs = await Promise.all(Array.from({ length: 5 }, () => client!.request('session.list', {})));
+        expect(catalogs.every((sessions) => sessions.length === 5)).toBe(true);
+
+        // A path change can leave the phone's old TCP socket looking OPEN even
+        // though the machine route is gone. One unanswered request must retire
+        // that socket before the host returns.
+        await host.close();
+        host = undefined;
+        const routeLostAt = states.length;
+        const stale = waitForState(client, 'stale');
+        const disconnected = waitForState(client, 'closed');
+        const reconnecting = waitForState(client, 'connecting');
+        const lostRequest = client.request('session.list', {}).catch((error: unknown) => error);
+        await stale;
+        await disconnected;
+        await reconnecting;
+        const lostStates = states.slice(routeLostAt);
+        expect(lostStates.indexOf('stale')).toBeLessThan(lostStates.indexOf('closed'));
+        expect(lostStates.indexOf('closed')).toBeLessThan(lostStates.indexOf('connecting'));
+
+        const recoveredSource = createFakeSessionSource();
+        for (let index = 0; index < 5; index += 1) await recoveredSource.start({ cwd: dataDir });
+        const recoveredHost = Promise.withResolvers<void>();
+        const recoveredClient = waitForState(client, 'open');
+        host = startHost({
+            relayUrl: `ws://127.0.0.1:${port}`,
+            machineId: 'load-machine',
+            source: recoveredSource,
+            domain: { unread: { acknowledge: () => undefined, noteActivity: () => undefined } } as never,
+            onStateChange: (state) => {
+                if (state === 'open') recoveredHost.resolve();
+            },
+        });
+        await recoveredHost.promise;
+        await recoveredClient;
+        await lostRequest;
+        await expect(client.request('session.list', {})).resolves.toHaveLength(5);
+
+        // The relay's first server-driven ping is at 30s. Sync after that proves
+        // the real client-host-relay socket stayed responsive through keepalive.
+        await delay(30_500);
+        await expect(client.request('session.list', {})).resolves.toHaveLength(5);
+        expect(client.state).toBe('open');
+    }, 40_000);
+
+    it('keeps explicit close final while ticket or grant acquisition is in flight', async () => {
+        let socketCreations = 0;
+        class CountingWebSocket {
+            static readonly CONNECTING = 0;
+            static readonly OPEN = 1;
+            readyState = CountingWebSocket.CONNECTING;
+            onopen: (() => void) | null = null;
+            onmessage: ((event: MessageEvent) => void) | null = null;
+            onerror: (() => void) | null = null;
+            onclose: (() => void) | null = null;
+            constructor(_url: string) { socketCreations += 1; }
+            send(): void {}
+            close(): void { this.onclose?.(); }
+        }
+        vi.stubGlobal('WebSocket', CountingWebSocket);
+
+        const ticketStarted = Promise.withResolvers<void>();
+        const ticketResponse = Promise.withResolvers<Response>();
+        vi.stubGlobal('fetch', vi.fn(() => {
+            ticketStarted.resolve();
+            return ticketResponse.promise;
+        }));
+        client = new MuxrClient({
+            mode: 'local',
+            relayUrl: 'wss://relay.test',
+            machineId: 'close-boundary',
+            token: 'ticket-credential',
+        });
+        const states: string[] = [];
+        client.onStateChange((state) => states.push(state));
+        client.connect();
+        await ticketStarted.promise;
+        client.close();
+        const closedStateCount = states.length;
+        ticketResponse.resolve(new Response(JSON.stringify({ ticket: 'ticket' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+        }));
+        await delay(0);
+        expect(socketCreations).toBe(0);
+        expect(client.state).toBe('closed');
+        expect(states).toHaveLength(closedStateCount);
+
+        const grantStarted = Promise.withResolvers<void>();
+        const grantResponse = Promise.withResolvers<never>();
+        hostedMocks.refreshHostedGrant.mockImplementationOnce(() => {
+            grantStarted.resolve();
+            return grantResponse.promise;
+        });
+        const permanentError = vi.fn();
+        client = new MuxrClient({
+            mode: 'hosted',
+            relayUrl: 'wss://relay.test',
+            machineId: 'close-boundary',
+            token: 'grant-credential',
+            hostedGrant: {} as never,
+            onPermanentError: permanentError,
+        });
+        client.connect();
+        await grantStarted.promise;
+        client.close();
+        grantResponse.reject(new Error('hosted device grant expired'));
+        await delay(0);
+        expect(permanentError).not.toHaveBeenCalled();
+        expect(client.state).toBe('closed');
+        expect(socketCreations).toBe(0);
+    });
+});


### PR DESCRIPTION
## Stack

Stacked on #151. Base: `feat/compact-agent-activity`. Do not merge before #151 is ready.

## Root causes

The original load flap came from mobile RPC timers surviving WebSocket loss. After a replacement socket received authenticated host traffic and became open, old 20-second timers demoted that healthy socket to stale; the next frame reopened it and triggered another catalog reconciliation. With five active agents, each `session.list` required a measured 103–116 ms Herdr snapshot, amplifying the stale/open cycle into repeated catalog batches.

A Tailscale off/on transition exposed a related but separate recovery gap: React Native could retain a half-open control or terminal socket whose `readyState` still said OPEN. Foreground terminal recovery treated OPEN as healthy and did not replace it. Ticket/grant acquisition can also spend up to 10 seconds in each awaited network leg, so closing or superseding a client during that await previously allowed a late socket/state resurrection.

Bounded live evidence for the load incident showed 232 `session.list` and 231 `machines.list` requests, bursts near five catalog cycles per second, no host request failures, no relay restart loop, empty TCP queues, and no descriptor/process pressure.

## Fix

- Re-check closed/socket ownership after awaited grant and ticket acquisition, before WebSocket creation/assignment.
- Ignore catch-path state and permanent-error callbacks after close or after another open claimed the socket.
- Parenthesize initial connection-ownership precedence and prevent concurrent-open orphan sockets.
- Clear and reject pending RPCs when their owning socket closes; cap pending RPCs at 128.
- Fence stale timeout decisions by current socket plus authenticated-host-frame revision.
- Immediately retire a half-open current socket and schedule a fresh ticketed connection when a request times out without newer authenticated host traffic.
- Rebuild the control connection when the native app returns to foreground, ensuring a network-route change obtains fresh grant/ticket reachability.
- Force a terminal reattach/full repaint on foreground instead of accepting a nominally OPEN stale terminal socket.
- Guard terminal socket creation after awaited ticket acquisition.
- Preserve cached agent lifecycle truth across transient transport loss.

E2EE, replay protection, relay routing authority, and native voice paths remain unchanged.

## Regression flows

The existing real client → relay → host WebSocket flow now covers:

- Five active sessions with measured 105 ms catalog latency.
- Relay interruption during an in-flight sync without a stale/open flap.
- Five concurrent catalog reads and health through the relay's first 30-second server ping.
- A route-loss transition where the relay remains up but the machine disappears: the unanswered request must produce `stale → closed → connecting`, retire the half-open socket, and recover five-session sync when the host returns.
- Close during delayed ticket acquisition: no WebSocket creation or state resurrection.
- Close during delayed grant failure: stable closed state and no permanent-error callback.

## Validation

- Focused mobile control/terminal recovery: 6 tests passed.
- Host connection flows: 7 tests passed.
- Relay routing/persistence flows: 6 tests passed.
- Real five-agent WebSocket reconnect/keepalive suite: 2 tests passed in 33.6 seconds.
- Mobile typecheck passed.
- Root TypeScript build passed.
- Mobile/host/relay architecture tests and both architecture scripts passed.
- `git diff --check` passed.

## Incident impact and residual risks

The currently installed mobile binary does not contain PR #155. It still has the old pending-timer amplification and lacks foreground/half-open socket replacement, so it explains both the slow recovery and why the phone can remain wedged after the host is reachable again. Desktop access remaining healthy is consistent with a mobile-path recovery defect rather than host failure.

Physical radio handoff, Tailscale daemon behavior, WAN loss, and proxy buffering were not reproduced on-device. The flow uses real local WebSockets in development cleartext mode; existing encrypted peer flows cover E2EE behavior. `session.list` still costs roughly 105 ms under this load but is stable after request amplification is removed.