### PR TITLE
ci(android): publish verified APK releases

### DIFF
--- a/.github/workflows/mobile-android-internal.yml
+++ b/.github/workflows/mobile-android-internal.yml
@@ -16,13 +16,18 @@ on:
         required: true
         default: false
         type: boolean
+      publish_github_release:
+        description: Publish the APK to the matching GitHub Release
+        required: true
+        default: true
+        type: boolean
       confirmation:
         description: Type release-VERSION-VERSION_CODE
         required: true
         type: string
 
 concurrency:
-  group: mobile-android-internal-${{ inputs.version }}-${{ inputs.version_code }}
+  group: mobile-android-internal-${{ inputs.version }}
   cancel-in-progress: true
 
 permissions:
@@ -156,14 +161,16 @@ jobs:
           mkdir -p "$output"
           install -m 600 apps/mobile/android/app/build/outputs/apk/release/app-release.apk "$output/muxr-$APP_VERSION-$ANDROID_VERSION_CODE.apk"
           install -m 600 apps/mobile/android/app/build/outputs/bundle/release/app-release.aab "$output/muxr-$APP_VERSION-$ANDROID_VERSION_CODE.aab"
+          apk_sha="$(sha256sum "$output/muxr-$APP_VERSION-$ANDROID_VERSION_CODE.apk" | cut -d ' ' -f 1)"
           aab_sha="$(sha256sum "$output/muxr-$APP_VERSION-$ANDROID_VERSION_CODE.aab" | cut -d ' ' -f 1)"
           jq -n \
             --arg gitCommitHash "$GITHUB_SHA" \
             --arg appVersion "$APP_VERSION" \
             --arg appBuildVersion "$ANDROID_VERSION_CODE" \
             --argjson submittedToInternal "$SUBMIT_TO_PLAY" \
+            --arg apkArtifactSha256 "$apk_sha" \
             --arg artifactSha256 "$aab_sha" \
-            '{platform:"ANDROID", $gitCommitHash, $appVersion, $appBuildVersion, bundleIdentifier:"com.trymuxr.app", $submittedToInternal, $artifactSha256}' \
+            '{platform:"ANDROID", $gitCommitHash, $appVersion, $appBuildVersion, bundleIdentifier:"com.trymuxr.app", $submittedToInternal, $apkArtifactSha256, $artifactSha256}' \
             > "$output/result.json"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -171,3 +178,50 @@ jobs:
           path: ${{ runner.temp }}/android-internal
           retention-days: 7
           if-no-files-found: error
+
+  publish:
+    if: github.ref == 'refs/heads/main' && inputs.publish_github_release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    env:
+      APP_VERSION: ${{ inputs.version }}
+      ANDROID_VERSION_CODE: ${{ inputs.version_code }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: android-internal
+          path: ${{ runner.temp }}/android-internal
+      - name: Verify and publish APK
+        run: |
+          artifact="$RUNNER_TEMP/android-internal"
+          apk="$artifact/muxr-$APP_VERSION-$ANDROID_VERSION_CODE.apk"
+          result="$artifact/result.json"
+          test -f "$apk"
+          test -f "$result"
+          test "$(find "$artifact" -type f -name '*.apk' | wc -l)" -eq 1
+          jq -e \
+            --arg gitCommitHash "$GITHUB_SHA" \
+            --arg appVersion "$APP_VERSION" \
+            --arg appBuildVersion "$ANDROID_VERSION_CODE" \
+            '.platform == "ANDROID" and .gitCommitHash == $gitCommitHash and .appVersion == $appVersion and .appBuildVersion == $appBuildVersion and .bundleIdentifier == "com.trymuxr.app" and (.apkArtifactSha256 | test("^[0-9a-f]{64}$"))' \
+            "$result" >/dev/null
+          test "$(sha256sum "$apk" | cut -d ' ' -f 1)" = "$(jq -r .apkArtifactSha256 "$result")"
+
+          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          test "$tag" = "v$APP_VERSION"
+
+          publish="$RUNNER_TEMP/github-release"
+          mkdir -p "$publish"
+          install -m 644 "$apk" "$publish/muxr-android-$APP_VERSION-build$ANDROID_VERSION_CODE.apk"
+          install -m 644 "$apk" "$publish/muxr-android.apk"
+          (cd "$publish" && sha256sum muxr-android-$APP_VERSION-build$ANDROID_VERSION_CODE.apk muxr-android.apk > SHA256SUMS)
+          gh release upload "$tag" "$publish/muxr-android-$APP_VERSION-build$ANDROID_VERSION_CODE.apk" "$publish/muxr-android.apk" "$publish/SHA256SUMS" --clobber --repo "$GITHUB_REPOSITORY"
+
+          downloaded="$RUNNER_TEMP/published-release"
+          mkdir -p "$downloaded"
+          gh release download "$tag" --pattern "muxr-android-$APP_VERSION-build$ANDROID_VERSION_CODE.apk" --pattern muxr-android.apk --pattern SHA256SUMS --dir "$downloaded" --repo "$GITHUB_REPOSITORY"
+          (cd "$downloaded" && sha256sum --check SHA256SUMS)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <p align="center">
   <a href="https://play.google.com/apps/testing/com.trymuxr.app">Google Play testing</a> ·
   <a href="https://testflight.apple.com/join/aJSbs8pN">iOS TestFlight</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.22-build49.apk">Direct APK: 0.1.22 (build 49)</a> ·
+  <a href="https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk">Direct APK: latest signed build</a> ·
   <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.22">Release 0.1.22</a>
 </p>
 
@@ -133,7 +133,7 @@ muxr
 
 Then install the mobile companion:
 
-- **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the signed APK (0.1.22 build 49)](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/muxr-android-0.1.22-build49.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/download/v0.1.22/SHA256SUMS)
+- **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the latest signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS)
 - **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
 - **All builds:** [muxr 0.1.22 release](https://github.com/umeranjum17/muxr/releases/tag/v0.1.22)


### PR DESCRIPTION
## Summary

- publish each successful, verified Android release-candidate APK to the matching GitHub Release by default
- provide both an immutable versioned APK and a stable `muxr-android.apk` download, with `SHA256SUMS`
- validate commit, version, build code, package id, and APK digest from build provenance before publication
- fail closed when the requested version does not match the latest GitHub Release
- prevent same-version build races so an older build cannot replace the stable APK
- keep AAB artifacts private and Play Internal submission separately opt-in
- isolate publication from the `stores` environment and all signing/Play secrets
- point README installs at stable `releases/latest` APK and checksum URLs

## Safety

- direct Gradle pipeline only; no EAS invocation
- publication runs only after the main-branch build and artifact verification succeed
- `contents: write` is scoped to the publication job; repository defaults remain read-only
- no mobile-store submission is enabled by this change

## Validation

- workflow YAML parsed successfully
- secret policy scan passed across 2,873 tracked/package files
- workflow security and race-condition review passed
- `git diff --check` passed