### PR TITLE
fix(mobile): clear final Herd emulator blockers

### DIFF
--- a/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
+++ b/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
@@ -71,6 +71,7 @@ vi.mock('@/utils/sessionUtils', () => ({
     getSessionAvatarId: (session: Session) => session.id,
 }));
 import { applyStatusToSession, sessionInfoToSession } from '../infrastructure/sessionMapping';
+import { applyHostInfoToAgent } from '../domain/agent';
 import { storage } from './storage';
 
 async function spawn(options: { modelMode?: string; effortLevel?: string }) {
@@ -192,6 +193,26 @@ describe('session sync flow', () => {
         expect(mapped.metadata?.paneId).toBe('%1');
         expect(mapped.metadata?.summary?.text).toBe('Stabilizing realtime voice');
         expect(mapped.metadata?.agentName).toBe('Maria');
+        const metadata = mapped.metadata;
+        if (metadata === null) throw new Error('mapped herdr session must have metadata');
+        const stableExisting: Session = {
+            ...mapped,
+            metadata: { ...metadata, terminalTitle: 'stable terminal title' },
+        };
+        const outputOnlyUpdate = sessionInfoToSession({
+            id: 'session-a',
+            paneId: '%1',
+            cwd: '/work/alpha',
+            path: '/work/alpha',
+            created: '2026-01-01T00:00:00Z',
+            modified: '2026-01-01T00:00:01Z',
+            messageCount: 0,
+            firstMessage: '',
+            displayName: 'Maria',
+            taskTitle: 'Stabilizing realtime voice',
+            terminalTitle: 'volatile terminal output',
+        });
+        expect(applyHostInfoToAgent(stableExisting, outputOnlyUpdate)).toBe(stableExisting);
 
         const lifecycle = (agentStatus: 'working' | 'done') => ({
             sessionId: mapped.id,

--- a/apps/mobile/sources/catalog/application/storage.ts
+++ b/apps/mobile/sources/catalog/application/storage.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import React from 'react';
+import deepEqual from 'fast-deep-equal';
 import type { Session, Machine, SessionAgentModesPatch } from '../infrastructure/storageTypes';
 import type { Settings } from './settings';
 import { settingsDefaults } from './settings';
@@ -310,9 +311,13 @@ export const storage = create<StorageState>()((set, get) => ({
         for (const session of sessions) {
             merged[session.id] = mergeCatalogSession(state.sessions[session.id], merged[session.id], session, replace);
         }
+        if (deepEqual(merged, state.sessions)) return state;
         return { sessions: merged, sessionListViewData: buildSessionListViewData(merged) };
     }),
-    applyHerdrTree: (herdrWorkspaces) => set({ herdrWorkspaces, herdrTreeLoaded: true }),
+    applyHerdrTree: (herdrWorkspaces) => set((state) =>
+        state.herdrTreeLoaded && deepEqual(herdrWorkspaces, state.herdrWorkspaces)
+            ? state
+            : { herdrWorkspaces, herdrTreeLoaded: true }),
     applyMachines: (machines, replace = false) => set((state) => {
         const next = replace ? {} as Record<string, Machine> : { ...state.machines };
         for (const machine of machines) next[machine.id] = machine;

--- a/apps/mobile/sources/catalog/application/sync.ts
+++ b/apps/mobile/sources/catalog/application/sync.ts
@@ -324,13 +324,9 @@ class MuxrSync {
             storage.getState().deleteSession(sessionId);
         }
 
-        // Topology only. Status ticks already updated the session row;
-        // refetching the whole tree on every token made the phone hitch.
-        if (
-            event.type === 'session.created'
-            || event.type === 'session.updated'
-            || event.type === 'session.removed'
-        ) {
+        // Only creation and removal change topology. Metadata/output updates are
+        // high-frequency and must not refetch the whole tree.
+        if (event.type === 'session.created' || event.type === 'session.removed') {
             void this.refreshHerdTree().catch(() => undefined);
         }
     }

--- a/apps/mobile/sources/catalog/domain/agent.ts
+++ b/apps/mobile/sources/catalog/domain/agent.ts
@@ -1,4 +1,5 @@
 import { isSessionIdle, normalizeAgentName, type SessionInfo, type SessionStatus } from '@muxr/contract';
+import deepEqual from 'fast-deep-equal';
 import type { Session } from '../infrastructure/storageTypes';
 import {
     lifecycleIsBusy,
@@ -145,16 +146,29 @@ export function mergeCatalogAgent(
 
 /** Live info churn carries a fresh host DTO but no status; keep status-derived fields. */
 export function applyHostInfoToAgent(existing: Session, fresh: Session): Session {
-    return {
+    const known = existing.metadata;
+    const merged: Session = {
         ...existing,
         ...fresh,
         thinking: existing.thinking,
         thinkingAt: existing.thinkingAt,
         agentState: existing.agentState,
         agentStateVersion: existing.agentStateVersion,
-        latestUsage: existing.latestUsage,
-        metadata: existing.metadata === null
+        metadata: known === null
             ? fresh.metadata
-            : { ...existing.metadata, ...fresh.metadata },
+            : {
+                  ...known,
+                  ...fresh.metadata,
+                  ...(known.summary === undefined ? {} : { summary: known.summary }),
+                  ...(known.taskTitle === undefined ? {} : { taskTitle: known.taskTitle }),
+                  ...(known.terminalTitle === undefined ? {} : { terminalTitle: known.terminalTitle }),
+              },
     };
+    const withoutOutputTimestamps: Session = {
+        ...merged,
+        updatedAt: existing.updatedAt,
+        activeAt: existing.activeAt,
+        presence: existing.presence,
+    };
+    return deepEqual(withoutOutputTimestamps, existing) ? existing : merged;
 }

--- a/apps/mobile/sources/catalog/infrastructure/sessionMapping.ts
+++ b/apps/mobile/sources/catalog/infrastructure/sessionMapping.ts
@@ -15,17 +15,17 @@ import {
 
 export const ACTIVE_SESSION_MS = AGENT_STILL_LISTED_MS;
 
-function parseTime(value: string | undefined): number {
-    if (value === undefined) return Date.now();
+function parseTime(value: string | undefined, fallback = Date.now()): number {
+    if (value === undefined) return fallback;
     const parsed = Date.parse(value);
-    return Number.isFinite(parsed) ? parsed : Date.now();
+    return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 
 /** Map a host SessionInfo DTO once into the stored Agent snapshot. */
 export function sessionInfoToSession(info: SessionInfo, status?: SessionStatus): Session {
     const createdAt = parseTime(info.created);
-    const updatedAt = parseTime(info.modified);
+    const updatedAt = parseTime(info.modified, createdAt);
     const now = Date.now();
     const busy = agentIsBusy(status);
     const cwd = info.cwd;

--- a/apps/mobile/sources/herd/application/liveTerminalOrder.spec.ts
+++ b/apps/mobile/sources/herd/application/liveTerminalOrder.spec.ts
@@ -51,7 +51,7 @@ describe('agent lifecycle presentation', () => {
             .map((item) => item.id)).toEqual(['done', 'working', 'blocked']);
     });
 
-    it('keeps a running tree pane through a lagging catalog join without replacing its slot', () => {
+    it('keeps terminal slots stable through catalog joins and equivalent snapshots', () => {
         const pane = (id: string, status: HerdPane['status'], changedAt?: number): HerdPane => ({
             id,
             name: `${id} agent`,
@@ -75,6 +75,11 @@ describe('agent lifecycle presentation', () => {
             ['first', 'blocked', 'first'],
             ['second', 'done', 'second'],
         ]);
+        const equivalent = selectLiveTerminalCards(
+            joined.flatMap((item) => item.session === undefined ? [] : [item.session]),
+            [pane('first', 'blocked', 200), pane('second', 'done', 200)],
+        );
+        expect(reconcileLiveTerminalCards(joined, equivalent)).toBe(joined);
     });
 
     it('shows only unseen meaningful transitions from the last day, latest per agent', () => {

--- a/apps/mobile/sources/herd/application/liveTerminalOrder.ts
+++ b/apps/mobile/sources/herd/application/liveTerminalOrder.ts
@@ -58,7 +58,7 @@ export function orderLiveTerminalCards(cards: readonly LiveTerminalOrderCard[]):
 export function reconcileLiveTerminalCards(
     previous: readonly LiveTerminalOrderCard[],
     current: readonly LiveTerminalOrderCard[],
-): LiveTerminalOrderCard[] {
+): readonly LiveTerminalOrderCard[] {
     const currentById = new Map(current.map((card) => [card.id, card]));
     const existing = previous.flatMap((card) => {
         const updated = currentById.get(card.id);
@@ -66,7 +66,18 @@ export function reconcileLiveTerminalCards(
         currentById.delete(card.id);
         return [updated];
     });
-    return [...existing, ...orderLiveTerminalCards([...currentById.values()])];
+    const next = [...existing, ...orderLiveTerminalCards([...currentById.values()])];
+    const unchanged = next.length === previous.length && next.every((card, index) => {
+        const before = previous[index]!;
+        return card.id === before.id
+            && card.session === before.session
+            && card.status === before.status
+            && card.title === before.title
+            && card.name === before.name
+            && card.changedAt === before.changedAt
+            && card.createdAt === before.createdAt;
+    });
+    return unchanged ? previous : next;
 }
 
 export interface ActivityAcknowledgementViewport {

--- a/apps/mobile/sources/herd/presentation/KernelNotifications.tsx
+++ b/apps/mobile/sources/herd/presentation/KernelNotifications.tsx
@@ -14,10 +14,21 @@ import {
     updateVoiceNotification,
 } from '@/../modules/voice-overlay';
 import { requestNotificationPermission } from '@/utils/microphonePermissions';
-import { completionNotificationState, completionTransition, herdNotificationState, sortHerd } from '../domain/herd';
+import { completionNotificationState, completionTransition, herdNotificationState, sortHerd, type HerdNotificationState } from '../domain/herd';
 import { boundRealtimeSession, configureVadStandby, useRealtimeMuted, useRealtimeSessionState } from '@/conversation/session';
 import { Modal } from '@/modal';
 import { registerNativePushNotifications } from '@/utils/nativePushNotifications';
+
+function sameNotification(
+    left: HerdNotificationState,
+    right: HerdNotificationState,
+): boolean {
+    return left.mode === right.mode
+        && left.count === right.count
+        && left.name === right.name
+        && left.names === right.names
+        && left.eventKey === right.eventKey;
+}
 
 /**
  * Unconditional kernel owner for Android's foreground service and baseline
@@ -52,16 +63,16 @@ export function KernelNotifications() {
     const herdActive = herd.mode === 'working' || herd.mode === 'attention';
 
     React.useEffect(() => {
+        let next = herd;
         if (lifecycleCatalogAvailable) {
             previous.current = null;
-            setPresentation(herd);
-            return;
+        } else {
+            const before = previous.current;
+            const { baseline, completed } = completionTransition(panes, status === 'connected', before);
+            previous.current = baseline;
+            if (before !== null && completed.length > 0) next = completionNotificationState(completed);
         }
-        const before = previous.current;
-        const { baseline, completed } = completionTransition(panes, status === 'connected', before);
-        previous.current = baseline;
-        if (before === null) return setPresentation(herd);
-        setPresentation(completed.length ? completionNotificationState(completed) : herd);
+        setPresentation((current) => sameNotification(current, next) ? current : next);
     }, [herd, lifecycleCatalogAvailable, panes, status]);
 
     React.useEffect(() => {

--- a/apps/mobile/sources/herd/presentation/LiveTerminalsRow.tsx
+++ b/apps/mobile/sources/herd/presentation/LiveTerminalsRow.tsx
@@ -145,9 +145,11 @@ export const LiveTerminalsRow = React.memo(({
         () => selectLiveTerminalCards(sessions, panes),
         [panes, sessions],
     );
-    const [cards, setCards] = React.useState(() => reconcileLiveTerminalCards([], candidateCards));
-    React.useEffect(() => {
-        setCards((current) => reconcileLiveTerminalCards(current, candidateCards));
+    const cardsRef = React.useRef<readonly LiveTerminalOrderCard[]>([]);
+    const cards = React.useMemo(() => {
+        const next = reconcileLiveTerminalCards(cardsRef.current, candidateCards);
+        cardsRef.current = next;
+        return next;
     }, [candidateCards]);
     const activityRows = React.useMemo(
         () => ready ? unseenActivityRows(lifecycleEvents, seenEventIds) : [],


### PR DESCRIPTION
## Problem
- real Herd session output emitted high-frequency session snapshots, repeatedly rerendering VirtualizedList surfaces until the dev client hit Maximum update depth
- that churn continuously restarted the one-second activity visibility timer, so a fully visible completed card never acknowledged its row

## Fix
- suppress output-only session metadata churn and stop refetching topology for metadata updates
- preserve stable notification/card snapshots while applying real lifecycle changes
- keep equivalent catalog/tree snapshots referentially stable
- extend the existing activity/session flow coverage

## Verification
- root + mobile typechecks
- focused activity/tree/session flows: 12 passed
- full `yarn run check`: 34/34 passed
- Android API 36 x86_64 debug/dev-client build and install
- actual emulator: offscreen activity remained, partially visible card remained, fully visible foreground card cleared after one second and stayed cleared across restart
- actual dev client stayed connected with no Maximum update depth recurrence

Stacked on `feat/compact-agent-activity`. Do not merge yet.