### PR TITLE
fix(android): prevent release lint metaspace exhaustion

### DIFF
--- a/apps/mobile/android/gradle.properties
+++ b/apps/mobile/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Summary

- raise the Gradle daemon metaspace ceiling from 512 MiB to 1 GiB
- prevent release lint analysis from exhausting metaspace across Expo and native modules
- unblock the direct GitHub Actions APK/AAB pipeline without using EAS Build

## Evidence

- build run 33274828792 completed all release gates and native compilation, then reported `OutOfMemoryError: Metaspace` in `lintVitalAnalyzeRelease`
- no release asset or public download link was published from the failed run
- `git diff --check` passes