### PR TITLE
fix(android): stabilize release build memory

### DIFF
--- a/.github/workflows/mobile-android-internal.yml
+++ b/.github/workflows/mobile-android-internal.yml
@@ -113,7 +113,7 @@ jobs:
           ORG_GRADLE_PROJECT_releaseStorePassword: ${{ secrets.ANDROID_UPLOAD_STORE_PASSWORD }}
           ORG_GRADLE_PROJECT_releaseKeyAlias: ${{ secrets.ANDROID_UPLOAD_KEY_ALIAS }}
           ORG_GRADLE_PROJECT_releaseKeyPassword: ${{ secrets.ANDROID_UPLOAD_KEY_PASSWORD }}
-        run: ./gradlew :app:assembleRelease :app:bundleRelease
+        run: ./gradlew :app:assembleRelease :app:bundleRelease --max-workers=2
       - name: Verify signed artifacts and versions
         run: |
           apk="apps/mobile/android/app/build/outputs/apk/release/app-release.apk"

--- a/apps/mobile/android/gradle.properties
+++ b/apps/mobile/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
+org.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
## Summary

- raise the Gradle release-build heap from 2 GiB to 3 GiB
- retain the 1 GiB metaspace ceiling that fixed native-module lint exhaustion
- cap the GitHub Actions release build at two Gradle workers to reduce concurrent memory pressure
- keep the direct signed APK/AAB workflow entirely independent of EAS Build

## Evidence

- run 33278936219 completed the signed APK/AAB build after the metaspace fix
- run 33280154917 later failed in `:app:mergeReleaseResources` with `Java heap space`, showing a separate heap peak
- limiting workers plus a 3 GiB heap fits the standard runner while leaving headroom for Node, native tooling, and the OS
- workflow YAML parses and `git diff --check` passes