### PR TITLE
fix: recover setup when Tailscale Serve is already owned

### DIFF
--- a/scripts/diagnostics/application/checkTailscaleIngress.mjs
+++ b/scripts/diagnostics/application/checkTailscaleIngress.mjs
@@ -1,19 +1,33 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { resolveAdvertise, tailscaleBin, tailscaleIngress } from '../../setup/index.mjs';
+import {
+    cleanupManagedIngress,
+    continueWithDirectTailscale,
+    inspectTailscaleServeRoot,
+    persistOwnedServeIngress,
+    readSelfhostState,
+    resolveAdvertise,
+    selfhostArgsFromSetupPlan,
+    tailscaleBin,
+    tailscaleIngress,
+} from '../../setup/index.mjs';
 
 const scratch = mkdtempSync(join(tmpdir(), 'muxr-tailscale-'));
 const fake = join(scratch, 'tailscale');
+const log = join(scratch, 'tailscale.log');
 const originalPath = process.env.PATH;
 const originalHome = process.env.HOME;
+const originalMuxrHome = process.env.MUXR_HOME;
 const originalPlatform = process.env.MUXR_PLATFORM;
 const configure = (status, serveStatus = '{}') => {
-    writeFileSync(fake, `#!/bin/sh\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}' ;;\n  "serve --yes --bg --https=443 http://127.0.0.1:8792") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
+    writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(log)}\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}' ;;\n  "serve --yes --bg --https=443 http://127.0.0.1:8792") exit 0 ;;\n  "serve --https=443 off") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
     chmodSync(fake, 0o755);
 };
+const commandsSince = (offset) => (existsSync(log) ? readFileSync(log, 'utf8') : '').slice(offset);
 process.env.PATH = `${scratch}:${originalPath}`;
+process.env.MUXR_HOME = join(scratch, 'muxr-home');
 try {
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } });
     const ingress = tailscaleIngress([]);
@@ -21,7 +35,7 @@ try {
     assert.deepEqual(await resolveAdvertise([], 8792, ingress), {
         url: 'wss://dev.tailnet.ts.net',
         note: 'Tailscale Serve (private tailnet HTTPS)',
-        ingress: { kind: 'tailscale-serve', port: 8792, dnsName: 'dev.tailnet.ts.net' },
+        ingress: { kind: 'tailscale-serve', port: 8792, dnsName: 'dev.tailnet.ts.net', proxy: 'http://127.0.0.1:8792' },
     });
 
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.' } }, JSON.stringify({ TCP: { '443': { HTTPS: true } }, Web: { 'dev.tailnet.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:9999' } } } } }));
@@ -43,6 +57,40 @@ try {
     await assert.rejects(resolveAdvertise(['--advertise', 'wss://user:pass@example.com'], 8792), /without credentials/);
     await assert.rejects(resolveAdvertise(['--advertise', 'wss://example.com/muxr'], 8792), /without credentials/);
 
+    const occupied = JSON.stringify({ TCP: { '443': { HTTPS: true } }, Web: { 'dev.tailnet.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:9999' } } } } });
+    const ours = JSON.stringify({ Web: { 'dev.tailnet.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:8792' } } } } });
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, occupied);
+    const beforeForeign = existsSync(log) ? readFileSync(log, 'utf8').length : 0;
+    assert.equal(inspectTailscaleServeRoot(8792, 'dev.tailnet.ts.net').status, 'occupied');
+    await assert.rejects(resolveAdvertise([], 8792, tailscaleIngress([])), /already owned/);
+    const recovered = continueWithDirectTailscale({ mode: 'tailscale', port: 8792, web: true, pairing: 'both' });
+    const recoveredArgs = selfhostArgsFromSetupPlan({ ...recovered, found: { lan: '192.168.1.8' } });
+    assert.equal(recoveredArgs.at(recoveredArgs.indexOf('--connection-mode') + 1), 'tailscale-direct');
+    assert.ok(recoveredArgs.includes('--tailscale-direct'));
+    assert.ok(!recoveredArgs.includes('--web'));
+    assert.equal((await resolveAdvertise(recoveredArgs, 8792, tailscaleIngress(recoveredArgs))).url, 'ws://100.64.0.1:8792');
+    cleanupManagedIngress({ version: 1 });
+    cleanupManagedIngress({ version: 1, ingress: { kind: 'tailscale-serve', port: 8792, dnsName: 'dev.tailnet.ts.net', proxy: 'http://127.0.0.1:8792' } });
+    assert.doesNotMatch(commandsSince(beforeForeign), /serve --yes|serve --https=443 off/, 'foreign Serve owner was claimed or reset');
+
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } });
+    const beforeClaim = readFileSync(log, 'utf8').length;
+    const owned = await resolveAdvertise([], 8792, tailscaleIngress([]));
+    persistOwnedServeIngress({ version: 1 }, owned.ingress);
+    assert.equal(readSelfhostState().ingress.proxy, 'http://127.0.0.1:8792');
+    assert.match(commandsSince(beforeClaim), /serve --yes --bg --https=443 http:\/\/127\.0\.0\.1:8792/);
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, ours);
+    cleanupManagedIngress(readSelfhostState());
+    assert.match(commandsSince(beforeClaim), /serve --https=443 off/);
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } });
+    const beforeGone = readFileSync(log, 'utf8').length;
+    cleanupManagedIngress(readSelfhostState());
+    assert.doesNotMatch(commandsSince(beforeGone), /serve --https=443 off/, 'owned cleanup ran again after Serve was already gone');
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, occupied);
+    const beforeStale = readFileSync(log, 'utf8').length;
+    cleanupManagedIngress(readSelfhostState());
+    assert.doesNotMatch(commandsSince(beforeStale), /serve --https=443 off/, 'stale muxr ownership reset a later foreign Serve owner');
+
     const macHome = join(scratch, 'mac-home');
     const macApp = join(macHome, 'Applications', 'Tailscale.app', 'Contents', 'MacOS', 'Tailscale');
     mkdirSync(join(scratch, 'empty-path'));
@@ -58,5 +106,6 @@ try {
 } finally {
     process.env.PATH = originalPath;
     if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+    if (originalMuxrHome === undefined) delete process.env.MUXR_HOME; else process.env.MUXR_HOME = originalMuxrHome;
     if (originalPlatform === undefined) delete process.env.MUXR_PLATFORM; else process.env.MUXR_PLATFORM = originalPlatform;
 }

--- a/scripts/setup/application/startSelfHost.mjs
+++ b/scripts/setup/application/startSelfHost.mjs
@@ -14,6 +14,7 @@ import { daemonIsRunning, runDaemon, startMuxrDaemon } from '../infrastructure/d
 import {
     cleanupManagedIngress,
     cloudflaredAlive,
+    persistOwnedServeIngress,
     readSelfhostState,
     selfhostPath,
     selfhostStateUnreadable,
@@ -95,6 +96,7 @@ export async function startSelfHost(args = []) {
             ? { url: state.relayUrl, note: 'existing Cloudflare quick tunnel', ingress: state.ingress }
             : await resolveAdvertise(args, port, tailscale);
         pendingIngress = advertise.ingress?.kind === 'cloudflare-quick' ? advertise.ingress : undefined;
+        if (advertise.ingress?.kind === 'tailscale-serve') state = persistOwnedServeIngress(state, advertise.ingress);
         if (web && !advertise.url.startsWith('wss://')) throw new Error('--web requires HTTPS (Tailscale Serve, a named HTTPS tunnel, or --advertise wss://...)');
         const bindHost = tailscale || args.includes('--tunnel') || web || explicitAdvertise?.startsWith('wss://') ? '127.0.0.1' : '0.0.0.0';
         const webOrigin = web ? advertise.url.replace(/^wss/, 'https') : undefined;

--- a/scripts/setup/index.mjs
+++ b/scripts/setup/index.mjs
@@ -53,14 +53,18 @@ export {
 export {
     applyMachineSetup,
     connectRemoteRelay,
+    continueWithDirectTailscale,
     hostSharedRelay,
     manageMachines,
+    selfhostArgsFromSetupPlan,
 } from './presentation/setupWizard.mjs';
 
 export {
     advertisedRelayHealthy,
     cleanupManagedIngress,
     cloudflaredAlive,
+    inspectTailscaleServeRoot,
+    persistOwnedServeIngress,
     readSelfhostState,
     runTailscale,
     selfhostConfigured,
@@ -69,6 +73,7 @@ export {
     selfhostPath,
     selfhostRelayHealthy,
     selfhostStateUnreadable,
+    SERVE_OWNED_ERROR,
     stopOwnedSelfhostRelay,
     tailscaleBin,
     tailscaleIngress,

--- a/scripts/setup/infrastructure/selfhost.mjs
+++ b/scripts/setup/infrastructure/selfhost.mjs
@@ -139,6 +139,30 @@ export function tailscaleRootProxy(value, dnsName) {
     return roots.length === 1 ? roots[0] : undefined;
 }
 
+export const SERVE_OWNED_ERROR = 'Tailscale Serve root is already owned by another service; use --tailscale-direct or remove it yourself';
+
+export function inspectTailscaleServeRoot(port, dnsName, expectedProxy) {
+    const expected = expectedProxy ?? `http://127.0.0.1:${port}`;
+    const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8' });
+    if (current.error?.code === 'ENOENT') return { status: 'unknown', missing: true, reason: 'tailscale not found' };
+    if (current.status !== 0) {
+        return { status: 'unknown', reason: `cannot inspect Tailscale Serve ownership: ${current.stderr.trim() || 'status failed'}` };
+    }
+    let rootProxy;
+    try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), dnsName); }
+    catch { return { status: 'unknown', reason: 'Tailscale Serve returned invalid status JSON' }; }
+    if (rootProxy === undefined) return { status: 'free' };
+    if (rootProxy === expected) return { status: 'ours' };
+    return { status: 'occupied' };
+}
+
+export function persistOwnedServeIngress(state, ingress) {
+    if (ingress?.kind !== 'tailscale-serve') return state;
+    const next = { ...state, ingress };
+    writeSelfhostState(next);
+    return next;
+}
+
 export function cloudflaredAlive(ingress) {
     if (ingress?.kind !== 'cloudflare-quick') return false;
     const pid = Number(ingress.pid);
@@ -153,16 +177,12 @@ export function cleanupManagedIngress(state) {
         return;
     }
     if (ingress?.kind !== 'tailscale-serve') return;
-    const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8' });
-    if (current.error?.code === 'ENOENT') return;
-    if (current.status !== 0) throw new Error('cannot inspect the previous muxr Tailscale Serve route; leaving it unchanged');
-    let parsed;
-    try { parsed = JSON.parse(current.stdout || '{}'); }
-    catch { throw new Error('Tailscale Serve returned invalid status JSON; leaving it unchanged'); }
-    const expected = `http://127.0.0.1:${ingress.port}`;
-    const rootProxy = tailscaleRootProxy(parsed, ingress.dnsName);
-    if (rootProxy === undefined) return;
-    if (rootProxy !== expected) throw new Error('the previous Tailscale Serve route changed outside muxr; leaving it unchanged');
+    const expected = typeof ingress.proxy === 'string' ? ingress.proxy : `http://127.0.0.1:${ingress.port}`;
+    const ownership = inspectTailscaleServeRoot(ingress.port, ingress.dnsName, expected);
+    if (ownership.missing || ownership.status === 'free' || ownership.status === 'occupied') return;
+    if (ownership.status === 'unknown') {
+        throw new Error('cannot inspect the previous muxr Tailscale Serve route; leaving it unchanged');
+    }
     const disabled = runTailscale(['serve', '--https=443', 'off'], { encoding: 'utf8' });
     if (disabled.status !== 0) throw new Error(`could not remove the previous muxr Tailscale Serve route: ${disabled.stderr.trim() || disabled.stdout.trim()}`);
 }

--- a/scripts/setup/infrastructure/selfhostRelay.mjs
+++ b/scripts/setup/infrastructure/selfhostRelay.mjs
@@ -26,13 +26,14 @@ import { daemonIsRunning } from './daemon.mjs';
 import {
     advertisedRelayHealthy,
     cloudflaredAlive,
+    inspectTailscaleServeRoot,
     readSelfhostState,
     runTailscale,
     selfhostControlBase,
     selfhostCredential,
     selfhostRelayHealthy,
+    SERVE_OWNED_ERROR,
     stopOwnedSelfhostRelay,
-    tailscaleRootProxy,
     writeSelfhostState,
 } from './selfhost.mjs';
 
@@ -133,21 +134,18 @@ export async function resolveAdvertise(args, port, tailscale) {
         };
     }
     if (tailscale) {
-        const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8' });
-        if (current.status !== 0) throw new Error(`cannot inspect Tailscale Serve ownership: ${current.stderr.trim() || 'status failed'}`);
-        let rootProxy;
-        try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), tailscale.dnsName); }
-        catch { throw new Error('Tailscale Serve returned invalid status JSON'); }
+        const ownership = inspectTailscaleServeRoot(port, tailscale.dnsName);
+        if (ownership.status === 'unknown') throw new Error(ownership.reason);
+        if (ownership.status === 'occupied') throw new Error(SERVE_OWNED_ERROR);
         const expected = `http://127.0.0.1:${port}`;
-        if (rootProxy !== undefined && rootProxy !== expected) throw new Error('Tailscale Serve root is already owned by another service; use --tailscale-direct or remove it yourself');
-        const serve = rootProxy === expected
+        const serve = ownership.status === 'ours'
             ? { status: 0, stdout: '', stderr: '' }
             : runTailscale(['serve', '--yes', '--bg', '--https=443', expected], { encoding: 'utf8' });
         if (serve.status !== 0) throw new Error(`tailscale serve failed: ${serve.stderr.trim() || serve.stdout.trim() || 'check operator permissions'}; use --tailscale-direct for direct tailnet mode`);
         return {
             url: `wss://${tailscale.dnsName}`,
             note: 'Tailscale Serve (private tailnet HTTPS)',
-            ingress: { kind: 'tailscale-serve', port, dnsName: tailscale.dnsName },
+            ingress: { kind: 'tailscale-serve', port, dnsName: tailscale.dnsName, proxy: expected },
         };
     }
     const status = runTailscale(['status', '--json'], { encoding: 'utf8' });

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -10,7 +10,7 @@ import { enrollMachine } from '../application/enrollMachine.mjs';
 import { listMachines } from '../application/listMachines.mjs';
 import { revokeMachine } from '../application/revokeMachine.mjs';
 import { selfhostPublicSummary, sharedMachineCount } from '../infrastructure/selfhostRelay.mjs';
-import { runTailscale, tailscaleBin } from '../infrastructure/selfhost.mjs';
+import { inspectTailscaleServeRoot, runTailscale, tailscaleBin } from '../infrastructure/selfhost.mjs';
 import { advertisedUrlForMode, connectionLabel, ingressPlan, modeAllowsBrowserHosting } from '../domain/dist/index.js';
 
 function command(name, args = []) {
@@ -227,13 +227,30 @@ const RELAY_KIND = {
 };
 const relayKind = (mode) => RELAY_KIND[mode] ?? mode;
 
-function choices(found, tailscalePlanned = false) {
+function choices(found, tailscalePlanned = false, serveRoot = { status: 'unknown' }) {
     // The relay is the one real choice in setup: it is how the phone reaches
     // the host. Never delete an option silently — show it disabled with the
     // reason and remedy attached, so the user sees what is standing in the way.
     const options = [];
+    const serveOccupied = serveRoot.status === 'occupied';
     if (found.tailscale.connected || tailscalePlanned) {
-        options.push({ value: 'tailscale', title: 'Tailscale · recommended', description: tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly' });
+        if (serveOccupied) {
+            options.push({
+                value: 'tailscale',
+                title: 'Tailscale Serve',
+                description: 'already used by another service · left unchanged',
+                disabled: true,
+            });
+            options.push({
+                value: 'tailscale-direct',
+                title: 'Tailscale · recommended',
+                description: tailscalePlanned
+                    ? 'connect during Apply · reach this computer over the tailnet address'
+                    : 'private tailnet address · leaves the existing Serve service unchanged',
+            });
+        } else {
+            options.push({ value: 'tailscale', title: 'Tailscale · recommended', description: tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly' });
+        }
     } else {
         options.push({ value: 'tailscale', title: 'Tailscale', description: found.tailscale.detail, disabled: true });
     }
@@ -252,6 +269,156 @@ function choices(found, tailscalePlanned = false) {
 }
 
 const aborted = (value) => value === undefined || value === BACK;
+
+export function continueWithDirectTailscale(plan) {
+    const browserPair = plan.pairing === 'browser' || plan.pairing === 'browser-view' || plan.pairing === 'both';
+    return {
+        mode: 'tailscale-direct',
+        port: plan.port,
+        endpoint: plan.endpoint,
+        web: false,
+        pairing: browserPair ? 'phone' : plan.pairing,
+    };
+}
+
+export function selfhostArgsFromSetupPlan({ mode, port, web, pairing, found, endpoint }) {
+    const selfhostArgs = ['--port', String(port), '--connection-mode', mode, '--reconfigure'];
+    if (mode === 'lan') selfhostArgs.push('--advertise', `ws://${found.lan}:${port}`);
+    if (mode === 'external') selfhostArgs.push('--advertise', endpoint);
+    if (mode === 'cloudflare') selfhostArgs.push('--tunnel');
+    if (mode === 'tailscale-direct') selfhostArgs.push('--tailscale-direct');
+    if (web) selfhostArgs.push('--web', '--yes');
+    if (pairing === 'browser') selfhostArgs.push('--pair-browser');
+    if (pairing === 'browser-view') selfhostArgs.push('--pair-browser-view');
+    if (pairing === 'none') selfhostArgs.push('--no-pair');
+    return selfhostArgs;
+}
+
+function serveRootFor(found, port) {
+    if (!found.tailscale.connected && !found.tailscale.dnsName) return { status: 'unknown' };
+    return inspectTailscaleServeRoot(port, found.tailscale.dnsName);
+}
+
+async function chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args }) {
+    const plannedPort = Number(value(args, '--port')) || current?.relayPort || 8792;
+    const serveRoot = serveRootFor(found, plannedPort);
+    let mode = requestedMode;
+    if (mode === 'selfhost') mode = undefined;
+    if (!mode) {
+        heading('muxr runs on this computer');
+        const connectionChoices = choices(found, tailscalePlanned, serveRoot).map((choice) => {
+            if (choice.value !== current?.connectionMode) return choice;
+            return { ...choice, title: `${choice.title} · current` };
+        });
+        const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
+        mode = await select('How should your phone connect?', connectionChoices, initial);
+    }
+    if (aborted(mode)) return undefined;
+    if (!['tailscale', 'tailscale-direct', 'lan', 'external', 'cloudflare'].includes(mode)) {
+        process.stderr.write(`unknown setup mode: ${mode}\n`);
+        return 1;
+    }
+    if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected && !tailscalePlanned) {
+        process.stderr.write(`Tailscale is unavailable: ${found.tailscale.detail}; or pick a different relay\n`);
+        return 1;
+    }
+    if (mode === 'lan' && !found.lan) {
+        process.stderr.write('no local network address was found; pick a different relay\n');
+        return 1;
+    }
+    if (mode === 'cloudflare' && !found.cloudflared.ok) {
+        process.stderr.write(`cloudflared is unavailable: ${found.cloudflared.detail}; pick a different relay\n`);
+        return 1;
+    }
+
+    let port = current === undefined && value(args, '--port') === undefined ? 8792 : undefined;
+    while (port === undefined) {
+        setupStep(2, 5, 'Choose connection port');
+        const portText = await prompt('Local connection port', value(args, '--port') ?? String(current.relayPort));
+        if (portText === undefined) return undefined;
+        const parsed = Number(portText);
+        if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
+        else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
+    }
+    let endpoint;
+    if (mode === 'external') {
+        while (endpoint === undefined) {
+            setupStep(2, 5, 'Enter your server address');
+            const entered = await prompt('External relay URL (wss://...)', current?.connectionMode === 'external' ? current.relayUrl : '');
+            if (entered === undefined) return undefined;
+            try {
+                const parsed = new URL(entered);
+                if (parsed.protocol === 'wss:' && parsed.hostname && !parsed.username && !parsed.password && parsed.pathname === '/' && !parsed.search && !parsed.hash) endpoint = parsed.toString().replace(/\/$/, '');
+                else status('External relay URL', 'use a root wss://host URL without credentials, query, or fragment', 'warn');
+            } catch {
+                status('External relay URL', 'use a valid wss:// URL', 'warn');
+            }
+        }
+    }
+
+    setupStep(2, 5, 'Choose app access');
+    let web = false;
+    if (modeAllowsBrowserHosting(mode)) {
+        web = await select('Host the browser client too?', [
+            { value: false, title: 'Native app only', description: 'do not expose the browser client' },
+            { value: true, title: 'Host the browser client', description: 'serve it over the selected HTTPS/WSS connection' },
+        ], current?.webEnabled ? 1 : 0);
+        if (aborted(web)) return undefined;
+    } else {
+        status('Browser client', 'requires Tailscale Serve, External WSS, or Cloudflare; native app only', 'off');
+    }
+    const desiredUrl = advertisedUrlForMode({ mode, found, current, port, endpoint, web, tailscalePlanned });
+    const connectionChanged = current === undefined || desiredUrl === undefined || current.relayUrl !== desiredUrl;
+    const pairingChoices = [
+        ...(current !== undefined ? [{
+            value: 'none',
+            title: 'Keep paired devices',
+            description: connectionChanged
+                ? 'same-LAN devices can adopt it through local discovery; remote devices must pair once with the new endpoint'
+                : 'no new QR; existing devices keep working',
+        }] : []),
+        { value: 'phone', title: 'Phone', description: 'pair the native app first' },
+        ...(web ? [
+            { value: 'browser', title: 'Control browser', description: 'full terminal and agent control for eight hours' },
+            { value: 'browser-view', title: 'View-only browser', description: 'observe agents without control for eight hours' },
+            { value: 'both', title: 'Phone, then control browser', description: 'complete both pairing steps' },
+        ] : []),
+    ];
+    setupStep(2, 5, 'Choose what to pair');
+    const pairing = pairingChoices.length === 1 ? pairingChoices[0].value : await select(connectionChanged && current !== undefined
+        ? 'The connection changed. Keep existing devices or pair another one?'
+        : 'Pair a client?', pairingChoices);
+    if (aborted(pairing)) return undefined;
+    return { mode, port, endpoint, web, pairing };
+}
+
+async function recoverOccupiedServe({ plan, found, current, tailscalePlanned, args }) {
+    if (plan.mode !== 'tailscale') return plan;
+    if (serveRootFor(found, plan.port).status !== 'occupied') return plan;
+    setupStep(5, 5, 'Tailscale Serve is already in use');
+    heading('Tailscale Serve is already in use');
+    note([
+        'Another service already owns the Tailscale Serve root.',
+        'muxr left that service unchanged.',
+        'You can use direct Tailscale networking, or go back and choose a different connection.',
+    ]);
+    const action = await select('How do you want to continue?', [
+        { value: 'direct', title: 'Use direct Tailscale networking', description: 'reach this computer over its tailnet address · leaves the other service unchanged' },
+        { value: 'back', title: 'Change how your phone connects', description: 'go back and pick a different connection' },
+    ]);
+    if (aborted(action)) return undefined;
+    if (action === 'direct') {
+        const next = continueWithDirectTailscale(plan);
+        if (plan.web) status('Browser client', 'needs Tailscale Serve or HTTPS; continuing with the native app only', 'warn');
+        status('Connection', connectionLabel(next.mode, next.endpoint, next.port), 'ok');
+        return next;
+    }
+    setupStep(2, 5, 'Choose how your phone connects');
+    const chosen = await chooseMachineConnection({ found, current, tailscalePlanned, requestedMode: undefined, args });
+    if (chosen === undefined) return undefined;
+    if (chosen === 1) return 1;
+    return chosen;
+}
 
 // Any abort before Apply must say so; a silent exit reads as "something ran".
 function cancelled() {
@@ -326,92 +493,11 @@ export async function applyMachineSetup(args = []) {
     const current = await selfhostPublicSummary();
 
     setupStep(2, 5, 'Choose how your phone connects');
-    let mode = requestedMode;
-    if (mode === 'selfhost') mode = undefined;
-    if (!mode) {
-        heading('muxr runs on this computer');
-        const connectionChoices = choices(found, tailscalePlanned).map((choice) => choice.value === current?.connectionMode
-            ? { ...choice, title: `${choice.title} · current` }
-            : choice);
-        const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
-        mode = await select('How should your phone connect?', connectionChoices, initial);
-    }
-    if (aborted(mode)) return cancelSetup();
-    if (!['tailscale', 'tailscale-direct', 'lan', 'external', 'cloudflare'].includes(mode)) {
-        process.stderr.write(`unknown setup mode: ${mode}\n`);
-        return 1;
-    }
-    if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected && !tailscalePlanned) {
-        process.stderr.write(`Tailscale is unavailable: ${found.tailscale.detail}; or pick a different relay\n`);
-        return 1;
-    }
-    if (mode === 'lan' && !found.lan) {
-        process.stderr.write('no local network address was found; pick a different relay\n');
-        return 1;
-    }
-    if (mode === 'cloudflare' && !found.cloudflared.ok) {
-        process.stderr.write(`cloudflared is unavailable: ${found.cloudflared.detail}; pick a different relay\n`);
-        return 1;
-    }
-
-    let port = current === undefined && value(args, '--port') === undefined ? 8792 : undefined;
-    while (port === undefined) {
-        setupStep(2, 5, 'Choose connection port');
-        const portText = await prompt('Local connection port', value(args, '--port') ?? String(current.relayPort));
-        if (portText === undefined) return cancelSetup();
-        const parsed = Number(portText);
-        if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
-        else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
-    }
-    let endpoint;
-    if (mode === 'external') {
-        while (endpoint === undefined) {
-            setupStep(2, 5, 'Enter your server address');
-            const entered = await prompt('External relay URL (wss://...)', current?.connectionMode === 'external' ? current.relayUrl : '');
-            if (entered === undefined) return cancelSetup();
-            try {
-                const parsed = new URL(entered);
-                if (parsed.protocol === 'wss:' && parsed.hostname && !parsed.username && !parsed.password && parsed.pathname === '/' && !parsed.search && !parsed.hash) endpoint = parsed.toString().replace(/\/$/, '');
-                else status('External relay URL', 'use a root wss://host URL without credentials, query, or fragment', 'warn');
-            } catch {
-                status('External relay URL', 'use a valid wss:// URL', 'warn');
-            }
-        }
-    }
-
-    setupStep(2, 5, 'Choose app access');
-    let web = false;
-    if (modeAllowsBrowserHosting(mode)) {
-        web = await select('Host the browser client too?', [
-            { value: false, title: 'Native app only', description: 'do not expose the browser client' },
-            { value: true, title: 'Host the browser client', description: 'serve it over the selected HTTPS/WSS connection' },
-        ], current?.webEnabled ? 1 : 0);
-        if (aborted(web)) return cancelSetup();
-    } else {
-        status('Browser client', 'requires Tailscale Serve, External WSS, or Cloudflare; native app only', 'off');
-    }
-    const desiredUrl = advertisedUrlForMode({ mode, found, current, port, endpoint, web, tailscalePlanned });
+    let plan = await chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args });
+    if (plan === undefined) return cancelSetup();
+    if (plan === 1) return 1;
+    const desiredUrl = advertisedUrlForMode({ ...plan, found, current, tailscalePlanned });
     const connectionChanged = current === undefined || desiredUrl === undefined || current.relayUrl !== desiredUrl;
-    const pairingChoices = [
-        ...(current !== undefined ? [{
-            value: 'none',
-            title: 'Keep paired devices',
-            description: connectionChanged
-                ? 'same-LAN devices can adopt it through local discovery; remote devices must pair once with the new endpoint'
-                : 'no new QR; existing devices keep working',
-        }] : []),
-        { value: 'phone', title: 'Phone', description: 'pair the native app first' },
-        ...(web ? [
-            { value: 'browser', title: 'Control browser', description: 'full terminal and agent control for eight hours' },
-            { value: 'browser-view', title: 'View-only browser', description: 'observe agents without control for eight hours' },
-            { value: 'both', title: 'Phone, then control browser', description: 'complete both pairing steps' },
-        ] : []),
-    ];
-    setupStep(2, 5, 'Choose what to pair');
-    const pairing = pairingChoices.length === 1 ? pairingChoices[0].value : await select(connectionChanged && current !== undefined
-        ? 'The connection changed. Keep existing devices or pair another one?'
-        : 'Pair a client?', pairingChoices);
-    if (aborted(pairing)) return cancelSetup();
 
     setupStep(3, 5, 'Connect agents and add-ons');
     const syncIntegrations = await select(found.agents.checked
@@ -427,14 +513,14 @@ export async function applyMachineSetup(args = []) {
 
     setupStep(4, 5, 'Review setup');
     note([
-        `Connection: ${connectionLabel(mode, endpoint, port)}`,
+        `Connection: ${connectionLabel(plan.mode, plan.endpoint, plan.port)}`,
         `Herdr: ${found.herdr.installed ? 'adopt existing installation and ensure its server is running' : 'download, install, and start during setup'}`,
         'Bundled plugins: link the public muxr plugins into Herdr',
         `Agent integrations: ${syncIntegrations ? 'sync detected lifecycle providers; leave agent prompt files unchanged' : 'leave lifecycle integrations unchanged'}`,
         `Optional add-ons: ${plugins.length ? plugins.map((plugin) => plugin.title).join(', ') : 'none'}`,
-        `Browser client: ${web ? 'host the web app; browser keys stay WebCrypto-wrapped on this device' : 'off'}`,
-        `Pairing: ${pairingChoiceLabel(pairing)}${browserGrantNote(pairing, { planned: true })}`,
-        `Ingress: ${ingressPlan(mode, tailscalePlanned)}`,
+        `Browser client: ${plan.web ? 'host the web app; browser keys stay WebCrypto-wrapped on this device' : 'off'}`,
+        `Pairing: ${pairingChoiceLabel(plan.pairing)}${browserGrantNote(plan.pairing, { planned: true })}`,
+        `Ingress: ${ingressPlan(plan.mode, tailscalePlanned)}`,
         'Services: register or restart the relay and host with systemd/launchd',
         `Existing connections: ${connectionChanged ? 'stored grants stay authoritative and adopt the advertised endpoint automatically' : 'keep working; restart only if a reviewed runtime setting changed'}`,
         'No change is made until you choose Apply setup.',
@@ -446,7 +532,7 @@ export async function applyMachineSetup(args = []) {
     if (apply !== true) return cancelSetup();
 
     setupStep(5, 5, 'Install, start, and pair');
-    if ((mode === 'tailscale' || mode === 'tailscale-direct') && tailscalePlanned && !(await applyTailscaleConnect(found))) {
+    if ((plan.mode === 'tailscale' || plan.mode === 'tailscale-direct') && tailscalePlanned && !(await applyTailscaleConnect(found))) {
         process.stderr.write('Tailscale did not connect; fix the reported issue, then rerun setup\n');
         return 1;
     }
@@ -458,17 +544,17 @@ export async function applyMachineSetup(args = []) {
     const prerequisites = await runLocalPrerequisites(prerequisiteArgs);
     if (prerequisites !== 0) return prerequisites;
     const pluginResult = await installPlugins(plugins);
-    const selfhostArgs = ['--port', String(port), '--connection-mode', mode, '--reconfigure'];
-    if (mode === 'lan') selfhostArgs.push('--advertise', `ws://${found.lan}:${port}`);
-    if (mode === 'external') selfhostArgs.push('--advertise', endpoint);
-    if (mode === 'cloudflare') selfhostArgs.push('--tunnel');
-    if (mode === 'tailscale-direct') selfhostArgs.push('--tailscale-direct');
-    if (web) selfhostArgs.push('--web', '--yes');
-    if (pairing === 'browser') selfhostArgs.push('--pair-browser');
-    if (pairing === 'browser-view') selfhostArgs.push('--pair-browser-view');
-    if (pairing === 'none') selfhostArgs.push('--no-pair');
-    const result = await startSelfHost(selfhostArgs);
-    if (result !== 0) return result;
+    let result = 1;
+    for (;;) {
+        const recovered = await recoverOccupiedServe({ plan, found, current, tailscalePlanned, args });
+        if (recovered === undefined) return cancelSetup();
+        if (recovered === 1) return 1;
+        plan = recovered;
+        result = await startSelfHost(selfhostArgsFromSetupPlan({ ...plan, found }));
+        if (result === 0) break;
+        if (plan.mode !== 'tailscale' || serveRootFor(found, plan.port).status !== 'occupied') return result;
+    }
+    const { mode, endpoint, port, pairing } = plan;
     const browserPairFailed = pairing === 'both' && (await pairDevice(['--browser'])) !== 0;
     const doctor = await inspectSetup();
     if (doctor !== 0) return doctor;


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.97.0
## Summary
- Interactive setup no longer dead-ends after plugin/integration sync when another service owns the Tailscale Serve root. muxr leaves that service unchanged and offers direct Tailscale networking or a connection change in the same apply flow, persisting `tailscale-direct` when chosen.
- muxr records Serve ownership when it creates a route. `muxr uninstall` and `muxr daemon uninstall` remove only muxr-owned Serve mappings and free the root. Foreign and pre-conflict Serve configuration is never reset, cleared, or overwritten, including after partial setup failure.
- Non-interactive `muxr self-host` still fails with the existing `--tailscale-direct` message. No user-facing command guidance in the README/runbook needed changing.

## Test plan
- [x] `node scripts/diagnostics/application/checkTailscaleIngress.mjs` (occupied refuse, direct recovery args, owned persist+uninstall cleanup, foreign/stale-owner preservation, idempotent cleanup)
- [x] `node scripts/diagnostics/application/checkSelfhostRevocation.mjs`
- [x] `node scripts/diagnostics/application/checkArchitecture.mjs`
- [ ] Interactive `muxr setup` with an occupied Serve root: choose direct and confirm setup continues without restarting
- [ ] `muxr uninstall` / `muxr daemon uninstall` after a muxr-owned Serve setup removes that route only
- [ ] Uninstall when Serve is owned by another service leaves that mapping in place