### PR TITLE
fix(ci): verify self-signed Android upload bundles

### DIFF
--- a/.github/workflows/mobile-android-internal.yml
+++ b/.github/workflows/mobile-android-internal.yml
@@ -123,7 +123,19 @@ jobs:
           test -x "$apksigner"
           test -x "$apkanalyzer"
           "$apksigner" verify --verbose --print-certs "$apk"
-          jarsigner -verify -strict "$aab" >/dev/null
+          if aab_verify_output="$(jarsigner -verify -strict "$aab" 2>&1)"; then
+            aab_verify_status=0
+          else
+            aab_verify_status=$?
+          fi
+          printf '%s\n' "$aab_verify_output"
+          grep -q 'jar verified' <<<"$aab_verify_output"
+          # A self-signed upload certificate is expected; jarsigner reports it as bit 4.
+          if [ "$aab_verify_status" -ne 0 ]; then
+            test "$aab_verify_status" -eq 4
+            grep -qi 'self-signed' <<<"$aab_verify_output"
+            ! grep -Eqi 'expired|not yet valid|algorithm.*disabled' <<<"$aab_verify_output"
+          fi
           test "$("$apkanalyzer" manifest version-name "$apk")" = "$APP_VERSION"
           test "$("$apkanalyzer" manifest version-code "$apk")" = "$ANDROID_VERSION_CODE"
           curl -fsSL https://github.com/google/bundletool/releases/download/1.18.3/bundletool-all-1.18.3.jar -o "$RUNNER_TEMP/bundletool.jar"


### PR DESCRIPTION
## Summary

- preserve strict `jarsigner` integrity verification for release AABs
- accept only exit code 4 when the expected self-signed upload certificate warning is present
- continue rejecting expired, not-yet-valid, or disabled-algorithm certificates
- expose verifier output in CI for auditable failures

## Evidence

- Android build run 33278936219 successfully produced the signed APK and AAB
- APK signature verification passed with production certificate SHA-256 `9c33841142483611257fcdf772f5e8fc30d6fac803f6da28e7eacfcaec12b08d`
- the AAB verifier then exited 4 because strict `jarsigner` treats a self-signed upload certificate as a severe warning
- workflow YAML parses and `git diff --check` passes