### PR TITLE
docs: publish Android 0.1.22 build 49 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <p align="center">
   <a href="https://play.google.com/apps/testing/com.trymuxr.app">Google Play testing</a> ·
   <a href="https://testflight.apple.com/join/aJSbs8pN">iOS TestFlight</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.12-build47.apk">Direct APK: 0.1.12 (build 47)</a> ·
+  <a href="https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.22-build49.apk">Direct APK: 0.1.22 (build 49)</a> ·
   <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.22">Release 0.1.22</a>
 </p>
 
@@ -133,7 +133,7 @@ muxr
 
 Then install the mobile companion:
 
-- **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the signed APK (0.1.12 build 47)](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.12-build47.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/SHA256SUMS)
+- **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the signed APK (0.1.22 build 49)](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.22-build49.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/SHA256SUMS)
 - **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
 - **All builds:** [muxr 0.1.22 release](https://github.com/umeranjum17/muxr/releases/tag/v0.1.22)


### PR DESCRIPTION
## Summary

- Update the README header download to the signed Android 0.1.22 build 49 APK.
- Update the mobile install section and checksum link for the same release asset.
- Keep Google Play testing and iOS TestFlight visible alongside the direct APK.

## Release proof

- Built directly with Gradle in GitHub Actions; no EAS build or submission was used.
- Release workflow: https://github.com/umeranjum17/muxr/actions/runs/33281359538
- Source commit: `75cba10d2a7576c08735c45b5ef0e20bac9d5753`
- Manifest: version `0.1.22`, version code `49`.
- Native ABI: `arm64-v8a` only.
- Signing certificate SHA-256: `9c33841142483611257fcdf772f5e8fc30d6fac803f6da28e7eacfcaec12b08d`.
- APK SHA-256: `e6afb5121fa6eaf8f544d06607c04b0fa7bf32f3cf3b2c5c3f5627c14cfbbc9e`.
- The release includes the merged QR-scanner pairing fix from #173.
- Play Internal upload was intentionally skipped.

## Verification

- GitHub Actions build and artifact verification passed.
- The public release URL returns HTTP 200 with the expected 174,870,067-byte asset.
- The published `SHA256SUMS` entry matches the uploaded APK.