### PR TITLE
fix(mobile): hold pairing confirm until scanner returns to foreground

### DIFF
--- a/apps/mobile/sources/pairing/application/deliverScannedPairing.ts
+++ b/apps/mobile/sources/pairing/application/deliverScannedPairing.ts
@@ -1,0 +1,50 @@
+import { AppState, type AppStateStatus, type NativeEventSubscription } from 'react-native';
+
+export type AppStateLike = {
+    currentState: AppStateStatus;
+    addEventListener: (type: 'change', listener: (state: AppStateStatus) => void) => NativeEventSubscription;
+};
+
+/**
+ * Google Code Scanner runs in its own Activity. A pairing confirm shown
+ * during that teardown is dropped on Android release, so the scan looks
+ * successful and Home stays unpaired. Wait until muxr is foreground again.
+ * Never time out into a confirm while the app is still inactive.
+ */
+export async function waitUntilAppActive(appState?: AppStateLike): Promise<void> {
+    const source = appState ?? AppState;
+    if (source.currentState === 'active') return;
+    await new Promise<void>((resolve) => {
+        let settled = false;
+        let subscription: NativeEventSubscription | undefined;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            subscription?.remove();
+            resolve();
+        };
+        subscription = source.addEventListener('change', (next) => {
+            if (next === 'active') finish();
+        });
+        // Subscribe first, then re-read: currentState can flip to active
+        // between the early return and addEventListener.
+        if (source.currentState === 'active') finish();
+    });
+}
+
+export async function deliverScannedPairingLink(
+    url: string,
+    handler: (url: string) => void,
+    deps: {
+        dismissScanner: () => Promise<unknown>;
+        appState?: AppStateLike;
+    },
+): Promise<void> {
+    try {
+        await deps.dismissScanner();
+    } catch {
+        // Decode already closed the scanner Activity.
+    }
+    await waitUntilAppActive(deps.appState);
+    handler(url);
+}

--- a/apps/mobile/sources/pairing/application/usePairing.ts
+++ b/apps/mobile/sources/pairing/application/usePairing.ts
@@ -7,6 +7,7 @@ import { hostedPairingAuthority, hostedPairingDisplayName } from './hostedE2ee';
 import { getCachedConnectionSettings } from '@/connection';
 import { useCheckScannerPermissions } from './useCheckCameraPermissions';
 import { pairMachine } from './PairMachine';
+import { deliverScannedPairingLink } from './deliverScannedPairing';
 
 const PAIR_LINK = /^https:\/\/[^#]+\/pair#|^muxr:\/\/pair[?#]|^wss?:\/\/[^?\s]+\?[^#\s]*\bpair=|^http:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?\/pair#/i;
 
@@ -80,8 +81,9 @@ function ensureScanSubscription(): void {
         const handler = pendingScan;
         if (handler === null || !PAIR_LINK.test(event.data)) return;
         pendingScan = null;
-        void CameraView.dismissScanner().catch(() => undefined);
-        handler(event.data);
+        void deliverScannedPairingLink(event.data, handler, {
+            dismissScanner: () => CameraView.dismissScanner(),
+        });
     });
 }
 

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { encodePayload } from '@muxr/contract';
+import type { AppStateLike } from '../application/deliverScannedPairing';
 
+vi.mock('react-native', () => ({
+    AppState: { currentState: 'active', addEventListener: vi.fn() },
+}));
 vi.mock('../application/hostedE2ee', () => ({
     refreshHostedGrant: vi.fn(async () => undefined),
     DeviceV2Crypto: class {},
@@ -51,5 +55,41 @@ describe('mobile plugin invalidation dispatch', () => {
         expect(received).toEqual([{ type: 'plugins.invalidated', reason: 'changed', pluginIds: ['example.ui'] }]);
         expect(client.state).toBe('open');
         client.close();
+    });
+});
+
+describe('scanned pairing delivery', () => {
+    it('holds the pairing confirm until the scanner Activity returns the app to the foreground', async () => {
+        const { deliverScannedPairingLink } = await import('../application/deliverScannedPairing');
+        const handled: string[] = [];
+        let dismissReleased: (() => void) | undefined;
+        const dismissScanner = vi.fn(() => new Promise<void>((resolve) => { dismissReleased = resolve; }));
+        let currentState: AppStateLike['currentState'] = 'inactive';
+        const listeners = new Set<(state: AppStateLike['currentState']) => void>();
+        const appState: AppStateLike = {
+            get currentState() { return currentState; },
+            addEventListener(_type, listener) {
+                listeners.add(listener);
+                return { remove: () => { listeners.delete(listener); } };
+            },
+        };
+        const delivery = deliverScannedPairingLink(
+            'ws://10.0.2.2:28793?pair=TESTCODE12',
+            (url) => { handled.push(url); },
+            { dismissScanner, appState },
+        );
+
+        await Promise.resolve();
+        expect(handled).toEqual([]);
+        dismissReleased?.();
+        await Promise.resolve();
+        expect(handled).toEqual([]);
+        expect(listeners.size).toBe(1);
+
+        currentState = 'active';
+        for (const listener of [...listeners]) listener('active');
+        await delivery;
+        expect(handled).toEqual(['ws://10.0.2.2:28793?pair=TESTCODE12']);
+        expect(listeners.size).toBe(0);
     });
 });


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.97.0
## Summary
- Android release drops `Alert.alert` while Google Code Scanner's Activity is tearing down. The QR scan looks successful, Home stays unpaired, and the host never gets a claim.
- This waits for `dismissScanner()` and for `AppState` to become `active` before showing the pairing confirm. It does not time out into a confirm while the app is still inactive.
- One flow-level test in the existing `muxrClient.spec.ts` drives that dismiss → foreground → handler sequence through the real waiter.

## Validation
- Focused test and `yarn tsc --build` passed on this branch.
- Published `muxr-android-0.1.12-build47` is **arm64-v8a only**. It cannot run on the x86_64 emulator used here (`SoLoaderDSONotFoundError: libreactnative.so`). That is a published-APK ABI limitation, not a pairing-code issue.
- A signed-equivalent **x86_64** emulator APK (versionCode 48, same signing cert) was built and installed to exercise the release binary. The scanner-lifecycle regression is covered by the focused test. Device/ARM QR proof and a non-EAS ARM test APK are **not** claimed here.
- The published v0.1.22 / 0.1.12-build47 APK is **not** fixed by this PR. Do not treat that asset as patched until an ARM artifact is built without EAS, published, and user-tested.

## Test plan
- [ ] Cold start: scan a `muxr pair` QR on a physical ARM device or ARM emulator; confirm the Pair dialog appears after the scanner closes; host prints paired-and-verified
- [ ] Warm app: same scan while muxr is already on Home
- [ ] Cancel the Pair dialog and confirm Home stays unpaired
- [ ] Manual pairing-string path still works