### PR TITLE
fix(voice): prevent Gemini playback overflow and persist wake standby

### DIFF
--- a/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayModule.kt
+++ b/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayModule.kt
@@ -123,6 +123,10 @@ class VoiceOverlayModule : Module() {
     Function("isRealtimePcmDrained") { realtimePcm.isDrained() }
     Function("stopRealtimePcm") { realtimePcm.stop() }
     Function("isServiceReady") { VoiceOverlayService.isVoiceForegroundReady() }
+    Function("setNetworkActive") { active: Boolean ->
+      VoiceOverlayService.setNetworkActive(active)
+      true
+    }
 
     // The whole Android audio session, so nothing else gets to argue about it.
     // Communication mode is what engages the hardware echo canceller; WebRTC

--- a/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayService.kt
+++ b/apps/mobile/modules/voice-overlay/android/src/main/java/expo/modules/voiceoverlay/VoiceOverlayService.kt
@@ -38,6 +38,11 @@ class VoiceOverlayService : Service() {
     private const val HERD_GROUP_KEY = "muxr.herd"
     @Volatile private var voiceForegroundReady = false
     internal fun isVoiceForegroundReady(): Boolean = voiceForegroundReady
+    @Volatile private var voiceNetworkActive = true
+    internal fun setNetworkActive(active: Boolean) {
+      voiceNetworkActive = active
+      instance?.get()?.applyNetworkLock(active)
+    }
 
     private var instance: WeakReference<VoiceOverlayService>? = null
     private var herdMode = "offline"
@@ -59,9 +64,8 @@ class VoiceOverlayService : Service() {
     private var voiceMuted = false
     private var voiceStartedAt = 0L
     /**
-     * Held only while a voice session is live: keeps the CPU and the Wi-Fi
-     * radio responsive with the screen off so the realtime socket and PCM
-     * playback do not stall. Both are released on stop/destroy/timeout.
+     * The CPU lock keeps background microphone detection alive. The Wi-Fi
+     * low-latency lock is held separately only for connected realtime traffic.
      */
     private var voiceWakeLock: PowerManager.WakeLock? = null
     private var voiceWifiLock: WifiManager.WifiLock? = null
@@ -535,6 +539,14 @@ class VoiceOverlayService : Service() {
         ?.apply { setReferenceCounted(false) }
     }
     runCatching { if (voiceWakeLock?.isHeld == false) voiceWakeLock?.acquire() }
+    applyNetworkLock(voiceNetworkActive)
+  }
+
+  private fun applyNetworkLock(active: Boolean) {
+    if (!active) {
+      runCatching { if (voiceWifiLock?.isHeld == true) voiceWifiLock?.release() }
+      return
+    }
     if (voiceWifiLock == null) {
       val wifi = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
       voiceWifiLock = wifi?.createWifiLock(WifiManager.WIFI_MODE_FULL_LOW_LATENCY, "muxr:voice")

--- a/apps/mobile/modules/voice-overlay/index.ts
+++ b/apps/mobile/modules/voice-overlay/index.ts
@@ -24,6 +24,7 @@ interface VoiceNative {
     stopRealtimePcm: () => RealtimePcmStats;
     startService: () => boolean;
     isServiceReady: () => boolean;
+    setNetworkActive: (active: boolean) => boolean;
     stopService: () => boolean;
     startHerdService: () => boolean;
     stopHerdService: () => boolean;
@@ -69,6 +70,15 @@ export function isVoiceServiceReady(): boolean {
         return native?.isServiceReady() ?? false;
     } catch {
         return false;
+    }
+}
+
+/** Wi-Fi latency is needed only while realtime provider traffic is active. */
+export function setVoiceNetworkActive(active: boolean): void {
+    try {
+        native?.setNetworkActive(active);
+    } catch {
+        // The CPU/microphone foreground service remains the standby fallback.
     }
 }
 

--- a/apps/mobile/modules/voice-overlay/ios/VoiceOverlayModule.swift
+++ b/apps/mobile/modules/voice-overlay/ios/VoiceOverlayModule.swift
@@ -51,6 +51,7 @@ public final class VoiceOverlayModule: Module {
     // iOS has no Android-style foreground service. These keep the shared JS
     // lifecycle platform-blind while APNs owns background agent notifications.
     Function("startService") { true }
+    Function("setNetworkActive") { (_: Bool) -> Bool in true }
     Function("stopService") { true }
     Function("startHerdService") { false }
     Function("stopHerdService") { true }

--- a/apps/mobile/sources/app/(app)/settings/voice.tsx
+++ b/apps/mobile/sources/app/(app)/settings/voice.tsx
@@ -136,7 +136,7 @@ export default function VoiceProviderScreen() {
                     />
                 </ItemGroup>
             )}
-            <ItemGroup title="Hands-free" footer="Audio stays on this device until speech is detected. Standby turns itself off after 30 minutes.">
+            <ItemGroup title="Hands-free" footer="Listens only on this device until speech is detected. The setting stays enabled until you disable it and uses additional battery.">
                 <Item
                     title="Wake on speech"
                     subtitle="Reconnect realtime voice when someone starts talking"

--- a/apps/mobile/sources/catalog/application/localSettings.ts
+++ b/apps/mobile/sources/catalog/application/localSettings.ts
@@ -14,7 +14,7 @@ export const LocalSettingsSchema = z.object({
     zenMode: z.boolean().describe('Hide all sidebars and non-essential UI for focused work'),
     promotedNotificationsPrompted: z.boolean().describe('Whether Android Live Updates access was already explained'),
     backgroundConnectionPrompted: z.boolean().describe('Whether Android background activity settings were already explained'),
-    vadStandbyEnabled: z.boolean().describe('Wake realtime voice from bounded local speech activity standby'),
+    vadStandbyEnabled: z.boolean().describe('Persistently wake realtime voice from local speech activity standby'),
     // Herd tab: bucket the agents section under workspace subheaders (herdr's "grouped" toggle).
     // Saved herdr tab layouts (split tree + agent kind per pane), newest first.
     savedLayouts: z

--- a/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
+++ b/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
@@ -564,11 +564,15 @@ describe('session sync flow', () => {
             };
         }
         mmkvValues.set('lifecycle-voice-reports-v1', JSON.stringify(persistedVoice));
+        state.applyLocalSettings({ vadStandbyEnabled: true });
 
         // Module re-evaluation simulates the store/app restarting while MMKV remains.
         vi.resetModules();
         const restarted = (await import('./storage')).storage;
         restarted.getState().setLifecycleScope('test-authority:machine');
+        expect(restarted.getState().localSettings.vadStandbyEnabled).toBe(true);
+        restarted.getState().applyLocalSettings({ vadStandbyEnabled: false });
+        expect(JSON.parse(mmkvValues.get('local-settings')!).vadStandbyEnabled).toBe(false);
         expect(restarted.getState().voicePendingReports).toEqual([durableReport]);
         expect(restarted.getState().voiceDeliveredReportIds).not.toContain('voice-collision');
         restarted.getState().setLifecycleScope('x'.repeat(201));

--- a/apps/mobile/sources/conversation/application/realtimeSession.spec.ts
+++ b/apps/mobile/sources/conversation/application/realtimeSession.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RealtimeWebRtcCallbacks } from '../infrastructure/realtimeWebRtc';
+import type * as VadStandbyModule from './vadStandby';
 
 const mocks = vi.hoisted(() => ({
     openStream: vi.fn(),
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => ({
         routeVoiceAudio: vi.fn(() => true),
         releaseVoiceAudio: vi.fn(),
         startVoiceService: vi.fn(() => true),
+        setVoiceNetworkActive: vi.fn(),
         stopVoiceService: vi.fn(),
     },
     webRtc: {
@@ -224,7 +226,7 @@ describe('generic realtime stream session', () => {
         await new Promise((resolve) => setTimeout(resolve, 30));
         expect(mocks.pcm.playRealtimePcm.mock.calls.filter(([data]) => data === 'c3RhbGUh')).toHaveLength(1);
 
-        const burst = Array.from({ length: 4 }, (_, index) => Buffer.alloc(20_000, index + 1).toString('base64'));
+        const burst = Array.from({ length: 180 }, (_, index) => Buffer.alloc(960, index + 1).toString('base64'));
         const pausesBefore = stream.send.mock.calls.filter(([frame]) => frame.action === 'pause_output').length;
         const resumesBefore = stream.send.mock.calls.filter(([frame]) => frame.action === 'resume_output').length;
         mocks.pcm.playRealtimePcm.mockReturnValue(false);
@@ -396,10 +398,18 @@ describe('generic realtime stream session', () => {
         expect(stream.close).toHaveBeenCalledOnce();
     });
 
-    it('arms locally after two speech-energy chunks and keeps silence off the provider path', async () => {
-        const vad = await vi.importActual<typeof import('./vadStandby')>('./vadStandby');
+    it('arms locally without an expiry and keeps silence off the provider path', async () => {
+        vi.useFakeTimers();
+        const timeout = vi.spyOn(globalThis, 'setTimeout');
+        const vad = await vi.importActual<typeof VadStandbyModule>('./vadStandby');
         const wake = vi.fn();
-        await expect(vad.startVadStandby(wake, vi.fn())).resolves.toBe(true);
+        await expect(vad.startVadStandby(wake)).resolves.toBe(true);
+        expect(timeout).not.toHaveBeenCalledWith(expect.any(Function), 30 * 60_000);
+        expect(mocks.pcm.startVoiceService.mock.invocationCallOrder[0])
+            .toBeLessThan(mocks.liveAudio.init.mock.invocationCallOrder[0]!);
+        expect(mocks.pcm.setVoiceNetworkActive).toHaveBeenCalledWith(false);
+        await vi.advanceTimersByTimeAsync(31 * 60_000);
+        expect(vad.vadStandbyOwnsMicrophone()).toBe(true);
         const inspect = mocks.liveAudio.on.mock.calls.at(-1)![1] as (data: string) => void;
         inspect(Buffer.alloc(4_800).toString('base64'));
         expect(wake).not.toHaveBeenCalled();
@@ -410,16 +420,18 @@ describe('generic realtime stream session', () => {
         inspect(speech.toString('base64'));
         expect(wake).toHaveBeenCalledOnce();
         vad.stopVadStandby();
+        expect(vad.vadStandbyOwnsMicrophone()).toBe(false);
+        vi.useRealTimers();
 
         let finishInit!: () => void;
         mocks.liveAudio.init.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
             finishInit = () => resolve(true);
         }));
         const startsBeforeCancellation = mocks.liveAudio.start.mock.calls.length;
-        const arming = vad.startVadStandby(vi.fn(), vi.fn());
+        const arming = vad.startVadStandby(vi.fn());
         await vi.waitFor(() => expect(finishInit).toBeTypeOf('function'));
         vad.cancelVadStandbyStart();
-        const newerArming = vad.startVadStandby(vi.fn(), vi.fn());
+        const newerArming = vad.startVadStandby(vi.fn());
         finishInit();
         await expect(arming).resolves.toBe(false);
         await expect(newerArming).resolves.toBe(true);

--- a/apps/mobile/sources/conversation/application/realtimeSessionState.ts
+++ b/apps/mobile/sources/conversation/application/realtimeSessionState.ts
@@ -4,6 +4,7 @@ import { sync } from '@/catalog/sync';
 import { getCachedConnectionSettings } from '@/connection';
 import {
     addVoiceNotificationActionListener,
+    setVoiceNetworkActive,
     startVoiceService,
     stopVoiceService,
 } from '@/../modules/voice-overlay';
@@ -77,7 +78,8 @@ let reportSpeech: {
     timer: ReturnType<typeof setTimeout>;
 } | null = null;
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
-let vadArming: Promise<boolean> | null = null;
+type VadArmResult = 'armed' | 'retry' | 'failed';
+let vadArming: Promise<VadArmResult> | null = null;
 let vadEpoch = 0;
 /** Local completion watch; unlike `session`, this owns no provider connection. */
 let watching = false;
@@ -364,6 +366,7 @@ function startRealtimeAfterService(target: RealtimeTarget, epoch: number): void 
         stopVoiceService();
         return;
     }
+    setVoiceNetworkActive(true);
     const liveEpoch = epoch;
     let handle!: RealtimeHandle;
     try {
@@ -393,33 +396,27 @@ function startRealtimeAfterService(target: RealtimeTarget, epoch: number): void 
     starting = false;
 }
 
-async function armVadStandby(): Promise<boolean> {
-    if (storage.getState().localSettings?.vadStandbyEnabled !== true || dictating || session !== null || starting) return false;
+async function armVadStandby(): Promise<VadArmResult> {
+    if (storage.getState().localSettings?.vadStandbyEnabled !== true || dictating || session !== null || starting) return 'retry';
     if (vadArming !== null) return vadArming;
     const epoch = vadEpoch;
-    const task = (async () => {
+    const task = (async (): Promise<VadArmResult> => {
         const target = realtimeTarget?.machineId === getCachedConnectionSettings().machineId
             ? realtimeTarget
             : await resolveRealtimeTarget();
         if (target === null || epoch !== vadEpoch || storage.getState().localSettings?.vadStandbyEnabled !== true
-            || dictating || session !== null || starting) return false;
+            || dictating || session !== null || starting) return 'retry';
         realtimeTarget = target;
         activateWatching();
-        const armed = await startVadStandby(
-            () => {
-                const wakeTarget = realtimeTarget;
-                if (wakeTarget !== null && session === null && !starting && !dictating) startRealtimeSession(wakeTarget);
-            },
-            () => {
-                storage.getState().applyLocalSettings({ vadStandbyEnabled: false });
-                notify();
-            },
-        );
+        const armed = await startVadStandby(() => {
+            const wakeTarget = realtimeTarget;
+            if (wakeTarget !== null && session === null && !starting && !dictating) startRealtimeSession(wakeTarget);
+        });
         if (epoch !== vadEpoch) {
             stopVadStandby();
-            return false;
+            return 'retry';
         }
-        return armed;
+        return armed ? 'armed' : 'failed';
     })();
     vadArming = task;
     try {
@@ -437,10 +434,16 @@ export async function configureVadStandby(enabled: boolean): Promise<boolean> {
         notify();
         return true;
     }
-    const armed = await armVadStandby();
-    if (!armed) storage.getState().applyLocalSettings({ vadStandbyEnabled: false });
+    const result = await armVadStandby();
+    if (result === 'failed') storage.getState().applyLocalSettings({ vadStandbyEnabled: false });
     notify();
-    return armed;
+    return result !== 'failed';
+}
+
+/** Retry a persisted preference without treating normal live/busy state as rejection. */
+export async function retryVadStandby(): Promise<boolean> {
+    if (storage.getState().localSettings?.vadStandbyEnabled !== true) return false;
+    return await armVadStandby() === 'armed';
 }
 
 function sleepRealtimeSession(): void {
@@ -455,11 +458,14 @@ function sleepRealtimeSession(): void {
 }
 
 export function stopRealtimeSession(): void {
+    if (storage.getState().localSettings?.vadStandbyEnabled === true) {
+        sleepRealtimeSession();
+        return;
+    }
     stopRealtimeConversation({
         endWatch: () => {
             watching = false;
             vadEpoch += 1;
-            storage.getState().applyLocalSettings({ vadStandbyEnabled: false });
             stopVadStandby();
         },
         interruptPlayback: () => sleepRealtimeSession(),

--- a/apps/mobile/sources/conversation/application/vadStandby.ts
+++ b/apps/mobile/sources/conversation/application/vadStandby.ts
@@ -1,17 +1,16 @@
-import { AppState } from 'react-native';
 import LiveAudioStream from 'react-native-live-audio-stream';
 import { REALTIME_INPUT_RATE, realtimePcm16ByteLength } from '@muxr/contract';
 import { chunkEnergy } from '../infrastructure/audioEnergy';
 import {
     releaseVoiceAudio,
     routeVoiceAudio,
+    setVoiceNetworkActive,
     startVoiceService,
     stopVoiceService,
 } from '@/../modules/voice-overlay';
 
 const PRE_ROLL_CHUNKS = 20;
 const TRIGGER_BUFFER_CHUNKS = 200;
-export const VAD_STANDBY_MS = 30 * 60_000;
 
 type CaptureOwner = { id: number; kind: 'vad' | 'realtime' };
 export interface RealtimeCaptureLease {
@@ -29,9 +28,6 @@ let buffered: string[] = [];
 let loudFrames = 0;
 let noiseFloor = 0.02;
 let wake: (() => void) | undefined;
-let expires: ReturnType<typeof setTimeout> | undefined;
-let expiresAt = 0;
-let expiryCallback: (() => void) | undefined;
 
 const enqueue = <T>(transition: () => Promise<T>): Promise<T> => {
     const result = transitions.then(transition, transition);
@@ -47,33 +43,16 @@ const clearVadState = (): void => {
     triggered = false;
     wake = undefined;
     buffered = [];
-    if (expires !== undefined) clearTimeout(expires);
-    expires = undefined;
-    expiresAt = 0;
-    expiryCallback = undefined;
 };
 
-function expireVadStandby(): void {
-    const callback = expiryCallback;
-    stopVadStandby();
-    callback?.();
-}
 
-function resetExpiry(onExpire: () => void): void {
-    if (expires !== undefined) clearTimeout(expires);
-    expiresAt = Date.now() + VAD_STANDBY_MS;
-    expiryCallback = onExpire;
-    expires = setTimeout(expireVadStandby, VAD_STANDBY_MS);
-}
-
-AppState.addEventListener('change', (state) => {
-    if (state === 'active' && active && Date.now() >= expiresAt) expireVadStandby();
-});
-
-/** Explicit, bounded local standby. No audio leaves the phone before speech wins the gate. */
-export async function startVadStandby(onWake: () => void, onExpire: () => void): Promise<boolean> {
+/** Persistent local standby. No audio leaves the phone before speech wins the gate. */
+export async function startVadStandby(onWake: () => void): Promise<boolean> {
     wake = onWake;
-    if (active) return true;
+    if (active) {
+        setVoiceNetworkActive(false);
+        return true;
+    }
     const candidate: CaptureOwner = { id: ++ownerSequence, kind: 'vad' };
     owner = candidate;
     return enqueue(async () => {
@@ -85,6 +64,7 @@ export async function startVadStandby(onWake: () => void, onExpire: () => void):
             clearVadState();
             return false;
         }
+        setVoiceNetworkActive(false);
         if (!routeVoiceAudio()) {
             if (isOwner(candidate)) {
                 owner = undefined;
@@ -120,7 +100,6 @@ export async function startVadStandby(onWake: () => void, onExpire: () => void):
                 if (owner === undefined) { stopVoiceService(); releaseVoiceAudio(); }
                 return false;
             }
-            resetExpiry(onExpire);
             return true;
         } catch {
             if (isOwner(candidate)) {
@@ -158,6 +137,7 @@ function inspect(data: string): void {
 
 /** Reuse an armed VAD recorder, or serialize opening a realtime-owned recorder. */
 export function acquireRealtimeCapture(sampleRate: number, onData: (data: string) => void): RealtimeCaptureLease {
+    setVoiceNetworkActive(true);
     const candidate: CaptureOwner = { id: ++ownerSequence, kind: 'realtime' };
     const claimed = active && owner?.kind === 'vad' && sampleRate === REALTIME_INPUT_RATE;
     const pending = claimed ? buffered : [];
@@ -192,6 +172,7 @@ export function acquireRealtimeCapture(sampleRate: number, onData: (data: string
 /** A provider/configuration failure leaves the local recorder alive; listen again. */
 export function rearmVadStandby(): void {
     if (!active) return;
+    setVoiceNetworkActive(false);
     triggered = false;
     loudFrames = 0;
     if (buffered.length > PRE_ROLL_CHUNKS) buffered = buffered.slice(-PRE_ROLL_CHUNKS);

--- a/apps/mobile/sources/herd/presentation/KernelNotifications.tsx
+++ b/apps/mobile/sources/herd/presentation/KernelNotifications.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/../modules/voice-overlay';
 import { requestNotificationPermission } from '@/utils/microphonePermissions';
 import { completionNotificationState, completionTransition, herdNotificationState, sortHerd, type HerdNotificationState } from '../domain/herd';
-import { boundRealtimeSession, configureVadStandby, useRealtimeMuted, useRealtimeSessionState } from '@/conversation/session';
+import { boundRealtimeSession, retryVadStandby, useRealtimeMuted, useRealtimeSessionState } from '@/conversation/session';
 import { Modal } from '@/modal';
 import { registerNativePushNotifications } from '@/utils/nativePushNotifications';
 
@@ -117,7 +117,7 @@ export function KernelNotifications() {
 
     React.useEffect(() => {
         if (isAuthenticated && appActive && vadStandbyEnabled && sessionCount > 0) {
-            void configureVadStandby(true);
+            void retryVadStandby();
         }
     }, [appActive, isAuthenticated, sessionCount, vadStandbyEnabled]);
 

--- a/apps/mobile/sources/utils/dictation.spec.ts
+++ b/apps/mobile/sources/utils/dictation.spec.ts
@@ -5,10 +5,11 @@ import { useDictation } from '@/utils/dictation';
 import { pcm16ChunksToArrayBuffer } from '@/utils/transcription';
 import { wakeAndReport } from '@/watch/application/wakeAndReport';
 import { usePluginEvents } from '@/plugins/events';
-import { cancelRealtimeReportWait, micOwners, realtimeGeneration, realtimeWatchTarget, registerRealtimeNotificationStart, releaseDictation, resolveRealtimeTarget, startRealtimeSession, stopRealtimeSession } from '@/conversation/session';
+import { cancelRealtimeReportWait, configureVadStandby, micOwners, realtimeGeneration, realtimeWatchTarget, registerRealtimeNotificationStart, releaseDictation, resolveRealtimeTarget, retryVadStandby, startRealtimeSession, stopRealtimeSession } from '@/conversation/session';
 
 const mocks = vi.hoisted(() => ({
     sessions: {} as Record<string, { id: string; activeAt: number; updatedAt: number }>,
+    vadStandbyEnabled: false,
     applyLocalSettings: vi.fn(),
     modalAlert: vi.fn(),
     permission: vi.fn(),
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     transcribe: vi.fn(),
     startRealtimeSession: vi.fn(),
     startVoiceService: vi.fn(),
+    setVoiceNetworkActive: vi.fn(),
     stopVoiceService: vi.fn(),
     notificationAction: null as ((action: 'start' | 'stop' | 'mute') => void) | null,
     addVoiceNotificationActionListener: vi.fn((listener: (action: 'start' | 'stop' | 'mute') => void) => {
@@ -56,8 +58,11 @@ vi.mock('@/catalog/store', () => ({
     }),
     getState: () => ({
         sessions: mocks.sessions,
-        localSettings: { vadStandbyEnabled: false },
-        applyLocalSettings: mocks.applyLocalSettings,
+        localSettings: { vadStandbyEnabled: mocks.vadStandbyEnabled },
+        applyLocalSettings: (patch: { vadStandbyEnabled?: boolean }) => {
+            if (patch.vadStandbyEnabled !== undefined) mocks.vadStandbyEnabled = patch.vadStandbyEnabled;
+            mocks.applyLocalSettings(patch);
+        },
         voicePendingReports: mocks.voicePending,
         voiceDeliveredReportIds: mocks.voiceDelivered,
         voiceReportScope: 'scope-a',
@@ -91,6 +96,9 @@ vi.mock('@/utils/microphonePermissions', () => ({
 vi.mock('../conversation/application/realtimeSession', () => ({ startRealtimeSession: mocks.startRealtimeSession }));
 vi.mock('@/../modules/voice-overlay', () => ({
     startVoiceService: mocks.startVoiceService,
+    setVoiceNetworkActive: mocks.setVoiceNetworkActive,
+    routeVoiceAudio: vi.fn(() => true),
+    releaseVoiceAudio: vi.fn(),
     stopVoiceService: mocks.stopVoiceService,
     addVoiceNotificationActionListener: mocks.addVoiceNotificationActionListener,
 }));
@@ -124,6 +132,7 @@ beforeEach(() => {
     appended = [];
     base = 'hello';
     onData = undefined;
+    mocks.vadStandbyEnabled = false;
     mocks.sessions = {
         'session-a': { id: 'session-a', activeAt: 1, updatedAt: 1 },
         'session-b': { id: 'session-b', activeAt: 2, updatedAt: 2 },
@@ -206,6 +215,32 @@ describe('on-device dictation flow', () => {
 
         mocks.notificationAction?.('mute');
         expect(setMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('keeps live-session standby enabled and arms it once realtime ends', async () => {
+        const live = { stop: vi.fn(), setMuted: vi.fn(), speak: vi.fn() };
+        mocks.startRealtimeSession.mockReturnValue(live);
+        startRealtimeSession('session-a');
+        const provider = mocks.startRealtimeSession.mock.calls[0]![0] as {
+            onStatus: (status: 'disconnected', detail?: string) => void;
+        };
+
+        await expect(configureVadStandby(true)).resolves.toBe(true);
+        await expect(retryVadStandby()).resolves.toBe(false);
+        await expect(retryVadStandby()).resolves.toBe(false);
+        expect(mocks.vadStandbyEnabled).toBe(true);
+        expect(mocks.applyLocalSettings).not.toHaveBeenCalledWith({ vadStandbyEnabled: false });
+
+        provider.onStatus('disconnected', 'ended');
+        await vi.waitFor(() => expect(mocks.liveAudio.start).toHaveBeenCalledOnce());
+        expect(mocks.vadStandbyEnabled).toBe(true);
+        expect(mocks.setVoiceNetworkActive).toHaveBeenLastCalledWith(false);
+
+        await expect(configureVadStandby(false)).resolves.toBe(true);
+        expect(mocks.vadStandbyEnabled).toBe(false);
+        mocks.startVoiceService.mockReturnValue(false);
+        await expect(configureVadStandby(true)).resolves.toBe(false);
+        expect(mocks.vadStandbyEnabled).toBe(false);
     });
 
     it('retains and serializes prioritized reports until delivery, then sleeps after drain', async () => {

--- a/plugins/voice-gemini/stream.mjs
+++ b/plugins/voice-gemini/stream.mjs
@@ -43,17 +43,89 @@ const GEMINI_TOOLS = [{
     functionDeclarations: providerTools.map(({ type: _type, ...tool }) => ({ ...tool, parameters: geminiSchema(tool.parameters) })),
 }];
 
-const emit = (frame) => process.stdout.write(`${JSON.stringify(frame)}\n`);
-// Provider deltas may exceed the public frame bound after tool calls. Base64 is
-// independently decodable when split on four-character boundaries.
+const OUTPUT_FRAME_MS = 20;
+const AUDIO_CHUNK_SIZE = OUTPUT_RATE * 2 * OUTPUT_FRAME_MS / 1000 * 4 / 3;
+const MAX_PENDING_OUTPUT_BYTES = 4 * 1024 * 1024;
+const outputQueue = [];
+let outputBytes = 0;
+let outputBlocked = false;
+let outputTimer;
+let outputDeadline = 0;
+let outputPausedByClient = false;
+
+function syncProviderReadState() {
+    if (ws?.readyState !== WebSocket.OPEN) return;
+    if (outputBlocked || outputQueue.length > 0 || outputPausedByClient) ws.pause();
+    else ws.resume();
+}
+function flushOutput() {
+    outputTimer = undefined;
+    if (outputBlocked || outputQueue.length === 0) {
+        if (outputQueue.length === 0) outputDeadline = 0;
+        syncProviderReadState();
+        return;
+    }
+    const index = outputPausedByClient ? outputQueue.findIndex((item) => item.force) : 0;
+    if (index === -1) {
+        syncProviderReadState();
+        return;
+    }
+    const [item] = outputQueue.splice(index, 1);
+    outputBytes -= item.line.length;
+    outputBlocked = !process.stdout.write(item.line, item.done);
+    if (item.delayMs > 0) {
+        if (outputDeadline === 0) outputDeadline = performance.now();
+        outputDeadline += item.delayMs;
+    }
+    const delayMs = item.delayMs > 0 ? Math.max(0, outputDeadline - performance.now()) : 0;
+    outputTimer = setTimeout(flushOutput, delayMs);
+    syncProviderReadState();
+}
+process.stdout.on('drain', () => {
+    outputBlocked = false;
+    outputDeadline = 0;
+    if (outputTimer === undefined) flushOutput();
+});
+const emit = (frame, done, force = false) => {
+    const line = `${JSON.stringify(frame)}\n`;
+    if (!force && outputBytes + line.length > MAX_PENDING_OUTPUT_BYTES) {
+        stopped = true;
+        ws?.close();
+        outputQueue.length = 0;
+        outputBytes = 0;
+        outputDeadline = 0;
+        close('Voice output buffer overflowed.', true);
+        return false;
+    }
+    const delayMs = frame.type === 'realtime.audio'
+        ? Math.max(1, Math.round(frame.data.length / 4 * 3 / (OUTPUT_RATE * 2) * 1000))
+        : 0;
+    outputQueue.push({ line, delayMs, done, force, audio: frame.type === 'realtime.audio' });
+    outputBytes += line.length;
+    if (outputTimer === undefined) outputTimer = setTimeout(flushOutput, 0);
+    syncProviderReadState();
+    return true;
+};
+function clearQueuedAudio() {
+    for (let index = outputQueue.length - 1; index >= 0; index -= 1) {
+        if (!outputQueue[index].audio) continue;
+        outputBytes -= outputQueue[index].line.length;
+        outputQueue.splice(index, 1);
+    }
+    if (!outputQueue.some((item) => item.audio)) outputDeadline = 0;
+}
+// Gemini can deliver several seconds in one provider event. Twenty-millisecond
+// frames keep native admission smooth while the paced queue backpressures the
+// provider WebSocket whenever the phone or app is not draining.
 export function chunkAudio(audio) {
     const chunks = [];
-    const chunkSize = 64 * 1024;
-    for (let offset = 0; offset < audio.length; offset += chunkSize) chunks.push(audio.slice(offset, offset + chunkSize));
+    for (let offset = 0; offset < audio.length; offset += AUDIO_CHUNK_SIZE) chunks.push(audio.slice(offset, offset + AUDIO_CHUNK_SIZE));
     return chunks;
 }
 const emitAudio = (audio) => {
-    for (const data of chunkAudio(audio)) emit({ type: 'realtime.audio', data });
+    for (const data of chunkAudio(audio)) {
+        if (!emit({ type: 'realtime.audio', data })) break;
+    }
 };
 const state = (value, detail) => emit(detail === undefined
     ? { type: 'realtime.state', state: value }
@@ -93,10 +165,10 @@ async function readKey() {
 }
 
 let closing = false;
-const close = (reason) => {
+const close = (reason, force = false) => {
     if (closing) return;
     closing = true;
-    process.stdout.write(`${JSON.stringify({ type: 'realtime.closed', reason })}\n`, () => process.exit(0));
+    emit({ type: 'realtime.closed', reason }, () => process.exit(0), force);
 };
 
 let ws;
@@ -134,7 +206,7 @@ function finishTurn() {
     if (endAfterResponse) {
         stopped = true;
         ws?.close();
-        close('ended');
+        close('ended', true);
     } else {
         state('connected');
     }
@@ -152,7 +224,10 @@ function handleGeminiEvent(raw) {
     }
     const content = message.serverContent;
     if (content) {
-        if (content.interrupted === true) emit({ type: 'realtime.audio.clear' });
+        if (content.interrupted === true) {
+            clearQueuedAudio();
+            emit({ type: 'realtime.audio.clear' }, undefined, true);
+        }
         if (typeof content.inputTranscription?.text === 'string') inputTranscript += content.inputTranscription.text;
         if (typeof content.outputTranscription?.text === 'string') outputTranscript += content.outputTranscription.text;
         for (const part of content.modelTurn?.parts ?? []) {
@@ -210,7 +285,7 @@ function handleGeminiEvent(raw) {
         if (!providerReady || terminal) {
             stopped = true;
             ws?.close();
-            close(`Voice provider error: ${detail}`);
+            close(`Voice provider error: ${detail}`, true);
         } else {
             state('connected', detail);
         }
@@ -218,6 +293,25 @@ function handleGeminiEvent(raw) {
 }
 
 function handleClientFrame(frame) {
+    if (frame.type === 'realtime.control') {
+        if (frame.action === 'stop') {
+            stopped = true;
+            ws?.close();
+            outputQueue.length = 0;
+            outputBytes = 0;
+            outputDeadline = 0;
+            close('ended', true);
+        } else if (frame.action === 'pause_output') {
+            outputPausedByClient = true;
+            outputDeadline = 0;
+            syncProviderReadState();
+        } else if (frame.action === 'resume_output') {
+            outputPausedByClient = false;
+            if (outputTimer === undefined) outputTimer = setTimeout(flushOutput, 0);
+            syncProviderReadState();
+        }
+        return;
+    }
     if (ws?.readyState !== WebSocket.OPEN) return;
     if (frame.type === 'realtime.audio') {
         ws.send(JSON.stringify({ realtimeInput: { audio: { data: frame.data, mimeType: `audio/pcm;rate=${INPUT_RATE}` } } }));
@@ -228,10 +322,6 @@ function handleClientFrame(frame) {
                 turnComplete: true,
             },
         }));
-    } else if (frame.type === 'realtime.control' && frame.action === 'stop') {
-        stopped = true;
-        ws.close();
-        close('ended');
     }
     // mute/unmute are enforced on the phone's capture side; nothing to forward.
 }
@@ -267,7 +357,7 @@ function connectProvider(key) {
     const onDown = (reason) => {
         if (stopped || ws !== current) return;
         if (providerReconnects >= 2) {
-            close(reason);
+            close(reason, true);
             return;
         }
         providerReconnects += 1;
@@ -302,7 +392,7 @@ function connectProvider(key) {
             current.terminate();
             if (stopped || ws !== current) return;
             const reason = providerRefusal(response.statusCode, body);
-            if (response.statusCode === 401 || response.statusCode === 403) close(reason);
+            if (response.statusCode === 401 || response.statusCode === 403) close(reason, true);
             else onDown(reason);
         });
     });
@@ -311,7 +401,7 @@ function connectProvider(key) {
         const detail = `The voice provider disconnected (${code})${reason ? `: ${reason}` : '.'}`;
         if (providerError(reason).terminal) {
             stopped = true;
-            close(detail);
+            close(detail, true);
         } else {
             onDown(detail);
         }
@@ -337,5 +427,5 @@ async function main() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-    main().catch((error) => close(cleanProviderProse(error instanceof Error ? error.message : error, 'Voice session could not start.', 300)));
+    main().catch((error) => close(cleanProviderProse(error instanceof Error ? error.message : error, 'Voice session could not start.', 300), true));
 }

--- a/plugins/voice/providerRefusal.spec.mjs
+++ b/plugins/voice/providerRefusal.spec.mjs
@@ -9,7 +9,7 @@ import { WebSocketServer } from 'ws';
 import { describe, expect, it } from 'vitest';
 import { RealtimeCodingCoordinator } from '../../apps/host/src/agent/infrastructure/realtimeCoordinator.ts';
 import { parseRealtimeHostFrame } from '../../packages/contract/src/realtime/domain/realtimeStream.ts';
-import { providerTools as geminiTools } from '../voice-gemini/stream.mjs';
+import { chunkAudio as chunkGeminiAudio, providerTools as geminiTools } from '../voice-gemini/stream.mjs';
 import { providerTools as openaiTools } from '../voice-openai/stream.mjs';
 import { providerError, providerRefusal, providerTools as xaiTools } from './stream.mjs';
 import { approvedSignalingUrl } from '../voice-codex/stream.mjs';
@@ -37,6 +37,17 @@ describe('providerRefusal', () => {
         expect(providerRefusal(403, body)).toBe(
             'Voice provider refused the connection (HTTP 403): Your team has either used all available credits or reached its monthly spending limit.',
         );
+    });
+
+    it('preserves a provider-shaped Gemini burst in native-paced frames', () => {
+        const pcm = Buffer.concat(Array.from({ length: 400 }, (_, index) => Buffer.alloc(960, index)));
+        const burst = pcm.toString('base64');
+        const frames = chunkGeminiAudio(burst);
+        expect(frames).toHaveLength(400);
+        expect(frames.map((frame) => Buffer.from(frame, 'base64')[0])).toEqual(
+            Array.from({ length: 400 }, (_, index) => index & 0xff),
+        );
+        expect(Buffer.from(frames.join(''), 'base64')).toEqual(pcm);
     });
 
     it('falls back to code when there is no error field', () => {


### PR DESCRIPTION
## Problem
- Gemini Live can deliver multi-second PCM bursts faster than the phone's bounded native sink drains, producing `Realtime playback buffer overflowed`.
- Wake on speech expired after 30 minutes and several non-toggle paths cleared its persisted preference.

## Fix
- Pace Gemini PCM as ordered 20 ms frames behind a bounded queue; pause the provider WebSocket for stdout/mobile backpressure.
- Preserve immediate interrupt clear and explicit-stop teardown; genuine queue overload remains visible and recoverable.
- Remove standby TTL/expiry, persist the preference across restart/reconnect/background, and disable it only through the settings toggle.
- Update the settings copy and add provider-shaped burst, pacing, clear, >30-minute, service-order, and persisted-restart assertions.

## Verification
- Focused mobile flows: 12 passed.
- Voice/provider flows: 10 passed.
- Root and mobile typechecks passed.
- Full `yarn check` passed.
- API 36 x86_64 release APK built, installed, and cold-launched; background/foreground after a simulated >30-minute clock jump hot-resumed.
- Physical audible playback was not re-run: no physical Android device was attached; deterministic native admission/interrupt assertions passed. No merge or publish performed.