### PR TITLE
Fix mobile Stop agent routing

### DIFF
--- a/apps/host/src/agent/application/openTerminal.ts
+++ b/apps/host/src/agent/application/openTerminal.ts
@@ -15,7 +15,6 @@ export type OpenTerminalResult =
 export interface TerminalPort {
     attach(command: OpenTerminalCommand): Promise<{ paneId: string }>;
     detach(channel: string, deviceId?: string): void;
-    detachSession?(sessionId: string): void;
 }
 
 export async function openTerminal(port: TerminalPort | undefined, command: OpenTerminalCommand): Promise<OpenTerminalResult> {

--- a/apps/host/src/agent/application/stopAgent.ts
+++ b/apps/host/src/agent/application/stopAgent.ts
@@ -9,12 +9,10 @@ export type StopAgentResult = { ok: true; data: null } | { ok: false; error: str
 
 export interface StopAgentPorts {
     sessions: Pick<SessionSource, 'stop' | 'abort' | 'reload'>;
-    detachSession?: (sessionId: string) => void;
 }
 
 export async function stopAgent(ports: StopAgentPorts, command: StopAgentCommand): Promise<StopAgentResult> {
     if (command.action === 'stop') {
-        ports.detachSession?.(command.sessionId);
         await ports.sessions.stop(command.sessionId);
         return { ok: true, data: null };
     }

--- a/apps/host/src/agent/infrastructure/fakeSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/fakeSessionSource.ts
@@ -334,7 +334,9 @@ export function createFakeSessionSource(): SessionSource {
 
         async abort() {},
         async stop(sessionId) {
+            requireSession(sessionId);
             sessions.delete(sessionId);
+            emit(sessionId, { type: 'session.removed' });
         },
         async reload() {},
         subscribe(listener) {

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -171,6 +171,113 @@ export async function sendKeysToLiveAgent(
     await client.call('agent.send_keys', { target: record.paneId, keys });
 }
 
+function agentRouteError(code: 'agent-unavailable' | 'agent-route-ambiguous'): Error {
+    const message = code === 'agent-route-ambiguous'
+        ? 'That Agent Route is ambiguous. Refresh and select the agent again.'
+        : 'That agent is no longer available. Refresh and try again.';
+    return Object.assign(new Error(message), { code });
+}
+
+/** Close one pane only when Herdr can preserve its tab and workspace. */
+export async function closeExactPane(
+    client: Pick<HerdrClient, 'call'>,
+    paneId: string,
+    panes: ReadonlyMap<string, Pick<PaneRecord, 'tab_id'>>,
+): Promise<void> {
+    const tabId = panes.get(paneId)?.tab_id;
+    if (tabId === undefined) {
+        throw Object.assign(new Error('That pane is no longer available. Refresh and try again.'), { code: 'pane-unavailable' });
+    }
+    let paneCount = 0;
+    for (const pane of panes.values()) {
+        if (pane.tab_id === tabId) paneCount += 1;
+    }
+    if (paneCount <= 1) {
+        throw Object.assign(new Error('Closing this pane would also close its tab. Use Close tab instead.'), { code: 'pane-close-would-widen' });
+    }
+    await client.call('pane.close', { pane_id: paneId });
+}
+
+/** Close one tab only when Herdr can preserve its workspace. */
+export async function closeExactTab(
+    client: Pick<HerdrClient, 'call'>,
+    tabId: string,
+    tabs: ReadonlyMap<string, Pick<TabRecord, 'workspace_id'>>,
+): Promise<void> {
+    const workspaceId = tabs.get(tabId)?.workspace_id;
+    if (workspaceId === undefined) {
+        throw Object.assign(new Error('That tab is no longer available. Refresh and try again.'), { code: 'tab-unavailable' });
+    }
+    let tabCount = 0;
+    for (const tab of tabs.values()) {
+        if (tab.workspace_id === workspaceId) tabCount += 1;
+    }
+    if (tabCount <= 1) {
+        throw Object.assign(new Error('Closing this tab would also close its workspace. Use Close workspace instead.'), { code: 'tab-close-would-widen' });
+    }
+    await client.call('tab.close', { tab_id: tabId });
+}
+
+/** Close one workspace, refusing Herdr's implicit parent-worktree group widening. */
+export async function closeExactWorkspace(
+    client: Pick<HerdrClient, 'call'>,
+    workspaceId: string,
+    workspaces: ReadonlyMap<string, WorkspaceRecord>,
+): Promise<void> {
+    const workspace = workspaces.get(workspaceId);
+    if (workspace === undefined) {
+        throw Object.assign(new Error('That workspace is no longer available. Refresh and try again.'), { code: 'workspace-unavailable' });
+    }
+    const worktree = workspace.worktree;
+    if (worktree?.is_linked_worktree === false && worktree.repo_key !== undefined) {
+        let groupSize = 0;
+        for (const candidate of workspaces.values()) {
+            if (candidate.worktree?.repo_key === worktree.repo_key) groupSize += 1;
+        }
+        if (groupSize >= 2) {
+            throw Object.assign(new Error('Closing this workspace would close its worktree group. Use the explicit Close worktree group action instead.'), {
+                code: 'worktree-group-confirmation-required',
+            });
+        }
+    }
+    await client.call('workspace.close', { workspace_id: workspaceId });
+}
+
+/** Close exactly the live pane or sole-pane tab selected by one stable Agent Route. */
+export async function closeAgentRoute(
+    client: Pick<HerdrClient, 'call'>,
+    sessionId: string,
+    identities: readonly Pick<AgentIdentity, 'sessionId' | 'paneId'>[],
+    liveAgents: Pick<ReadonlyMap<string, unknown>, 'has'>,
+    panes: ReadonlyMap<string, Pick<PaneRecord, 'tab_id'>>,
+    tabs: ReadonlyMap<string, Pick<TabRecord, 'workspace_id'>>,
+    afterClose: (record: Pick<AgentIdentity, 'sessionId' | 'paneId'>) => void,
+): Promise<void> {
+    let match: Pick<AgentIdentity, 'sessionId' | 'paneId'> | undefined;
+    for (const identity of identities) {
+        if (identity.sessionId !== sessionId) continue;
+        if (match !== undefined) throw agentRouteError('agent-route-ambiguous');
+        match = identity;
+    }
+    if (match === undefined || !liveAgents.has(match.paneId)) throw agentRouteError('agent-unavailable');
+    const tabId = panes.get(match.paneId)?.tab_id;
+    if (tabId === undefined) throw agentRouteError('agent-unavailable');
+    let paneCount = 0;
+    for (const pane of panes.values()) {
+        if (pane.tab_id === tabId) paneCount += 1;
+    }
+    if (paneCount === 0) throw agentRouteError('agent-unavailable');
+    try {
+        if (paneCount > 1) await closeExactPane(client, match.paneId, panes);
+        else await closeExactTab(client, tabId, tabs);
+    } catch (error) {
+        if (error !== null && typeof error === 'object' && 'code' in error
+            && (error.code === 'pane-close-would-widen' || error.code === 'tab-close-would-widen')) throw error;
+        throw agentRouteError('agent-unavailable');
+    }
+    afterClose(match);
+}
+
 
 interface PaneRecord {
     pane_id: string;
@@ -191,7 +298,13 @@ interface WorkspaceRecord {
     workspace_id: string;
     label?: string;
     focused?: boolean;
-    worktree?: { repo_name?: string; repo_root?: string; checkout_path?: string };
+    worktree?: {
+        repo_key?: string;
+        repo_name?: string;
+        repo_root?: string;
+        checkout_path?: string;
+        is_linked_worktree?: boolean;
+    };
 }
 
 interface TabRecord {
@@ -838,9 +951,7 @@ export async function createHerdrSessionSource(
     }
 
     function agentUnavailable(): Error {
-        const error = new Error('That agent is no longer available. Refresh and try again.') as Error & { code: string };
-        error.code = 'agent-unavailable';
-        return error;
+        return agentRouteError('agent-unavailable');
     }
 
     async function resolvePane(sessionId: string): Promise<AgentIdentity> {
@@ -1875,16 +1986,19 @@ export async function createHerdrSessionSource(
 
         async closeTab(sessionId: string, tabId: string): Promise<void> {
             await resolvePane(sessionId);
-            await client.call('tab.close', { tab_id: tabId });
+            await closeExactTab(client, tabId, tabsById);
         },
 
         async closePane(sessionId: string): Promise<void> {
             const record = await resolvePane(sessionId);
-            await client.call('pane.close', { pane_id: record.paneId });
+            await closeExactPane(client, record.paneId, panesById);
         },
 
         async closeWorkspace(workspaceId: string): Promise<void> {
-            await client.call('workspace.close', { workspace_id: workspaceId });
+            try { await refreshSnapshot(); } catch {
+                throw Object.assign(new Error('That workspace is no longer available. Refresh and try again.'), { code: 'workspace-unavailable' });
+            }
+            await closeExactWorkspace(client, workspaceId, workspacesById);
         },
 
         async createTab(sessionId: string, options: { kind?: string; label?: string }): Promise<void> {
@@ -1943,17 +2057,20 @@ export async function createHerdrSessionSource(
         },
 
         async stop(sessionId: string): Promise<void> {
-            pluginStreams?.closeSession(sessionId);
-            const record = await resolvePane(sessionId);
-            await client.call('pane.close', { pane_id: record.paneId }).catch(() => {});
-            // Close the pane's status watch BEFORE removing the identity record --
-            // the syncDiscovery cleanup only walks live records, so a watch
-            // orphaned here leaks a socket (and its reconnect loop) forever.
-            statusWatches.get(record.paneId)?.();
-            statusWatches.delete(record.paneId);
-            identity.remove(sessionId);
-            options.lifecycle?.remove(sessionId);
-            clearAttention(sessionId);
+            try { await refreshSnapshot(); } catch { throw agentUnavailable(); }
+            await closeAgentRoute(client, sessionId, identity.all(), agentsByPane, panesById, tabsById, (record) => {
+                pluginStreams?.closeSession(record.sessionId);
+                statusWatches.get(record.paneId)?.();
+                statusWatches.delete(record.paneId);
+                lifecycleEpochByPane.delete(record.paneId);
+                lastStateSignature.delete(record.sessionId);
+                lastInfoSignature.delete(record.sessionId);
+                attachments.dropPane(record.paneId);
+                identity.remove(record.sessionId);
+                options.lifecycle?.remove(record.sessionId);
+                clearAttention(record.sessionId);
+                publish(record.sessionId, { type: 'session.removed' });
+            });
         },
 
         async abort(sessionId: string): Promise<void> {

--- a/apps/host/src/agent/infrastructure/layoutSelfCheck.ts
+++ b/apps/host/src/agent/infrastructure/layoutSelfCheck.ts
@@ -13,7 +13,7 @@ import {
 import { lifecycleReasonForObservation } from '../domain/lifecycle.js';
 import { IdentityStore, parseTaskTitle } from './identity.js';
 import { RealtimeCodingCoordinator } from './realtimeCoordinator.js';
-import { sendKeysToLiveAgent } from './herdrSessionSource.js';
+import { closeAgentRoute, closeExactPane, closeExactTab, closeExactWorkspace, sendKeysToLiveAgent } from './herdrSessionSource.js';
 import { createConnection } from 'node:net';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -174,6 +174,136 @@ async function demo(): Promise<void> {
     assert(JSON.stringify(herdrKeyCalls) === JSON.stringify([{
         method: 'agent.send_keys', params: { target: 'w1:p2', keys: ['escape'] },
     }]), 'runtime Agent Name reuse cannot redirect Escape or session.answer away from the authoritative pane');
+    const stopCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let failStopClose = false;
+    const stopClient = {
+        call: async <T>(method: string, params: Record<string, unknown> = {}): Promise<T> => {
+            stopCalls.push({ method, params });
+            if (failStopClose) throw new Error('close failed');
+            return undefined as T;
+        },
+    };
+    let stopIdentities = [
+        { sessionId: 'route-selected', paneId: 'w1:p2' },
+        { sessionId: 'route-sibling', paneId: 'w1:p3' },
+        { sessionId: 'route-sole', paneId: 'w1:p4' },
+    ];
+    const liveStopAgents = new Set(['w1:p2', 'w1:p3', 'w1:p4']);
+    const stopPanes = new Map([
+        ['w1:p2', { tab_id: 'w1:t1' }],
+        ['w1:p3', { tab_id: 'w1:t1' }],
+        ['w1:p4', { tab_id: 'w1:t2' }],
+        ['w1:p5', { tab_id: 'w1:t3' }],
+    ]);
+    const stopTabs = new Map([
+        ['w1:t1', { workspace_id: 'w1' }],
+        ['w1:t2', { workspace_id: 'w1' }],
+        ['w1:t3', { workspace_id: 'w1' }],
+    ]);
+    const cleanupCalls: string[] = [];
+    const recordCleanup = (record: { sessionId: string }): void => { cleanupCalls.push(record.sessionId); };
+    await closeAgentRoute(stopClient, 'route-selected', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup);
+    await closeAgentRoute(stopClient, 'route-sole', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup);
+    assert(JSON.stringify(stopCalls) === JSON.stringify([
+        { method: 'pane.close', params: { pane_id: 'w1:p2' } },
+        { method: 'tab.close', params: { tab_id: 'w1:t2' } },
+    ]), 'session.stop closes one selected pane in a split tab and one selected sole-pane tab');
+    assert(JSON.stringify(cleanupCalls) === JSON.stringify(['route-selected', 'route-sole']), 'route-owned plugin streams, status, and identity clean up only after each successful exact close');
+    stopIdentities = [{ sessionId: 'route-last-tab', paneId: 'w2:p4' }];
+    liveStopAgents.add('w2:p4');
+    stopPanes.set('w2:p4', { tab_id: 'w2:t4' });
+    stopTabs.set('w2:t4', { workspace_id: 'w2' });
+    let lastTabStopError: unknown;
+    try { await closeAgentRoute(stopClient, 'route-last-tab', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup); }
+    catch (error) { lastTabStopError = error; }
+    const lastTabStopCode = lastTabStopError !== null && typeof lastTabStopError === 'object' && 'code' in lastTabStopError
+        ? lastTabStopError.code
+        : undefined;
+    assert(lastTabStopCode === 'tab-close-would-widen' && stopCalls.length === 2 && cleanupCalls.length === 2, 'Stop agent refuses a sole last tab instead of closing its workspace');
+    assert(stopCalls.every(({ method }) => method !== 'workspace.close' && !method.startsWith('worktree.')), 'session.stop never closes a workspace or worktree group');
+    stopIdentities = [{ sessionId: 'route-stale', paneId: 'w9:p9' }];
+    liveStopAgents.clear();
+    let staleStopError: unknown;
+    try { await closeAgentRoute(stopClient, 'route-stale', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup); }
+    catch (error) { staleStopError = error; }
+    const staleStopCode = staleStopError !== null && typeof staleStopError === 'object' && 'code' in staleStopError
+        ? staleStopError.code
+        : undefined;
+    assert(staleStopCode === 'agent-unavailable' && stopCalls.length === 2 && cleanupCalls.length === 2, 'stale Agent Route rejects without mutation or cleanup');
+    stopIdentities = [
+        { sessionId: 'route-ambiguous', paneId: 'w2:p1' },
+        { sessionId: 'route-ambiguous', paneId: 'w2:p2' },
+    ];
+    liveStopAgents.add('w2:p1');
+    liveStopAgents.add('w2:p2');
+    let ambiguousStopError: unknown;
+    try { await closeAgentRoute(stopClient, 'route-ambiguous', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup); }
+    catch (error) { ambiguousStopError = error; }
+    const ambiguousStopCode = ambiguousStopError !== null && typeof ambiguousStopError === 'object' && 'code' in ambiguousStopError
+        ? ambiguousStopError.code
+        : undefined;
+    assert(ambiguousStopCode === 'agent-route-ambiguous' && stopCalls.length === 2 && cleanupCalls.length === 2, 'ambiguous Agent Route rejects without mutation or cleanup');
+    stopIdentities = [{ sessionId: 'route-failed-close', paneId: 'w3:p1' }];
+    liveStopAgents.clear();
+    liveStopAgents.add('w3:p1');
+    stopPanes.set('w3:p1', { tab_id: 'w3:t1' });
+    stopTabs.set('w3:t1', { workspace_id: 'w3' });
+    stopTabs.set('w3:t2', { workspace_id: 'w3' });
+    failStopClose = true;
+    try { await closeAgentRoute(stopClient, 'route-failed-close', stopIdentities, liveStopAgents, stopPanes, stopTabs, recordCleanup); }
+    catch {}
+    assert(cleanupCalls.length === 2, 'failed exact close leaves plugin streams, status, and identity untouched');
+    const explicitCloseCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const explicitCloseClient = {
+        call: async <T>(method: string, params: Record<string, unknown> = {}): Promise<T> => {
+            explicitCloseCalls.push({ method, params });
+            return undefined as T;
+        },
+    };
+    const explicitPanes = new Map([
+        ['w4:p1', { tab_id: 'w4:t1' }],
+        ['w4:p2', { tab_id: 'w4:t1' }],
+    ]);
+    const explicitTabs = new Map([
+        ['w4:t2', { workspace_id: 'w4' }],
+        ['w4:t3', { workspace_id: 'w4' }],
+    ]);
+    await closeExactPane(explicitCloseClient, 'w4:p1', explicitPanes);
+    await closeExactTab(explicitCloseClient, 'w4:t2', explicitTabs);
+    let paneWidenError: unknown;
+    try { await closeExactPane(explicitCloseClient, 'w7:p1', new Map([['w7:p1', { tab_id: 'w7:t1' }]])); }
+    catch (error) { paneWidenError = error; }
+    let tabWidenError: unknown;
+    try { await closeExactTab(explicitCloseClient, 'w8:t1', new Map([['w8:t1', { workspace_id: 'w8' }]])); }
+    catch (error) { tabWidenError = error; }
+    const paneWidenCode = paneWidenError !== null && typeof paneWidenError === 'object' && 'code' in paneWidenError
+        ? paneWidenError.code
+        : undefined;
+    const tabWidenCode = tabWidenError !== null && typeof tabWidenError === 'object' && 'code' in tabWidenError
+        ? tabWidenError.code
+        : undefined;
+    assert(paneWidenCode === 'pane-close-would-widen' && tabWidenCode === 'tab-close-would-widen'
+        && explicitCloseCalls.length === 2, 'Close pane and Close tab refuse hidden widening without mutation');
+    await closeExactWorkspace(explicitCloseClient, 'w4', new Map([['w4', { workspace_id: 'w4' }]]));
+    const groupedWorkspaces = new Map([
+        ['w5', { workspace_id: 'w5', worktree: { repo_key: 'repo', is_linked_worktree: false } }],
+        ['w6', { workspace_id: 'w6', worktree: { repo_key: 'repo', is_linked_worktree: true } }],
+    ]);
+    await closeExactWorkspace(explicitCloseClient, 'w6', groupedWorkspaces);
+    assert(JSON.stringify(explicitCloseCalls) === JSON.stringify([
+        { method: 'pane.close', params: { pane_id: 'w4:p1' } },
+        { method: 'tab.close', params: { tab_id: 'w4:t2' } },
+        { method: 'workspace.close', params: { workspace_id: 'w4' } },
+        { method: 'workspace.close', params: { workspace_id: 'w6' } },
+    ]), 'Close pane, Close tab, and Close workspace each issue exactly their named Herdr RPC');
+    let groupCloseError: unknown;
+    try { await closeExactWorkspace(explicitCloseClient, 'w5', groupedWorkspaces); }
+    catch (error) { groupCloseError = error; }
+    const groupCloseCode = groupCloseError !== null && typeof groupCloseError === 'object' && 'code' in groupCloseError
+        ? groupCloseError.code
+        : undefined;
+    assert(groupCloseCode === 'worktree-group-confirmation-required' && explicitCloseCalls.length === 4, 'parent worktree workspace requires an explicit group action without mutation');
+    assert(explicitCloseCalls.every(({ method }) => !method.startsWith('worktree.')), 'no ordinary close action can close a worktree group');
     await rediscovered.flush();
     const afterMove = new IdentityStore(stableDir);
     await afterMove.load();

--- a/apps/host/src/agent/infrastructure/terminalManager.ts
+++ b/apps/host/src/agent/infrastructure/terminalManager.ts
@@ -349,12 +349,6 @@ export class TerminalManager {
         attachment.close();
     }
 
-    /** Kill every stream bound to a session (session.stop, host shutdown). */
-    detachSession(sessionId: string): void {
-        for (const [channel, attachment] of this.attachments) {
-            if (attachment.sessionId === sessionId) this.detach(channel);
-        }
-    }
 
     closeAll(): void {
         for (const channel of [...this.attachments.keys()]) this.detach(channel);

--- a/apps/host/src/requests/application/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/application/createRequestDispatcher.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { MISSING_CWD_ERROR_PREFIX } from '@muxr/contract';
 import { createRequestDispatcher } from './createRequestDispatcher.js';
-import type { SessionSource } from '../../agent/index.js';
+import { createFakeSessionSource, type SessionSource } from '../../agent/index.js';
 import { hostPlatformLabel } from '../../machine/index.js';
 
 function dispatcherWithSpy(): { dispatch: ReturnType<typeof createRequestDispatcher>['dispatch']; started: string[] } {
@@ -100,6 +100,103 @@ describe('agent lifecycle request flow', () => {
             error: 'That agent is no longer available. Refresh and try again.',
         });
         expect(JSON.stringify(stale)).not.toMatch(/\/|prompt|pane-|stable-session/);
+    });
+});
+
+describe('session.stop dispatcher flow', () => {
+    it('forwards only the Agent Route through SessionSource and preserves safe failures', async () => {
+        const stops: string[] = [];
+        const source = {
+            async stop(sessionId: string) {
+                stops.push(sessionId);
+                if (sessionId === 'route-selected') return;
+                const ambiguous = sessionId === 'route-ambiguous';
+                const error = Object.assign(new Error(ambiguous
+                    ? 'That Agent Route is ambiguous. Refresh and select the agent again.'
+                    : 'That agent is no longer available. Refresh and try again.'), {
+                    code: ambiguous ? 'agent-route-ambiguous' : 'agent-unavailable',
+                });
+                throw error;
+            },
+        } as unknown as SessionSource;
+        const { dispatch } = createRequestDispatcher({
+            source,
+            domain: {} as never,
+            machineId: 'm1',
+            hostVersion: '0.0.0',
+        });
+
+        await expect(dispatch({
+            type: 'session.stop', requestId: 'stop-live', params: { sessionId: 'route-selected' },
+        } as never)).resolves.toMatchObject({ ok: true, data: null });
+        const stale = await dispatch({
+            type: 'session.stop', requestId: 'stop-stale', params: { sessionId: 'route-stale' },
+        } as never);
+        expect(stale).toMatchObject({ ok: false, code: 'agent-unavailable', error: 'That agent is no longer available. Refresh and try again.' });
+        const ambiguous = await dispatch({
+            type: 'session.stop', requestId: 'stop-ambiguous', params: { sessionId: 'route-ambiguous' },
+        } as never);
+        expect(ambiguous).toMatchObject({ ok: false, code: 'agent-route-ambiguous', error: 'That Agent Route is ambiguous. Refresh and select the agent again.' });
+        expect(stops).toEqual(['route-selected', 'route-stale', 'route-ambiguous']);
+        expect([stale, ambiguous].map((result) => 'error' in result ? result.error : '').join(' ')).not.toMatch(/w\d+:p\d+|route-(?:stale|ambiguous)/);
+    });
+
+    it('fake mode closes only the selected session layout and preserves its sibling', async () => {
+        const source = createFakeSessionSource();
+        await source.start({ cwd: '/tmp/fake-stop' });
+        await source.start({ cwd: '/tmp/fake-stop' });
+        const before = await source.list();
+        const selected = before[0]!;
+        const sibling = before[1]!;
+        const events: Array<{ sessionId: string; type: string }> = [];
+        source.subscribe((sessionId, event) => events.push({ sessionId, type: event.type }));
+        const { dispatch } = createRequestDispatcher({
+            source,
+            domain: {} as never,
+            machineId: 'm1',
+            hostVersion: '0.0.0',
+        });
+
+        await expect(dispatch({
+            type: 'session.stop', requestId: 'stop-fake', params: { sessionId: selected.id },
+        } as never)).resolves.toMatchObject({ ok: true, data: null });
+        await expect(source.list()).resolves.toEqual([sibling]);
+        await expect(source.open({ sessionId: sibling.id })).resolves.toMatchObject({ info: { id: sibling.id } });
+        await expect(source.open({ sessionId: selected.id })).rejects.toThrow('unknown session');
+        expect(events).toContainEqual({ sessionId: selected.id, type: 'session.removed' });
+        await source.dispose();
+    });
+});
+
+describe('explicit layout close dispatcher flow', () => {
+    it('forwards each named target without widening or narrowing its scope', async () => {
+        const closes: unknown[] = [];
+        const source = {
+            async closePane(sessionId: string) { closes.push({ type: 'pane', sessionId }); },
+            async closeTab(sessionId: string, tabId: string) { closes.push({ type: 'tab', sessionId, tabId }); },
+            async closeWorkspace(workspaceId: string) { closes.push({ type: 'workspace', workspaceId }); },
+        } as unknown as SessionSource;
+        const { dispatch } = createRequestDispatcher({
+            source,
+            domain: {} as never,
+            machineId: 'm1',
+            hostVersion: '0.0.0',
+        });
+
+        await expect(dispatch({
+            type: 'pane.close', requestId: 'close-pane', params: { sessionId: 'route-pane' },
+        } as never)).resolves.toMatchObject({ ok: true, data: null });
+        await expect(dispatch({
+            type: 'tab.close', requestId: 'close-tab', params: { sessionId: 'route-tab', tabId: 'tab-selected' },
+        } as never)).resolves.toMatchObject({ ok: true, data: null });
+        await expect(dispatch({
+            type: 'workspace.close', requestId: 'close-workspace', params: { workspaceId: 'workspace-selected' },
+        } as never)).resolves.toMatchObject({ ok: true, data: null });
+        expect(closes).toEqual([
+            { type: 'pane', sessionId: 'route-pane' },
+            { type: 'tab', sessionId: 'route-tab', tabId: 'tab-selected' },
+            { type: 'workspace', workspaceId: 'workspace-selected' },
+        ]);
     });
 });
 

--- a/apps/host/src/requests/application/createRequestDispatcher.ts
+++ b/apps/host/src/requests/application/createRequestDispatcher.ts
@@ -187,8 +187,7 @@ export function createRequestDispatcher(options: RequestDispatcherOptions): {
         'session.answer': async (params) => useCaseData(await answerAgent(source, params)),
         'pane.zoom': (params) => source.paneZoom(params),
         'session.stop': async (params) => useCaseData(await stopAgent(
-            { sessions: source, detachSession: (sessionId) => options.terminals?.detachSession(sessionId) },
-            { sessionId: params.sessionId, action: 'stop' },
+            { sessions: source }, { sessionId: params.sessionId, action: 'stop' },
         )),
         'session.abort': async (params) => useCaseData(await stopAgent(
             { sessions: source }, { sessionId: params.sessionId, action: 'abort' },

--- a/apps/mobile/sources/USE_CASES.md
+++ b/apps/mobile/sources/USE_CASES.md
@@ -33,7 +33,7 @@ Navigate by capability. Domain language is in the root [CONTEXT.md](../../../CON
 | Prompt an Agent | `catalog/application/promptAgent.ts` | Agent | `catalog/application/sync.ts` (`sendMessage`), `TerminalScreen.tsx` |
 | Read an Agent's workspace file | `catalog/application/readAgentFile.ts` | Agent | `catalog/application/ops.ts` (`sessionReadFile`), `app/(app)/session/[id]/file.tsx` |
 | Read a listed Agent | `catalog/application/readAgentSession.ts` | Agent | Catalog store lookups by Agent Route |
-| Stop or abort an Agent | `catalog/application/stopAgent.ts` | Agent | `catalog/application/ops.ts` (`sessionKill`, `sessionAbort`) |
+| Stop or abort an Agent | `catalog/application/stopAgent.ts` | Agent | `catalog/application/ops.ts` (`sessionStop`, `sessionAbort`) |
 | Watch Agent lifecycle on this machine | `watch/application/watchAgentLifecycle.ts` | Agent Watch | `catalog/application/sync.ts` bootstrap |
 | Report an Agent outcome | `watch/application/reportAgentOutcome.ts` | Voice Report | `watch/application/wakeAndReport.ts`, plugin `speech.wake` |
 | Bind this device to a machine | `pairing/application/PairMachine.ts` | Pairing String, Hosted Grant, PairedMachine | `usePairing.ts`, `app/(app)/pair.tsx` |

--- a/apps/mobile/sources/catalog/application/ops.ts
+++ b/apps/mobile/sources/catalog/application/ops.ts
@@ -127,10 +127,6 @@ interface SessionWriteFileResponse {
     error?: string;
 }
 
-interface SessionKillResponse {
-    success: boolean;
-    message: string;
-}
 
 export async function sessionAbort(sessionId: string): Promise<void> {
     await stopAgent({ agentRoute: sessionId, kind: 'abort' }, {
@@ -140,13 +136,12 @@ export async function sessionAbort(sessionId: string): Promise<void> {
     });
 }
 
-export async function sessionKill(sessionId: string): Promise<SessionKillResponse> {
+export async function sessionStop(sessionId: string): Promise<void> {
     await stopAgent({ agentRoute: sessionId, kind: 'stop' }, {
         abort: (agentRoute) => sync.request('session.abort', { sessionId: agentRoute }),
         stop: (agentRoute) => sync.request('session.stop', { sessionId: agentRoute }),
         refreshCatalog: () => sync.refreshSessions(),
     });
-    return { success: true, message: 'stopped' };
 }
 
 export function sessionSetAgentModes(_sessionId: string, _patch: SessionAgentModesPatch): void {

--- a/apps/mobile/sources/herd/presentation/SpacesTree.tsx
+++ b/apps/mobile/sources/herd/presentation/SpacesTree.tsx
@@ -363,7 +363,7 @@ export const SpacesTree = React.memo(({
 
     const confirmCloseWorkspace = React.useCallback((workspace: HerdrTreeWorkspace) => {
         const name = workspaceName(workspace);
-        Modal.alert('Close space?', `Closes "${name}" in herdr — its tabs, panes, and their processes are gone.`, [
+        Modal.alert('Close workspace?', `Closes only the "${name}" workspace in herdr. If that would close its worktree group, nothing closes.`, [
             { text: 'Cancel', style: 'cancel' },
             {
                 text: 'Close',
@@ -388,7 +388,7 @@ export const SpacesTree = React.memo(({
         if (sessionId === undefined) return;
         const labels = agentLabels(pane);
         const identity = labels.agentName === undefined ? '' : ` (${labels.agentName})`;
-        Modal.alert('Close pane?', `Closes "${labels.taskTitle}"${identity} in herdr — its process is gone.`, [
+        Modal.alert('Close pane?', `Closes only the pane for "${labels.taskTitle}"${identity} in herdr. If that would also close its tab, nothing closes.`, [
             { text: 'Cancel', style: 'cancel' },
             {
                 text: 'Close',

--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -18,6 +18,7 @@ import { router, useFocusEffect } from 'expo-router';
 import { Modal } from '@/modal';
 import * as Clipboard from 'expo-clipboard';
 import { storage, useSession, useSessionGitStatus, useSessions } from '@/catalog/store';
+import { sessionStop } from '@/catalog/ops';
 import { sync } from '@/catalog/sync';
 import { resolveMessageModeMeta } from '@/catalog/infrastructure/messageMeta';
 import { permissionModeChip, resolveStatusBarGitBranch } from '../domain/sessionStatusBar';
@@ -322,19 +323,15 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     }, [selectedImages, attaching, clearImages, props.id]);
 
     const stopSession = React.useCallback(() => {
-        Modal.alert('Stop agent?', 'Closes this agent pane in herdr. The pane and its process are gone.', [
+        Modal.alert('Stop agent?', 'Closes only this agent pane, or its tab when the pane is alone. Other panes, tabs, and the workspace stay open; if they cannot, nothing closes.', [
             { text: 'Cancel', style: 'cancel' },
             {
                 text: 'Stop',
                 style: 'destructive',
                 onPress: () => {
                     setStopping(true);
-                    void sync
-                        .request('session.stop', { sessionId: props.id })
+                    void sessionStop(props.id)
                         .then(() => {
-                            // Closing one pane of a tab should leave you in that
-                            // tab, not eject you to the list. Prefer the pane
-                            // after this one, fall back to the one before.
                             const index = siblings.indexOf(props.id);
                             const remaining = siblings.filter((id) => id !== props.id);
                             const next = remaining[index] ?? remaining[remaining.length - 1];

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -125,7 +125,11 @@ phone.
 | session.start | workspace-per-cwd → tab → `agent.start` | `workspace.create` / `tab.create` / `agent.start --kind` |
 | session.prompt | submit text to the agent | `agent.prompt` |
 | session.abort | interrupt | `agent.send_keys esc` |
-| session.stop | close the pane | `pane.close` |
+| session.stop | close only the selected live Agent Route's pane, or its tab when it is the sole pane | `pane.close` / `tab.close`; refuse if that would also close the workspace/group |
+| pane.close | close only the selected pane | `pane.close`; refuse if its tab could not remain |
+| tab.close | close only the selected tab | `tab.close`; refuse if its workspace could not remain |
+| workspace.close | close only the selected workspace | `workspace.close`; refuse if its worktree group would also close |
+| Close worktree group | explicit Herdr group action and confirmation only | never inferred from pane, tab, workspace, or Stop agent |
 | status | `idle · working · blocked · done · unknown` | `pane.agent_status_changed` |
 | inbox / attention | blocked → needs you, done → finished | derived host-side |
 | live view | terminal frames over the `/terminal` channel | CLI `herdr terminal session control` (interactive, `--takeover`) / `observe` (read-only previews) |

--- a/packages/contract/src/control-plane/domain/requests.ts
+++ b/packages/contract/src/control-plane/domain/requests.ts
@@ -337,11 +337,11 @@ export interface RequestMap extends PeerRequestMap {
         params: { sessionId: string; kind?: string; label?: string };
         result: null;
     };
-    /** Close a tab in this session's workspace. The pane and process are gone. */
+    /** Close exactly the selected tab; if Herdr would widen to its workspace or worktree group, fail without mutation. */
     'tab.close': { params: { sessionId: string; tabId: string }; result: null };
-    /** Close one pane (and its process). Its tab survives if other panes remain. */
+    /** Close exactly the selected pane; if Herdr would widen to its tab, workspace, or worktree group, fail without mutation. */
     'pane.close': { params: { sessionId: string }; result: null };
-    /** Close a workspace (a space on the Herd screen) and everything in it. */
+    /** Close exactly the selected workspace; if Herdr would widen to its worktree group, fail and require the explicit group action. */
     'workspace.close': { params: { workspaceId: string }; result: null };
     /**
      * Zoom this session's pane to fill its tab. herdr no-ops on a single-pane
@@ -353,6 +353,7 @@ export interface RequestMap extends PeerRequestMap {
     };
     /** Attach to an existing Pi session (resume). */
     'session.open': { params: { sessionId: string; path?: string }; result: SessionSnapshot };
+    /** Close the selected live pane, or its sole-pane tab; if Herdr would widen to the workspace/group, fail without mutation. */
     'session.stop': { params: { sessionId: string }; result: null };
     'session.abort': { params: { sessionId: string }; result: null };
     'session.reload': { params: { sessionId: string }; result: null };


### PR DESCRIPTION
## What

Every explicit mobile layout action now maps to exactly its named scope:

- **Stop agent**: resolve one recognized live pane from the stable Agent Route after a fresh Herdr snapshot. Close that pane when its tab has siblings; otherwise close that tab only when the workspace has other tabs.
- **Close pane**: issue exactly one `pane.close`; refuse without mutation if the tab could not remain.
- **Close tab**: issue exactly one `tab.close`; refuse without mutation if the workspace could not remain.
- **Close workspace**: issue exactly one `workspace.close`; refuse without mutation when Herdr would widen a parent workspace close to its worktree group.
- **Close worktree group**: available only through Herdr's explicit group action and confirmation; never inferred from another action.

Targets never derive from cwd, name, title, or kind. No action closes multiple panes/tabs, a workspace, or a worktree group implicitly. Route-owned plugin streams, status, lifecycle, attachments, and identity clean up only after the exact selected close succeeds. Dead terminal `detachSession` surfaces are removed and fake mode closes only the selected session row.

## Why

Physical build45 widened mobile Stop into `Close worktree group?`. The contract is now strict: the UI label determines the maximum mutation scope, and structurally wider closes fail safely.

## Verify

```bash
yarn vitest run apps/host/src/requests/application/createRequestDispatcher.test.ts
yarn typecheck
yarn --cwd apps/mobile typecheck
yarn check:architecture
yarn check
node apps/host/dist/agent/infrastructure/layoutSelfCheck.js
```

- Dispatcher flows: 9/9 passed, including exact pane/tab/workspace forwarding and fake selected-row preservation.
- Infrastructure self-check records exact Stop/pane/tab/workspace Herdr RPCs, rejects hidden pane→tab, tab→workspace, and workspace→group widening with zero mutation, and verifies cleanup only after success.
- Root/mobile typechecks, architecture checks, and full repository suite passed.

Do not merge or publish from this PR.