### PR TITLE
fix: journal socket, attach, and agent-not-ready misses

### DIFF
--- a/apps/host/src/agent/application/openTerminal.ts
+++ b/apps/host/src/agent/application/openTerminal.ts
@@ -10,7 +10,7 @@ export type OpenTerminalCommand = {
 
 export type OpenTerminalResult =
     | { ok: true; data: { paneId: string } }
-    | { ok: false; error: string };
+    | { ok: false; error: string; code?: string };
 
 export interface TerminalPort {
     attach(command: OpenTerminalCommand): Promise<{ paneId: string }>;
@@ -18,8 +18,17 @@ export interface TerminalPort {
 }
 
 export async function openTerminal(port: TerminalPort | undefined, command: OpenTerminalCommand): Promise<OpenTerminalResult> {
-    if (port === undefined) return { ok: false, error: 'terminal: not available on this host' };
-    return { ok: true, data: await port.attach(command) };
+    if (port === undefined) return { ok: false, error: 'terminal: not available on this host', code: 'unavailable' };
+    try {
+        return { ok: true, data: await port.attach(command) };
+    } catch (error) {
+        const code = (error as { code?: unknown }).code;
+        return {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+            ...(typeof code === 'string' ? { code } : {}),
+        };
+    }
 }
 
 export type CloseTerminalCommand = { channel: string; deviceId?: string };

--- a/apps/host/src/agent/application/promptAgent.ts
+++ b/apps/host/src/agent/application/promptAgent.ts
@@ -2,12 +2,21 @@ import type { SessionPromptOptions, SessionSource } from './sessionSource.js';
 
 export type PromptAgentCommand = SessionPromptOptions;
 
-export type PromptAgentResult = { ok: true; data: null } | { ok: false; error: string };
+export type PromptAgentResult = { ok: true; data: null } | { ok: false; error: string; code?: string };
 
 export async function promptAgent(
     sessions: Pick<SessionSource, 'prompt'>,
     command: PromptAgentCommand,
 ): Promise<PromptAgentResult> {
-    await sessions.prompt(command);
-    return { ok: true, data: null };
+    try {
+        await sessions.prompt(command);
+        return { ok: true, data: null };
+    } catch (error) {
+        const code = (error as { code?: unknown }).code;
+        return {
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+            ...(typeof code === 'string' ? { code } : {}),
+        };
+    }
 }

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -170,7 +170,11 @@ export interface CreateHerdrSessionSourceOptions {
     /** Writes bounded semantic prompt outcomes to the owner-only host diagnostics journal. */
     onRealtimePromptDiagnostic?: (event: RealtimePromptDiagnostic) => void;
     /** Privacy-safe route-generation and readiness outcomes only. */
-    onAgentReadinessDiagnostic?: (reason: 'starting' | 'ready' | 'not-promptable', promptable: boolean) => void;
+    onAgentReadinessDiagnostic?: (
+        reason: 'starting' | 'ready' | 'not-promptable',
+        promptable: boolean,
+        detail?: { kind?: string; lifecycle?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' },
+    ) => void;
 }
 
 export interface AgentRecord {
@@ -550,7 +554,7 @@ export async function createHerdrSessionSource(
     const statusWatches = new Map<string, () => void>();
 
     /** Stamp a freshly spawned pane with who asked for it. Best effort. */
-    const lastPromptableBySession = new Map<string, boolean>();
+    const lastReadinessBySession = new Map<string, string>();
     async function tagSpawn(paneId: string, parentSessionId: string): Promise<void> {
         await client
             .call('pane.report_metadata', {
@@ -653,13 +657,32 @@ export async function createHerdrSessionSource(
     }
 
     function agentPromptable(session: CurrentSession | undefined): boolean {
-        if (session?.agent === undefined) return false;
+        return readinessGate(session) === 'ready';
+    }
+
+    function readinessGate(session: CurrentSession | undefined): 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' {
+        if (session?.agent === undefined) return 'no-agent';
+        const lifecycle = lifecycleOf(session);
+        if (lifecycle === 'starting') return 'starting';
         const ref = agentSession(session.agent);
         const bound = routes.get(session.sessionId);
-        return ref !== undefined
-            && bound !== undefined
-            && herdrAgentSessionKey(ref) === herdrAgentSessionKey(bound)
-            && herdrAgentIsPromptable(session.agent, lifecycleOf(session));
+        if (ref === undefined || bound === undefined || herdrAgentSessionKey(ref) !== herdrAgentSessionKey(bound)) {
+            return 'unbound';
+        }
+        return herdrAgentIsPromptable(session.agent, lifecycle) ? 'ready' : 'not-interactive';
+    }
+
+    function readinessDetail(session: CurrentSession): {
+        kind?: string;
+        lifecycle: ReturnType<typeof lifecycleOf>;
+        gate: ReturnType<typeof readinessGate>;
+    } {
+        const kind = publicAgentKind(session.agent?.agent ?? undefined);
+        return {
+            ...(kind === undefined ? {} : { kind }),
+            lifecycle: lifecycleOf(session),
+            gate: readinessGate(session),
+        };
     }
 
     /** Herdr boundary adapter: Task Title comes only from current AgentInfo.title. */
@@ -898,7 +921,7 @@ export async function createHerdrSessionSource(
         clearAttention(sessionId);
         lastStateSignature.delete(sessionId);
         lastInfoSignature.delete(sessionId);
-        lastPromptableBySession.delete(sessionId);
+        lastReadinessBySession.delete(sessionId);
         publish(sessionId, { type: 'session.removed' });
     }
 
@@ -908,9 +931,15 @@ export async function createHerdrSessionSource(
         const agentStatus = lifecycleOf(session);
         if (session.agent !== undefined) {
             const promptable = agentPromptable(session);
-            if (lastPromptableBySession.get(sessionId) !== promptable) {
-                lastPromptableBySession.set(sessionId, promptable);
-                options.onAgentReadinessDiagnostic?.(promptable ? 'ready' : 'starting', promptable);
+            const detail = readinessDetail(session);
+            const signature = `${detail.gate}|${detail.kind ?? ''}|${detail.lifecycle}|${String(promptable)}`;
+            if (lastReadinessBySession.get(sessionId) !== signature) {
+                lastReadinessBySession.set(sessionId, signature);
+                options.onAgentReadinessDiagnostic?.(
+                    promptable ? 'ready' : agentStatus === 'starting' ? 'starting' : 'not-promptable',
+                    promptable,
+                    detail,
+                );
             }
         }
         const stateSignature = `${agentStatus}|${String(agentPromptable(session))}`;
@@ -1389,7 +1418,7 @@ export async function createHerdrSessionSource(
     async function promptSession(sessionId: string, text: string): Promise<void> {
         const session = await resolvePane(sessionId);
         const promptable = agentPromptable(session);
-        if (!promptable) options.onAgentReadinessDiagnostic?.('not-promptable', false);
+        if (!promptable) options.onAgentReadinessDiagnostic?.('not-promptable', false, readinessDetail(session));
         await promptPromptableHerdrAgent(client, session, promptable, text);
     }
 

--- a/apps/host/src/agent/infrastructure/terminalManager.ts
+++ b/apps/host/src/agent/infrastructure/terminalManager.ts
@@ -54,7 +54,7 @@ export class TerminalManager {
         takeover?: boolean;
     }): Promise<{ paneId: string }> {
         if (this.hosted !== undefined && (params.deviceId === undefined || this.options.hostedE2ee?.ingressKeys[params.deviceId] === undefined)) {
-            throw new Error('terminal: hosted attach requires an active device grant');
+            throw Object.assign(new Error('terminal: hosted attach requires an active device grant'), { code: 'e2ee-required' });
         }
         const paneId = await this.options.resolvePane(params.sessionId);
         if ((params.mode ?? 'control') !== 'control') return this.attachNow(params, paneId);
@@ -89,7 +89,7 @@ export class TerminalManager {
                 attachment.mode === 'control' && attachment.paneId === paneId,
             );
             if (controller !== undefined && controller.deviceId !== params.deviceId && params.takeover !== true) {
-                throw new Error('terminal: pane is controlled by another device; explicit takeover required');
+                throw Object.assign(new Error('terminal: pane is controlled by another device; explicit takeover required'), { code: 'takeover' });
             }
         }
 
@@ -116,7 +116,7 @@ export class TerminalManager {
         await new Promise<void>((resolve, reject) => {
             const timer = setTimeout(() => {
                 socket.close();
-                reject(new Error('terminal: relay did not accept the channel'));
+                reject(Object.assign(new Error('terminal: relay did not accept the channel'), { code: 'socket-timeout' }));
             }, ATTACH_TIMEOUT_MS);
             socket.once('open', () => {
                 clearTimeout(timer);
@@ -161,7 +161,7 @@ export class TerminalManager {
                 cleanup();
                 socket.close();
                 process.stderr.write(`terminal: could not start ${herdr}: ${error.message}\n`);
-                reject(new Error(`terminal: could not start Herdr: ${error.message}`));
+                reject(Object.assign(new Error(`terminal: could not start Herdr: ${error.message}`), { code: 'unavailable' }));
             };
             child.once('spawn', onSpawn);
             child.once('error', onError);

--- a/apps/host/src/diagnostics/infrastructure/journal.ts
+++ b/apps/host/src/diagnostics/infrastructure/journal.ts
@@ -15,6 +15,7 @@ export type DiagnosticBrokerOperation = 'list' | 'read' | 'status' | 'watch' | '
 export type DiagnosticPeerConnectionPhase = 'grant-refresh' | 'ticket-issue' | 'socket-open' | 'liveness-proof';
 export type DiagnosticPeerIngressOutcome = 'received' | 'decrypt-rejected' | 'decoded';
 export type DiagnosticRealtimePromptOutcome = 'queued' | 'rejected' | 'failed';
+export type DiagnosticReadinessGate = 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent';
 
 
 type ClientCounts = Record<DiagnosticClientKind, number>;
@@ -30,7 +31,7 @@ export type HostDiagnosticEvent =
     | { at: string; event: 'peer.ingress'; direction: 'inbound'; outcome: DiagnosticPeerIngressOutcome }
     | { at: string; event: 'peer.broker'; operation: DiagnosticBrokerOperation; outcome: DiagnosticOutcome; durationMs: number; code?: string }
     | { at: string; event: 'realtime.prompt'; provider: string; action: 'prompt'; requestedAgentName: string; resolvedAgentName: string | null; outcome: DiagnosticRealtimePromptOutcome }
-    | { at: string; event: 'agent.readiness'; reason: 'starting' | 'ready' | 'not-promptable'; promptable: boolean };
+    | { at: string; event: 'agent.readiness'; reason: 'starting' | 'ready' | 'not-promptable'; promptable: boolean; kind?: string; lifecycle?: string; gate?: DiagnosticReadinessGate };
 
 interface HostDiagnosticState {
     version: 1;
@@ -57,6 +58,8 @@ const safeCodes = new Set([
     'ticket-required', 'ticket-invalid', 'local-identity-invalid',
     'device-revoked', 'ticket-scope-mismatch', 'preview-bridge-required',
     'agent-not-ready', 'timeout', 'unavailable',
+    'not-connected', 'connection-lost', 'client-closed', 'request-timeout',
+    'dead-socket', 'stale', 'disconnected', 'takeover',
 ]);
 const loggedRequests = new Set<RequestType>([
     'machines.list', 'herdr.tree', 'terminal.attach', 'terminal.detach',
@@ -64,6 +67,28 @@ const loggedRequests = new Set<RequestType>([
     'peer.prepare', 'peer.authorize', 'peer.install', 'peer.list', 'peer.revoke',
     'peer.remote.list', 'peer.remote.read', 'peer.remote.status', 'peer.remote.watch', 'peer.remote.prompt', 'peer.remote.start',
 ]);
+
+function safeAgentKind(value: string | undefined): string | undefined {
+    if (value === undefined) return undefined;
+    const kind = value.normalize('NFKC').trim().toLowerCase();
+    if (kind === 'shell' || !/^[a-z][a-z0-9._-]{0,31}$/.test(kind)) return undefined;
+    return kind;
+}
+
+function safeLifecycle(value: string | undefined): string | undefined {
+    if (value === 'idle' || value === 'working' || value === 'blocked' || value === 'done'
+        || value === 'failed' || value === 'starting' || value === 'unknown') {
+        return value;
+    }
+    return undefined;
+}
+
+function safeReadinessGate(value: string | undefined): DiagnosticReadinessGate | undefined {
+    if (value === 'ready' || value === 'starting' || value === 'not-interactive' || value === 'unbound' || value === 'no-agent') {
+        return value;
+    }
+    return undefined;
+}
 
 function safeCode(value: string | undefined): string | undefined {
     if (value === undefined) return undefined;
@@ -200,8 +225,23 @@ export class HostDiagnosticsJournal {
         });
     }
 
-    agentReadiness(reason: 'starting' | 'ready' | 'not-promptable', promptable: boolean): void {
-        this.record({ at: this.timestamp(), event: 'agent.readiness', reason, promptable });
+    agentReadiness(
+        reason: 'starting' | 'ready' | 'not-promptable',
+        promptable: boolean,
+        detail?: { kind?: string; lifecycle?: string; gate?: DiagnosticReadinessGate },
+    ): void {
+        const kind = safeAgentKind(detail?.kind);
+        const lifecycle = safeLifecycle(detail?.lifecycle);
+        const gate = safeReadinessGate(detail?.gate);
+        this.record({
+            at: this.timestamp(),
+            event: 'agent.readiness',
+            reason,
+            promptable,
+            ...(kind === undefined ? {} : { kind }),
+            ...(lifecycle === undefined ? {} : { lifecycle }),
+            ...(gate === undefined ? {} : { gate }),
+        });
     }
 
     relationships(peers: Array<{ state: keyof RelationshipCounts }>): void {

--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -602,8 +602,8 @@ async function main(): Promise<void> {
                     event.resolvedAgentName,
                     event.outcome,
                 ),
-                onAgentReadinessDiagnostic: (reason, promptable) =>
-                    diagnostics.agentReadiness(reason, promptable),
+                onAgentReadinessDiagnostic: (reason, promptable, detail) =>
+                    diagnostics.agentReadiness(reason, promptable, detail),
             }),
         });
     }
@@ -612,7 +612,9 @@ async function main(): Promise<void> {
         machineId,
         resolvePane: async (sessionId) => {
             const snapshot = await source.open({ sessionId, acknowledgeAttention: false });
-            if (snapshot.info.paneId === undefined) throw new Error('That session has no current Herdr pane.');
+            if (snapshot.info.paneId === undefined) {
+                throw Object.assign(new Error('That session has no current Herdr pane.'), { code: 'unavailable' });
+            }
             return snapshot.info.paneId;
         },
         ...(token === undefined ? {} : { token }),

--- a/apps/host/src/peer/application/peerFlow.test.ts
+++ b/apps/host/src/peer/application/peerFlow.test.ts
@@ -571,7 +571,10 @@ describe('host peer collaboration flow', () => {
         diagnostics.request('peer.prepare', 'native', 'rejected', 1, 'peer-recovery-pending');
         diagnostics.agentReadiness('starting', false);
         diagnostics.agentReadiness('ready', true);
-        diagnostics.agentReadiness('not-promptable', false);
+        diagnostics.agentReadiness('not-promptable', false, { kind: 'omp', lifecycle: 'idle', gate: 'not-interactive' });
+        diagnostics.agentReadiness('not-promptable', false, { kind: 'w1EW:pH', lifecycle: 'idle', gate: 'unbound' });
+        diagnostics.request('session.prompt', 'native', 'rejected', 8, 'agent-not-ready');
+        diagnostics.request('terminal.attach', 'native', 'rejected', 11, 'socket-timeout');
         for (let index = 0; index < 600; index += 1) diagnostics.request('herdr.tree', 'native', 'ok', 1);
         await broker.close();
         await diagnostics.flush();
@@ -585,11 +588,16 @@ describe('host peer collaboration flow', () => {
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'peer.broker', operation: 'prompt', code: 'agent-not-ready' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'peer.connection', phase: 'liveness-proof', outcome: 'timeout' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'peer.prepare', code: 'peer-recovery-pending' }));
+        expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'session.prompt', outcome: 'rejected', code: 'agent-not-ready' }));
         expect(diagnosticEvents).toEqual(expect.arrayContaining([
             expect.objectContaining({ event: 'agent.readiness', reason: 'starting', promptable: false }),
             expect.objectContaining({ event: 'agent.readiness', reason: 'ready', promptable: true }),
             expect.objectContaining({ event: 'agent.readiness', reason: 'not-promptable', promptable: false }),
+            expect.objectContaining({ event: 'agent.readiness', reason: 'not-promptable', kind: 'omp', lifecycle: 'idle', gate: 'not-interactive' }),
         ]));
+        expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'terminal.attach', outcome: 'rejected', code: 'socket-timeout' }));
+        expect(diagnosticEvents).not.toContainEqual(expect.objectContaining({ kind: 'w1EW:pH' }));
+        expect(diagnosticEvents).not.toContainEqual(expect.objectContaining({ kind: 'w1ew:ph' }));
         expect(diagnosticEvents).not.toContainEqual(expect.objectContaining({ event: 'client.request', request: 'herdr.tree', outcome: 'ok' }));
         expect(diagnosticOutput).not.toMatch(/target-machine|muxr-session|internal-pane-path|Report Xcode status|machineId|sessionId|relationshipId|operationId/);
         let diagnosticNow = Date.parse('2026-08-26T00:00:00.000Z');

--- a/apps/mobile/sources/account/application/accountSession.integration.spec.ts
+++ b/apps/mobile/sources/account/application/accountSession.integration.spec.ts
@@ -67,6 +67,7 @@ vi.mock('@/pairing/infrastructure/muxrClient', () => ({
             });
         }
         close() { harness.clientCloses += 1; this.state = 'closed'; }
+        isLive() { return this.state === 'open'; }
         onStateChange(listener: (state: string) => void) { this.listeners.push(listener); return () => undefined; }
         onEvent() { return () => undefined; }
         async request(type: string) {

--- a/apps/mobile/sources/catalog/application/sync.ts
+++ b/apps/mobile/sources/catalog/application/sync.ts
@@ -20,6 +20,7 @@ import {
 } from '@muxr/contract';
 import { decodeBase64, encodeBase64 } from '@/encryption/base64';
 import type { AttachmentPreview } from '../infrastructure/attachmentTypes';
+import { recordSocketReconnect, recordSocketState, recordTrackedRpc } from '../infrastructure/connectionDiagnostics';
 import { Modal } from '@/modal';
 import { Encryption } from '../infrastructure/encryption/encryption';
 import type { DecryptedArtifact } from '../infrastructure/artifactTypes';
@@ -76,15 +77,27 @@ function socketStatusFromClient(state: string): 'connected' | 'connecting' | 'er
 }
 
 function waitUntilClientOpen(client: MuxrClient, timeoutMs: number): Promise<void> {
-    if (client.state === 'open') return Promise.resolve();
-    return new Promise<void>((resolve) => {
-        const timeout = setTimeout(resolve, timeoutMs);
-        const off = client.onStateChange((state) => {
-            if (state === 'open') {
-                clearTimeout(timeout);
-                off();
-                resolve();
-            }
+    if (client.isLive()) return Promise.resolve();
+    // Header can stay `open` after the socket dies without onclose. A new
+    // connect() is what unblocks herdr.tree / terminal.attach.
+    if (client.state === 'open' || client.state === 'stale' || client.state === 'closed') {
+        recordSocketReconnect(client.state, client.isLive());
+        client.connect();
+    }
+    return new Promise<void>((resolve, reject) => {
+        if (client.isLive()) {
+            resolve();
+            return;
+        }
+        const timeout = setTimeout(() => {
+            off();
+            reject(new Error('not connected'));
+        }, timeoutMs);
+        const off = client.onStateChange(() => {
+            if (!client.isLive()) return;
+            clearTimeout(timeout);
+            off();
+            resolve();
         });
     });
 }
@@ -274,6 +287,7 @@ class MuxrSync {
         });
         client.onPluginsInvalidated?.((frame) => reconcilePluginCaches(frame));
         client.onStateChange((state) => {
+            recordSocketState(state, client.isLive());
             storage.getState().setSocketStatus(socketStatusFromClient(state));
             // Events emitted while the socket was down are gone: nothing replays them.
             // Re-open from the host snapshot instead of leaving a stale transcript
@@ -481,7 +495,7 @@ class MuxrSync {
             await this.refreshAccountSession();
             return { workspaces: [], herdrConnected: undefined };
         }
-        const tree = await this.ensureClient().request('herdr.tree', {});
+        const tree = await this.request('herdr.tree', {});
         // Requests can cross when a done frame and a newer working frame arrive
         // close together. Only the latest canonical read may update the UI.
         if (request === this.herdrTreeRequest) storage.getState().applyHerdrTree(tree.workspaces);
@@ -502,7 +516,7 @@ class MuxrSync {
             return;
         }
         const client = this.ensureClient();
-        if (client.state !== 'open') await waitUntilClientOpen(client, 5000);
+        if (!client.isLive()) await waitUntilClientOpen(client, 5000);
         const [machines, sessions, attention, lifecycle, tree] = await Promise.all([
             client.request('machines.list', {}),
             client.request('session.list', {}),
@@ -645,9 +659,10 @@ class MuxrSync {
         const previews = options?.attachments ?? [];
         if (text.trim().length === 0 && previews.length === 0) return;
         if (storage.getState().sessions[sessionId]?.metadata?.promptable !== true) {
-            throw new Error('Agent is not ready yet');
+            const error = Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' });
+            recordTrackedRpc('session.prompt', { ok: false, error }, 0);
+            throw error;
         }
-        const client = this.ensureClient();
         // No optimistic echo: the host emits message.append for the prompt, so the
         // transcript fold owns ordering and there is nothing to reconcile.
         // Steer, don't follow up: a message typed mid-turn is a correction, so it
@@ -658,7 +673,7 @@ class MuxrSync {
             {
                 markSent: (agentRoute) => storage.getState().updateSession(agentRoute, { lastMessageSentAt: Date.now() }),
                 attachments: () => toPromptAttachments(previews),
-                deliver: ({ agentRoute, text: prompt, streamingBehavior, attachments }) => client.request('session.prompt', {
+                deliver: ({ agentRoute, text: prompt, streamingBehavior, attachments }) => this.request('session.prompt', {
                     sessionId: agentRoute,
                     text: prompt,
                     streamingBehavior,
@@ -710,22 +725,29 @@ class MuxrSync {
         params: import('@muxr/contract').RequestParams<T>,
         timeoutMs?: number,
     ): Promise<import('@muxr/contract').RequestResult<T>> {
-        const client = this.ensureClient();
-        if (client.state !== 'open') {
-            // Cold starts (deep links, app relaunch straight into a session)
-            // raced the socket: requests fired while it was still connecting
-            // and failed with 'not connected'. Wait it out; the request's own
-            // timeout still bounds a relay that never comes up.
-            await waitUntilClientOpen(client, 10_000);
+        const started = Date.now();
+        try {
+            const client = this.ensureClient();
+            if (!client.isLive()) {
+                // Cold starts and a header that still says connected while the
+                // socket is dead both used to throw 'not connected' immediately.
+                await waitUntilClientOpen(client, 10_000);
+            }
+            const request = () => client.request(type, params, timeoutMs);
+            const data = type === 'plugin.call' || type === 'plugin.invoke'
+                ? await pluginExecutionGate.run(
+                    (params as import('@muxr/contract').RequestParams<'plugin.call'> | import('@muxr/contract').RequestParams<'plugin.invoke'>).pluginId,
+                    request,
+                ) as import('@muxr/contract').RequestResult<T>
+                : type === 'pane.read'
+                    ? await paneReadGate.run(request)
+                    : await request();
+            recordTrackedRpc(type, { ok: true }, Date.now() - started);
+            return data;
+        } catch (error) {
+            recordTrackedRpc(type, { ok: false, error }, Date.now() - started);
+            throw error;
         }
-        const request = () => client.request(type, params, timeoutMs);
-        if (type === 'plugin.call' || type === 'plugin.invoke') {
-            const pluginId = (params as import('@muxr/contract').RequestParams<'plugin.call'> | import('@muxr/contract').RequestParams<'plugin.invoke'>).pluginId;
-            return pluginExecutionGate.run(pluginId, request) as Promise<import('@muxr/contract').RequestResult<T>>;
-        }
-        return type === 'pane.read'
-            ? paneReadGate.run(request)
-            : request();
     }
 
     /**

--- a/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
+++ b/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
@@ -96,9 +96,11 @@ export function connectionDiagnosticOutcome(error: unknown): ConnectionDiagnosti
     return 'rejected';
 }
 
-export function recordConnectionDiagnostic(
-    event: Omit<ConnectionDiagnosticEvent, 'at'> & { at?: string },
-): void {
+type ConnectionDiagnosticDraft = ConnectionDiagnosticEvent extends infer Event
+    ? Event extends { at: string } ? Omit<Event, 'at'> & { at?: string } : never
+    : never;
+
+export function recordConnectionDiagnostic(event: ConnectionDiagnosticDraft): void {
     const entry = { at: event.at ?? new Date().toISOString(), ...event } as ConnectionDiagnosticEvent;
     if (!isValidEvent(entry)) return;
     events = [...events, entry].slice(-MAX_EVENTS);

--- a/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
+++ b/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
@@ -1,0 +1,298 @@
+/**
+ * Phone-side transport and terminal-channel trail.
+ *
+ * Host `diagnostics.json` only sees frames that crossed the relay. The header
+ * can say connected while `herdr.tree` / `terminal.attach` never leave the
+ * device; those misses live here. Codes only — no machine, session, channel,
+ * ticket, or error text.
+ */
+
+export type ConnectionDiagnosticRequest = 'herdr.tree' | 'terminal.attach' | 'terminal.detach' | 'session.prompt';
+export type ConnectionDiagnosticOutcome = 'ok' | 'rejected' | 'timeout' | 'unavailable';
+export type ConnectionDiagnosticCode =
+    | 'not-connected'
+    | 'connection-lost'
+    | 'client-closed'
+    | 'request-timeout'
+    | 'ticket-required'
+    | 'grant-expired'
+    | 'e2ee-required'
+    | 'agent-not-ready'
+    | 'dead-socket'
+    | 'stale'
+    | 'takeover'
+    | 'disconnected'
+    | 'unavailable';
+export type ConnectionDiagnosticSocketState = 'connecting' | 'open' | 'stale' | 'closed';
+export type ConnectionDiagnosticReconnectReason = 'dead-socket' | 'stale' | 'closed';
+export type ConnectionDiagnosticChannelPhase = 'attach' | 'socket-open' | 'live' | 'reconnecting' | 'disconnected';
+export type ConnectionDiagnosticGate = 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'missing';
+export type ConnectionDiagnosticLifecycle = 'idle' | 'working' | 'blocked' | 'done' | 'failed' | 'starting' | 'unknown';
+
+export type ConnectionDiagnosticEvent =
+    | { at: string; event: 'socket.state'; state: ConnectionDiagnosticSocketState; live: boolean }
+    | { at: string; event: 'socket.reconnect'; reason: ConnectionDiagnosticReconnectReason }
+    | { at: string; event: 'rpc'; request: ConnectionDiagnosticRequest; outcome: ConnectionDiagnosticOutcome; durationMs: number; code?: ConnectionDiagnosticCode }
+    | { at: string; event: 'terminal.channel'; phase: ConnectionDiagnosticChannelPhase; outcome: ConnectionDiagnosticOutcome; code?: ConnectionDiagnosticCode }
+    | { at: string; event: 'agent.gate'; kind?: string; lifecycle: ConnectionDiagnosticLifecycle; promptable: boolean; gate: ConnectionDiagnosticGate };
+
+const MAX_EVENTS = 64;
+const STORAGE_KEY = 'connection-diagnostics-v1';
+const TRACKED = new Set<string>(['herdr.tree', 'terminal.attach', 'terminal.detach', 'session.prompt']);
+const SOCKET_STATES = new Set<string>(['connecting', 'open', 'stale', 'closed']);
+const RECONNECT_REASONS = new Set<string>(['dead-socket', 'stale', 'closed']);
+const CHANNEL_PHASES = new Set<string>(['attach', 'socket-open', 'live', 'reconnecting', 'disconnected']);
+const GATES = new Set<string>(['ready', 'starting', 'not-interactive', 'unbound', 'missing']);
+const LIFECYCLES = new Set<string>(['idle', 'working', 'blocked', 'done', 'failed', 'starting', 'unknown']);
+const OUTCOMES = new Set<string>(['ok', 'rejected', 'timeout', 'unavailable']);
+const CODES = new Set<string>([
+    'not-connected', 'connection-lost', 'client-closed', 'request-timeout',
+    'ticket-required', 'grant-expired', 'e2ee-required', 'agent-not-ready',
+    'dead-socket', 'stale', 'takeover', 'disconnected', 'unavailable',
+]);
+
+let events: ConnectionDiagnosticEvent[] = loadPersisted();
+
+export function resetConnectionDiagnostics(): void {
+    events = [];
+    persist(events);
+}
+
+export function readConnectionDiagnostics(): readonly ConnectionDiagnosticEvent[] {
+    return events;
+}
+
+export function isTrackedConnectionRequest(type: string): type is ConnectionDiagnosticRequest {
+    return TRACKED.has(type);
+}
+
+export function connectionDiagnosticCode(error: unknown): ConnectionDiagnosticCode | undefined {
+    if (typeof error === 'string' && CODES.has(error)) return error as ConnectionDiagnosticCode;
+    const code = error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string'
+        ? (error as { code: string }).code
+        : undefined;
+    if (typeof code === 'string' && CODES.has(code)) return code as ConnectionDiagnosticCode;
+    const message = error instanceof Error ? error.message : String(error);
+    if (/^not connected$/i.test(message)) return 'not-connected';
+    if (/^connection lost$/i.test(message)) return 'connection-lost';
+    if (/^client closed$/i.test(message)) return 'client-closed';
+    if (/^request timed out:/i.test(message)) return 'request-timeout';
+    if (/relay ticket required/i.test(message)) return 'ticket-required';
+    if (/grant expired/i.test(message)) return 'grant-expired';
+    if (/grant is missing/i.test(message)) return 'e2ee-required';
+    if (/not ready/i.test(message)) return 'agent-not-ready';
+    if (/control moved|takeover required/i.test(message)) return 'takeover';
+    if (/relay did not accept/i.test(message)) return 'connection-lost';
+    if (/could not start Herdr|no current Herdr pane|not available on this host/i.test(message)) return 'unavailable';
+    return undefined;
+}
+
+export function connectionDiagnosticOutcome(error: unknown): ConnectionDiagnosticOutcome {
+    const code = connectionDiagnosticCode(error);
+    if (code === 'request-timeout') return 'timeout';
+    if (code === 'not-connected' || code === 'connection-lost' || code === 'client-closed' || code === 'dead-socket' || code === 'stale' || code === 'disconnected' || code === 'unavailable') {
+        return 'unavailable';
+    }
+    return 'rejected';
+}
+
+export function recordConnectionDiagnostic(
+    event: Omit<ConnectionDiagnosticEvent, 'at'> & { at?: string },
+): void {
+    const entry = { at: event.at ?? new Date().toISOString(), ...event } as ConnectionDiagnosticEvent;
+    if (!isValidEvent(entry)) return;
+    events = [...events, entry].slice(-MAX_EVENTS);
+    persist(events);
+    if (typeof __DEV__ !== 'undefined' && __DEV__) {
+        console.debug('[muxr.diag]', entry.event, summarize(entry));
+    }
+}
+
+export function recordSocketState(state: string, live: boolean): void {
+    if (!SOCKET_STATES.has(state)) return;
+    recordConnectionDiagnostic({
+        event: 'socket.state',
+        state: state as ConnectionDiagnosticSocketState,
+        live,
+    });
+}
+
+export function recordSocketReconnect(state: string, live: boolean): void {
+    const reason: ConnectionDiagnosticReconnectReason = state === 'open' && !live
+        ? 'dead-socket'
+        : state === 'stale' ? 'stale' : 'closed';
+    recordConnectionDiagnostic({ event: 'socket.reconnect', reason });
+}
+
+export function recordTrackedRpc(
+    type: string,
+    result: { ok: true } | { ok: false; error: unknown },
+    durationMs: number,
+): void {
+    if (!isTrackedConnectionRequest(type)) return;
+    if (result.ok) {
+        recordConnectionDiagnostic({ event: 'rpc', request: type, outcome: 'ok', durationMs: boundedDuration(durationMs) });
+        return;
+    }
+    const code = connectionDiagnosticCode(result.error);
+    recordConnectionDiagnostic({
+        event: 'rpc',
+        request: type,
+        outcome: connectionDiagnosticOutcome(result.error),
+        durationMs: boundedDuration(durationMs),
+        ...(code === undefined ? {} : { code }),
+    });
+}
+
+export function recordAgentGate(input: {
+    kind?: string;
+    lifecycle?: string;
+    promptable: boolean;
+    gate: ConnectionDiagnosticGate;
+}): void {
+    const kind = safeAgentKind(input.kind);
+    const lifecycle = LIFECYCLES.has(String(input.lifecycle))
+        ? input.lifecycle as ConnectionDiagnosticLifecycle
+        : 'unknown';
+    const last = events.at(-1);
+    if (last?.event === 'agent.gate'
+        && last.kind === kind
+        && last.lifecycle === lifecycle
+        && last.promptable === input.promptable
+        && last.gate === input.gate) {
+        return;
+    }
+    recordConnectionDiagnostic({
+        event: 'agent.gate',
+        ...(kind === undefined ? {} : { kind }),
+        lifecycle,
+        promptable: input.promptable,
+        gate: input.gate,
+    });
+}
+
+export function recordTerminalChannel(
+    phase: ConnectionDiagnosticChannelPhase,
+    result: { ok: true } | { ok: false; error?: unknown; code?: ConnectionDiagnosticCode },
+): void {
+    if (result.ok) {
+        recordConnectionDiagnostic({ event: 'terminal.channel', phase, outcome: 'ok' });
+        return;
+    }
+    const code = result.code ?? connectionDiagnosticCode(result.error);
+    recordConnectionDiagnostic({
+        event: 'terminal.channel',
+        phase,
+        outcome: result.error === undefined && code === undefined ? 'rejected' : connectionDiagnosticOutcome(result.error ?? code),
+        ...(code === undefined ? {} : { code }),
+    });
+}
+
+export function formatConnectionDiagnosticsForReport(): string {
+    if (events.length === 0) return 'No phone transport events yet.';
+    return events.map((event) => `${event.at} ${summarize(event)}`).join('\n');
+}
+
+function summarize(event: ConnectionDiagnosticEvent): string {
+    if (event.event === 'socket.state') return `socket.state ${event.state} live=${String(event.live)}`;
+    if (event.event === 'socket.reconnect') return `socket.reconnect ${event.reason}`;
+    if (event.event === 'rpc') {
+        const code = event.code === undefined ? '' : ` ${event.code}`;
+        return `rpc ${event.request} ${event.outcome}${code} ${event.durationMs}ms`;
+    }
+    if (event.event === 'agent.gate') {
+        const kind = event.kind === undefined ? '' : ` ${event.kind}`;
+        return `agent.gate${kind} ${event.lifecycle} promptable=${String(event.promptable)} ${event.gate}`;
+    }
+    const code = event.code === undefined ? '' : ` ${event.code}`;
+    return `terminal.channel ${event.phase} ${event.outcome}${code}`;
+}
+
+function safeAgentKind(value: string | undefined): string | undefined {
+    if (value === undefined) return undefined;
+    const kind = value.trim().toLowerCase();
+    if (kind === 'shell' || !/^[a-z][a-z0-9._-]{0,31}$/.test(kind)) return undefined;
+    return kind;
+}
+
+function boundedDuration(durationMs: number): number {
+    if (!Number.isFinite(durationMs)) return 0;
+    return Math.max(0, Math.min(Math.round(durationMs), 10 * 60_000));
+}
+
+function isIsoTime(value: unknown): value is string {
+    return typeof value === 'string' && Number.isFinite(Date.parse(value)) && value.length <= 40;
+}
+
+function isValidEvent(value: unknown): value is ConnectionDiagnosticEvent {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const event = value as Record<string, unknown>;
+    if (!isIsoTime(event.at)) return false;
+    if (event.event === 'socket.state') {
+        return SOCKET_STATES.has(String(event.state)) && typeof event.live === 'boolean';
+    }
+    if (event.event === 'socket.reconnect') return RECONNECT_REASONS.has(String(event.reason));
+    if (event.event === 'rpc') {
+        return TRACKED.has(String(event.request))
+            && OUTCOMES.has(String(event.outcome))
+            && typeof event.durationMs === 'number'
+            && Number.isFinite(event.durationMs)
+            && (event.code === undefined || CODES.has(String(event.code)));
+    }
+    if (event.event === 'terminal.channel') {
+        return CHANNEL_PHASES.has(String(event.phase))
+            && OUTCOMES.has(String(event.outcome))
+            && (event.code === undefined || CODES.has(String(event.code)));
+    }
+    if (event.event === 'agent.gate') {
+        return LIFECYCLES.has(String(event.lifecycle))
+            && GATES.has(String(event.gate))
+            && typeof event.promptable === 'boolean'
+            && (event.kind === undefined || typeof event.kind === 'string' && /^[a-z][a-z0-9._-]{0,31}$/.test(event.kind));
+    }
+    return false;
+}
+
+function loadPersisted(): ConnectionDiagnosticEvent[] {
+    const raw = readStore();
+    if (raw === undefined) return [];
+    try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (!Array.isArray(parsed)) return [];
+        return parsed.filter(isValidEvent).slice(-MAX_EVENTS);
+    } catch {
+        return [];
+    }
+}
+
+function persist(next: readonly ConnectionDiagnosticEvent[]): void {
+    writeStore(JSON.stringify(next));
+}
+
+function readStore(): string | undefined {
+    try {
+        const store = mmkv();
+        const raw = store?.getString(STORAGE_KEY);
+        return typeof raw === 'string' ? raw : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function writeStore(value: string): void {
+    try {
+        mmkv()?.set(STORAGE_KEY, value);
+    } catch {
+        // Tests and web without MMKV keep the in-memory trail only.
+    }
+}
+
+function mmkv(): { getString(key: string): string | undefined; set(key: string, value: string): void } | undefined {
+    try {
+        // Lazy so vitest can record without a native store.
+        const { MMKV } = require('react-native-mmkv') as { MMKV: new () => { getString(key: string): string | undefined; set(key: string, value: string): void } };
+        return new MMKV();
+    } catch {
+        return undefined;
+    }
+}

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
@@ -13,6 +13,7 @@ vi.mock('../application/hostedE2ee', () => ({
 import { MuxrClient } from './muxrClient';
 
 class FakeWebSocket {
+    static CONNECTING = 0;
     static OPEN = 1;
     static current: FakeWebSocket | undefined;
     readyState = 0;
@@ -91,5 +92,77 @@ describe('scanned pairing delivery', () => {
         await delivery;
         expect(handled).toEqual(['ws://10.0.2.2:28793?pair=TESTCODE12']);
         expect(listeners.size).toBe(0);
+    });
+});
+
+describe('mobile relay liveness', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        FakeWebSocket.current = undefined;
+    });
+
+    it('isLive is false until a host frame arrives, then a dead socket can reconnect', async () => {
+        vi.stubGlobal('WebSocket', FakeWebSocket);
+        const client = new MuxrClient({ mode: 'local', relayUrl: 'ws://relay.test', machineId: 'machine-1' });
+        client.connect();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        const first = FakeWebSocket.current!;
+        expect(client.isLive()).toBe(false);
+        await expect(client.request('herdr.tree', {})).rejects.toThrow('not connected');
+        first.onmessage?.({ data: JSON.stringify({
+            header: { machineId: 'machine-1', seq: 1, at: Date.now() },
+            payload: encodePayload({ type: 'plugins.invalidated', reason: 'changed', pluginIds: ['example.ui'] } as never),
+        }) });
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        expect(client.state).toBe('open');
+        expect(client.isLive()).toBe(true);
+        first.readyState = 3;
+        client.connect();
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+        expect(FakeWebSocket.current).not.toBe(first);
+        expect(client.isLive()).toBe(false);
+        client.close();
+    });
+});
+
+describe('connection diagnostic codes', () => {
+    it('maps socket, attach, and agent-not-ready failures without identifiers', async () => {
+        const {
+            resetConnectionDiagnostics,
+            recordSocketReconnect,
+            recordTrackedRpc,
+            recordTerminalChannel,
+            recordAgentGate,
+            readConnectionDiagnostics,
+            formatConnectionDiagnosticsForReport,
+            connectionDiagnosticCode,
+        } = await import('../../catalog/infrastructure/connectionDiagnostics');
+        resetConnectionDiagnostics();
+        expect(connectionDiagnosticCode(new Error('not connected'))).toBe('not-connected');
+        expect(connectionDiagnosticCode(Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' }))).toBe('agent-not-ready');
+        expect(connectionDiagnosticCode(new Error('terminal: relay did not accept the channel'))).toBe('connection-lost');
+        recordSocketReconnect('open', false);
+        recordTrackedRpc('terminal.attach', { ok: false, error: new Error('request timed out: terminal.attach') }, 12);
+        recordTrackedRpc('session.prompt', {
+            ok: false,
+            error: Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' }),
+        }, 0);
+        recordTerminalChannel('disconnected', { ok: false, code: 'disconnected' });
+        recordAgentGate({ kind: 'omp', lifecycle: 'idle', promptable: false, gate: 'not-interactive' });
+        recordAgentGate({ kind: 'w1EW:pH', lifecycle: 'idle', promptable: false, gate: 'missing' });
+        expect(readConnectionDiagnostics()).toEqual(expect.arrayContaining([
+            expect.objectContaining({ event: 'socket.reconnect', reason: 'dead-socket' }),
+            expect.objectContaining({ event: 'rpc', request: 'terminal.attach', outcome: 'timeout', code: 'request-timeout' }),
+            expect.objectContaining({ event: 'rpc', request: 'session.prompt', outcome: 'rejected', code: 'agent-not-ready' }),
+            expect.objectContaining({ event: 'terminal.channel', phase: 'disconnected', outcome: 'unavailable', code: 'disconnected' }),
+            expect.objectContaining({ event: 'agent.gate', kind: 'omp', lifecycle: 'idle', promptable: false, gate: 'not-interactive' }),
+            expect.objectContaining({ event: 'agent.gate', lifecycle: 'idle', promptable: false, gate: 'missing' }),
+        ]));
+        expect(readConnectionDiagnostics().some((event) => event.event === 'agent.gate' && 'kind' in event && event.kind === 'w1ew:ph')).toBe(false);
+        const report = formatConnectionDiagnosticsForReport();
+        expect(report).toMatch(/socket\.reconnect dead-socket/);
+        expect(report).toMatch(/rpc session\.prompt rejected agent-not-ready/);
+        expect(report).toMatch(/agent\.gate omp idle promptable=false not-interactive/);
+        expect(report).not.toMatch(/pp_|pwt-|devtok_|machine-|session-|w1EW:pH/);
     });
 });

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
@@ -96,13 +96,29 @@ export class MuxrClient {
         return this.hosted !== undefined;
     }
 
+    /** Relay accepted us and a host frame arrived on this socket. */
+    isLive(): boolean {
+        return this.state === 'open'
+            && this.socket !== undefined
+            && this.socket.readyState === (WebSocket.OPEN ?? 1);
+    }
+
     connect(): void {
         void this.open();
     }
 
     private async open(): Promise<void> {
-        if (this.closed || (this.socket !== undefined
-            && (this.socket.readyState === WebSocket.CONNECTING || this.socket.readyState === WebSocket.OPEN))) return;
+        if (this.closed) return;
+        if (this.socket !== undefined
+            && this.socket.readyState !== (WebSocket.CONNECTING ?? 0)
+            && this.socket.readyState !== (WebSocket.OPEN ?? 1)) {
+            const stale = this.socket;
+            this.socket = undefined;
+            stale.onclose = () => {};
+            stale.close();
+        }
+        if (this.socket !== undefined
+            && (this.socket.readyState === (WebSocket.CONNECTING ?? 0) || this.socket.readyState === (WebSocket.OPEN ?? 1))) return;
         if (this.reconnectTimer !== undefined) {
             clearTimeout(this.reconnectTimer);
             this.reconnectTimer = undefined;
@@ -227,7 +243,7 @@ export class MuxrClient {
                 return;
             }
             const socket = this.socket;
-            if (socket === undefined || socket.readyState !== WebSocket.OPEN) {
+            if (!this.isLive() || socket === undefined) {
                 reject(new Error('not connected'));
                 return;
             }

--- a/apps/mobile/sources/terminal/application/OpenTerminal.spec.ts
+++ b/apps/mobile/sources/terminal/application/OpenTerminal.spec.ts
@@ -56,6 +56,7 @@ vi.stubGlobal('WebSocket', FakeWebSocket);
 vi.stubGlobal('fetch', mocks.fetch);
 
 import { openTerminal } from './OpenTerminal';
+import { readConnectionDiagnostics, resetConnectionDiagnostics } from '@/catalog/infrastructure/connectionDiagnostics';
 
 describe('openTerminal reconnect ownership', () => {
     beforeEach(() => {
@@ -68,6 +69,7 @@ describe('openTerminal reconnect ownership', () => {
             json: async () => ({ ticket: 'pwt-test', expires_in: 60 }),
         });
         FakeWebSocket.instances.length = 0;
+        resetConnectionDiagnostics();
     });
 
     afterEach(() => {
@@ -80,6 +82,9 @@ describe('openTerminal reconnect ownership', () => {
             .rejects.toThrow('terminal: relay ticket required');
         expect(mocks.request).not.toHaveBeenCalled();
         expect(FakeWebSocket.instances).toHaveLength(0);
+        expect(readConnectionDiagnostics()).toEqual(expect.arrayContaining([
+            expect.objectContaining({ event: 'terminal.channel', phase: 'attach', code: 'ticket-required' }),
+        ]));
     });
 
     it('replays the first paint when it arrives before the native view subscribes', async () => {
@@ -150,6 +155,12 @@ describe('openTerminal reconnect ownership', () => {
         expect(replacement.close).toHaveBeenCalledTimes(1);
 
         channel.close();
+        expect(readConnectionDiagnostics()).toEqual(expect.arrayContaining([
+            expect.objectContaining({ event: 'terminal.channel', phase: 'attach', outcome: 'ok' }),
+            expect.objectContaining({ event: 'terminal.channel', phase: 'socket-open', outcome: 'ok' }),
+            expect.objectContaining({ event: 'terminal.channel', phase: 'live', outcome: 'ok' }),
+            expect.objectContaining({ event: 'terminal.channel', phase: 'reconnecting', outcome: 'ok' }),
+        ]));
     });
 });
 

--- a/apps/mobile/sources/terminal/application/OpenTerminal.ts
+++ b/apps/mobile/sources/terminal/application/OpenTerminal.ts
@@ -14,6 +14,7 @@
 import { issueWsTicket, newTerminalChannel, ticketSocketUrl, type Envelope, type TerminalHostFrame } from '@muxr/contract';
 import { getCachedConnectionSettings } from '@/connection';
 import { sync } from '@/catalog/sync';
+import { recordTerminalChannel } from '@/catalog/infrastructure/connectionDiagnostics';
 import { DeviceV2Crypto, getCachedHostedGrant, refreshHostedGrant } from '@/pairing/e2ee';
 
 export type TerminalChannelState = 'live' | 'reconnecting';
@@ -53,8 +54,14 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
     const options = command.mode === undefined ? undefined : { mode: command.mode };
     const settings = getCachedConnectionSettings();
     let grant = settings.mode === 'hosted' ? getCachedHostedGrant(settings.machineId) : undefined;
-    if (settings.mode === 'hosted' && grant === undefined) throw new Error('terminal: hosted machine grant is missing');
-    if (grant !== undefined && grant.expiresAt <= Date.now()) throw new Error('terminal: device grant expired; pair this browser again');
+    if (settings.mode === 'hosted' && grant === undefined) {
+        recordTerminalChannel('attach', { ok: false, code: 'e2ee-required' });
+        throw new Error('terminal: hosted machine grant is missing');
+    }
+    if (grant !== undefined && grant.expiresAt <= Date.now()) {
+        recordTerminalChannel('attach', { ok: false, code: 'grant-expired' });
+        throw new Error('terminal: device grant expired; pair this browser again');
+    }
     let hosted = grant === undefined ? undefined : new DeviceV2Crypto(grant);
     const channel = newTerminalChannel();
 
@@ -74,7 +81,7 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
         ...(options?.mode === undefined ? {} : { mode: options.mode }),
         ...(grant === undefined ? {} : { deviceId: grant.deviceId, takeover }),
     });
-    const attach = (takeover: boolean): Promise<unknown> => grant === undefined ? sendAttachRequest(takeover) : (async () => {
+    const attachOnce = (takeover: boolean): Promise<unknown> => grant === undefined ? sendAttachRequest(takeover) : (async () => {
         const latest = await refreshHostedGrant(settings.machineId, grant!.credential);
         if (latest !== undefined && latest.keyVersion >= grant!.keyVersion) {
             if (latest.expiresAt <= Date.now()) throw new Error('terminal: device grant expired; pair this browser again');
@@ -83,13 +90,26 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
         }
         return sendAttachRequest(takeover);
     })();
+    const attach = async (takeover: boolean): Promise<unknown> => {
+        try {
+            const result = await attachOnce(takeover);
+            recordTerminalChannel('attach', { ok: true });
+            return result;
+        } catch (error) {
+            recordTerminalChannel('attach', { ok: false, error });
+            throw error;
+        }
+    };
     const relayTicket = (): { relayUrl: string; credential: string } | undefined => grant !== undefined
         ? { relayUrl: grant.relayUrl, credential: grant.credential }
         : settings.token !== '' && !settings.token.startsWith('acctok_')
             ? { relayUrl: settings.relayUrl, credential: settings.token }
             : undefined;
     // Fail before attach: a ticketless socket is what produced the 1 Hz loop.
-    if (relayTicket() === undefined) throw new Error('terminal: relay ticket required');
+    if (relayTicket() === undefined) {
+        recordTerminalChannel('attach', { ok: false, code: 'ticket-required' });
+        throw new Error('terminal: relay ticket required');
+    }
     await attach(true);
 
     const dataListeners = new Set<(base64: string) => void>();
@@ -107,6 +127,7 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
     let takeoverRequested = false;
 
     const emitState = (state: TerminalChannelState): void => {
+        recordTerminalChannel(state, { ok: true });
         for (const listener of stateListeners) listener(state);
     };
 
@@ -114,6 +135,7 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
         if (closedByUser || retryTimer !== undefined) return;
         attempts += 1;
         if (attempts > MAX_ATTEMPTS) {
+            recordTerminalChannel('disconnected', { ok: false, code: 'disconnected' });
             for (const listener of closeListeners) listener('disconnected');
             return;
         }
@@ -188,7 +210,10 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
         // tokens cannot mint a channel ticket, so fail closed instead of
         // opening a 1 Hz unauthorized reconnect loop.
         const ticketInput = relayTicket();
-        if (ticketInput === undefined) throw new Error('terminal: relay ticket required');
+        if (ticketInput === undefined) {
+            recordTerminalChannel('attach', { ok: false, code: 'ticket-required' });
+            throw new Error('terminal: relay ticket required');
+        }
         const url = ticketSocketUrl(ticketInput.relayUrl, await issueWsTicket({
             relayUrl: ticketInput.relayUrl,
             credential: ticketInput.credential,
@@ -214,6 +239,7 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
             }
             opened = true;
             attempts = 0;
+            recordTerminalChannel('socket-open', { ok: true });
             emitState('live');
             for (const line of outbox.splice(0)) next.send(line);
         };
@@ -245,6 +271,10 @@ export async function openTerminal(command: OpenTerminalCommand): Promise<Termin
                     // Only the user's visible retry action may reverse a takeover.
                     closedByTakeover = reason === 'control moved to another device';
                     closedByUser = true;
+                    recordTerminalChannel('disconnected', {
+                        ok: false,
+                        code: closedByTakeover ? 'takeover' : 'disconnected',
+                    });
                     for (const listener of closeListeners) listener(reason);
                 }
             } catch {

--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -17,10 +17,11 @@ import { Ionicons } from '@expo/vector-icons';
 import { router, useFocusEffect } from 'expo-router';
 import { Modal } from '@/modal';
 import * as Clipboard from 'expo-clipboard';
-import { storage, useSession, useSessionGitStatus, useSessions } from '@/catalog/store';
+import { storage, useHerdrTree, useSession, useSessionGitStatus, useSessions } from '@/catalog/store';
 import { sessionStop } from '@/catalog/ops';
 import { sync } from '@/catalog/sync';
 import { resolveMessageModeMeta } from '@/catalog/infrastructure/messageMeta';
+import { recordAgentGate, recordTrackedRpc } from '@/catalog/infrastructure/connectionDiagnostics';
 import { permissionModeChip, resolveStatusBarGitBranch } from '../domain/sessionStatusBar';
 import { SessionMetaLine } from '@/herd/ui';
 import { HeaderBackButton } from '@/components/navigation/HeaderBackButton';
@@ -29,7 +30,7 @@ import { TerminalView } from './TerminalView';
 import { usePaneGestures } from '../application/usePaneGestures';
 import { AgentGlyph } from '@/components/AgentGlyph';
 import { AnimatedPopup } from '@/components/AnimatedOverlay';
-import { agentAccessibilityLabel, agentLabels, agentNameLine, agentStateLabel, agentStatusColor, isShellLabels } from '@/herd';
+import { agentAccessibilityLabel, agentLabels, agentNameLine, agentStateLabel, agentStatusColor, herdrPaneForSession, isShellLabels } from '@/herd';
 import { terminalPaneCanSend, terminalPaneStatus } from '../domain/promptAvailability';
 import type { TerminalChannel } from '../application/OpenTerminal';
 import { useImagePicker } from '@/hooks/useImagePicker';
@@ -75,6 +76,8 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     const keyboardHeight = useKeyboardState().height;
     const session = useSession(props.id);
     const sessions = useSessions();
+    const { workspaces } = useHerdrTree();
+    const storedPane = herdrPaneForSession(workspaces, props.id);
     const gitStatus = useSessionGitStatus(props.id);
     const pluginButtons = useSessionPlugins();
     const [pluginActionBusy, setExtensionActionBusy] = React.useState<string>();
@@ -205,9 +208,32 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     React.useEffect(() => {
         loadSiblings();
     }, [loadSiblings, session?.metadata?.promptable]);
-    const currentTab = tabs.find((tab) => tab.tabId === tabId);
-    const currentPane = currentTab?.panes.find((pane) => pane.sessionId === props.id);
+    const storedWorkspaceTabs = workspaces.find((entry) => entry.workspaceId === session?.metadata?.workspaceId)?.tabs;
+    const currentTab = tabs.find((tab) => tab.tabId === tabId)
+        ?? storedWorkspaceTabs?.find((tab) => tab.tabId === tabId);
+    const fetchedPane = currentTab?.panes.find((pane) => pane.sessionId === props.id);
+    const currentPane = fetchedPane ?? storedPane;
     const panePromptable = currentPane?.promptable === true;
+    const paneKind = currentPane?.agentKind;
+    const paneLifecycle = currentPane?.agentStatus;
+    const paneMissing = currentPane === undefined || isShellLabels(agentLabels(currentPane));
+    React.useEffect(() => {
+        if (paneMissing) {
+            recordAgentGate({
+                ...(paneKind === undefined ? {} : { kind: paneKind }),
+                lifecycle: paneLifecycle,
+                promptable: false,
+                gate: 'missing',
+            });
+            return;
+        }
+        recordAgentGate({
+            ...(paneKind === undefined ? {} : { kind: paneKind }),
+            lifecycle: paneLifecycle,
+            promptable: panePromptable,
+            gate: panePromptable ? 'ready' : paneLifecycle === 'starting' ? 'starting' : 'not-interactive',
+        });
+    }, [paneKind, paneLifecycle, paneMissing, panePromptable]);
 
     // Transient hint so a gesture that found no neighbour doesn't feel dead.
     const [gestureHint, setGestureHint] = React.useState<string | null>(null);
@@ -274,6 +300,10 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     // chips and are appended once, at send.
     const sendPrompt = React.useCallback(() => {
         if (!panePromptable) {
+            recordTrackedRpc('session.prompt', {
+                ok: false,
+                error: Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' }),
+            }, 0);
             Modal.alert('Not ready', 'Agent is not ready yet');
             return;
         }


### PR DESCRIPTION
## Summary

- Phone trail (codes only, local): socket live/dead, reconnect reason (`dead-socket` / `stale` / `closed`), `herdr.tree` / `terminal.attach` / `session.prompt`, terminal channel phase, and `agent.gate` with kind + lifecycle + gate. No machine, session, channel, ticket, or terminal text. Settings is unchanged.
- Host `diagnostics.json`: `agent.readiness` now keeps privacy-safe `kind`, `lifecycle`, and `gate` (`ready` / `starting` / `not-interactive` / `unbound` / `no-agent`) so Cursor vs Pi vs OMP in the same workspace is obvious. `session.prompt` keeps `agent-not-ready`. `terminal.attach` keeps `socket-timeout`, `takeover`, `e2ee-required`, or `unavailable`.
- Mobile relay liveness: `isLive()` requires an open socket. Dead sockets are retired so `connect()` is not blocked. Session header uses the stored herd tree so a missed `herdr.tree` does not collapse to Shell / Terminal / connecting.

The header can say connected while frames never leave the phone, or while one pane attaches and stays closed. A later report should read as a code, not a guess.

Official `@trymuxr/cli@0.1.22` will not write kind/gate until a newer CLI. Do not republish 0.1.22. Do not restart the official muxr on 8792 from this PR.

## Test plan

- [x] `npx vitest run apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts --config apps/mobile/vitest.config.ts` (4 passed)
- [x] `npx vitest run apps/mobile/sources/terminal/application/OpenTerminal.spec.ts --config apps/mobile/vitest.config.ts` (5 passed)
- [x] `npx vitest run apps/mobile/sources/architecture.spec.ts --config apps/mobile/vitest.config.ts` (6 passed)
- [x] `npx vitest run apps/host/src/peer/application/peerFlow.test.ts` (7 passed)
- [x] `npx vitest run apps/host/src/requests/application/createRequestDispatcher.test.ts` (9 passed)
- [x] Emulator `emulator-5574`: home extreme / connected, no MACHINE chip, no LogBox
- [x] Open LIVE **Pockit Main · pi/puma**: title holds, workspace OMP muxr handover, no Shell / connecting, composer **Agent is not ready yet**
- [x] Open LIVE **Remove Public Cloud Language · cursor**: same workspace, composer **Type a prompt…**, no Shell / connecting
- [ ] After a newer CLI: `muxr doctor` shows `agent.readiness` with kind/gate and `session.prompt rejected agent-not-ready` / `terminal.attach` codes when those fail