### PR TITLE
fix: start the requested agent kind and deliver its first prompt

### DIFF
--- a/apps/host/src/agent/application/startAgent.ts
+++ b/apps/host/src/agent/application/startAgent.ts
@@ -1,11 +1,11 @@
-import { MISSING_CWD_ERROR_PREFIX, type SessionStartResult } from '@muxr/contract';
+import { MISSING_CWD_ERROR_PREFIX, startWasAccepted, type SessionStartResult } from '@muxr/contract';
 import type { SessionStartOptions } from './sessionSource.js';
 
 export type StartAgentCommand = SessionStartOptions;
 
 export type StartAgentResult =
     | { ok: true; data: SessionStartResult }
-    | { ok: false; error: string };
+    | { ok: false; error: string; code?: string };
 
 export interface StartAgentWorkspace {
     exists(cwd: string): boolean;
@@ -28,5 +28,9 @@ export async function startAgent(
         }
         await workspace.create(command.cwd);
     }
-    return { ok: true, data: await workspace.start(command) };
+    const data = await workspace.start(command);
+    if (!startWasAccepted(data)) {
+        return { ok: false, error: data.acceptance.message, code: data.acceptance.code };
+    }
+    return { ok: true, data };
 }

--- a/apps/host/src/agent/application/startAgent.ts
+++ b/apps/host/src/agent/application/startAgent.ts
@@ -1,5 +1,13 @@
+import { homedir } from 'node:os';
 import { MISSING_CWD_ERROR_PREFIX, startWasAccepted, type SessionStartResult } from '@muxr/contract';
 import type { SessionStartOptions } from './sessionSource.js';
+
+/** Clients that never learned the machine's home directory send a literal `~`. */
+export function expandHome(cwd: string, home = homedir()): string {
+    if (cwd === '~') return home;
+    if (cwd.startsWith('~/')) return `${home}/${cwd.slice(2)}`;
+    return cwd;
+}
 
 export type StartAgentCommand = SessionStartOptions;
 
@@ -22,13 +30,14 @@ export async function startAgent(
     workspace: StartAgentWorkspace,
     command: StartAgentCommand,
 ): Promise<StartAgentResult> {
-    if (!workspace.exists(command.cwd)) {
+    const cwd = expandHome(command.cwd);
+    if (!workspace.exists(cwd)) {
         if (command.createCwd !== true) {
-            return { ok: false, error: `${MISSING_CWD_ERROR_PREFIX}${command.cwd}` };
+            return { ok: false, error: `${MISSING_CWD_ERROR_PREFIX}${cwd}` };
         }
-        await workspace.create(command.cwd);
+        await workspace.create(cwd);
     }
-    const data = await workspace.start(command);
+    const data = await workspace.start({ ...command, cwd });
     if (!startWasAccepted(data)) {
         return { ok: false, error: data.acceptance.message, code: data.acceptance.code };
     }

--- a/apps/host/src/agent/index.ts
+++ b/apps/host/src/agent/index.ts
@@ -1,7 +1,11 @@
 export {
     AgentRouteStore,
     herdrAgentSessionKey,
+    isMuxrLaunchSession,
+    muxrLaunchSession,
     parseHerdrAgentSession,
+    shouldAdoptPublishedLaunch,
+    MUXR_LAUNCH_SOURCE,
     type AgentRouteBinding,
     type HerdrAgentSessionRef,
 } from './infrastructure/agentRouteStore.js';

--- a/apps/host/src/agent/infrastructure/agentRouteStore.ts
+++ b/apps/host/src/agent/infrastructure/agentRouteStore.ts
@@ -36,6 +36,21 @@ export function herdrAgentSessionKey(value: HerdrAgentSessionRef): string {
     return JSON.stringify([value.source, value.agent, value.kind, value.value]);
 }
 
+export const MUXR_LAUNCH_SOURCE = 'muxr:launch';
+
+export function muxrLaunchSession(agent: string, launchName: string): HerdrAgentSessionRef {
+    return { source: MUXR_LAUNCH_SOURCE, agent, kind: 'id', value: launchName };
+}
+
+export function isMuxrLaunchSession(ref: HerdrAgentSessionRef): boolean {
+    return ref.source === MUXR_LAUNCH_SOURCE && ref.kind === 'id' && ref.value.length > 0;
+}
+
+/** Only adopt when Herdr published the same kind the launch asked for. */
+export function shouldAdoptPublishedLaunch(pending: HerdrAgentSessionRef, published: HerdrAgentSessionRef): boolean {
+    return isMuxrLaunchSession(pending) && !isMuxrLaunchSession(published) && pending.agent === published.agent;
+}
+
 /** Durable authorization only. Display identity and topology always come from Herdr. */
 export class AgentRouteStore {
     private readonly byRoute = new Map<string, AgentRouteBinding>();
@@ -93,6 +108,23 @@ export class AgentRouteStore {
         this.routeBySession.set(herdrAgentSessionKey(agentSession), route);
         this.persist();
         return { route, created: true };
+    }
+
+    /** Keep the phone's route when a launch generation later publishes its Herdr session. */
+    adopt(from: HerdrAgentSessionRef, to: HerdrAgentSessionRef): { route: string } | undefined {
+        const toRoute = this.route(to);
+        const fromRoute = this.route(from);
+        if (toRoute !== undefined) {
+            if (fromRoute !== undefined && fromRoute !== toRoute) this.remove(fromRoute);
+            return { route: toRoute };
+        }
+        if (fromRoute === undefined) return undefined;
+        this.routeBySession.delete(herdrAgentSessionKey(from));
+        const binding = { route: fromRoute, agentSession: to };
+        this.byRoute.set(fromRoute, binding);
+        this.routeBySession.set(herdrAgentSessionKey(to), fromRoute);
+        this.persist();
+        return { route: fromRoute };
     }
 
     remove(route: string): AgentRouteBinding | undefined {

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -581,9 +581,17 @@ export async function createHerdrSessionSource(
         return parseHerdrAgentSession(agent?.agent_session);
     }
 
+    function listedAgent(agent: AgentRecord | undefined): agent is AgentRecord {
+        return agentSession(agent) !== undefined && typeof agent?.name === 'string' && agent.name.length > 0;
+    }
+
     function namedAgent(agent: AgentRecord | undefined): agent is AgentRecord {
-        return agentSession(agent) !== undefined && typeof agent?.name === 'string' && agent.name.length > 0
-            && !/^pph?_/i.test(agent.name);
+        return listedAgent(agent) && typeof agent.name === 'string' && !/^pph?_/i.test(agent.name);
+    }
+
+    function publicListedName(agent: AgentRecord | undefined): string | undefined {
+        if (agent === undefined || !namedAgent(agent)) return undefined;
+        return typeof agent.name === 'string' && agent.name.length > 0 ? agent.name : undefined;
     }
 
     function shellRoute(paneId: string): string {
@@ -605,7 +613,7 @@ export async function createHerdrSessionSource(
 
     function currentAgentFor(agentSessionRef: HerdrAgentSessionRef): AgentRecord | undefined {
         const match = currentAgentRecordFor(agentSessionRef);
-        return namedAgent(match) ? match : undefined;
+        return listedAgent(match) ? match : undefined;
     }
 
     function closePaneId(sessionId: string): string | undefined {
@@ -811,6 +819,7 @@ export async function createHerdrSessionSource(
         const displayAgent = session.agent?.display_agent ?? undefined;
         const terminalTitle = session.agent?.terminal_title_stripped ?? session.pane.terminal_title_stripped ?? undefined;
         const spawnedBy = session.pane.tokens?.spawned_by;
+        const listedName = publicListedName(session.agent);
         return {
             id: session.sessionId,
             cwd: cwdForSession(session.sessionId) ?? '',
@@ -818,7 +827,7 @@ export async function createHerdrSessionSource(
             firstMessage: '',
             promptable: agentPromptable(session),
             agentStatus: lifecycleOf(session),
-            ...(session.agent?.name === undefined || session.agent.name === null ? {} : { agentName: session.agent.name }),
+            ...(listedName === undefined ? {} : { agentName: listedName }),
             ...(taskTitle === undefined ? {} : { taskTitle }),
             ...(agentKind === undefined ? {} : { agentKind }),
             ...(displayAgent === undefined ? {} : { displayAgent }),
@@ -984,7 +993,7 @@ export async function createHerdrSessionSource(
         const createdRoutes: string[] = [];
         for (const agent of agentsByPane.values()) {
             ensureStatusWatch(agent.pane_id);
-            if (!namedAgent(agent)) continue;
+            if (!listedAgent(agent)) continue;
             const ref = agentSession(agent)!;
             const bound = routes.bind(ref);
             paneByAgentRoute.set(bound.route, agent.pane_id);
@@ -1093,13 +1102,34 @@ export async function createHerdrSessionSource(
         void refreshSnapshot().then(emitAllStates).catch(() => {});
     });
 
+    function bindListedPane(paneId: string): CurrentSession | undefined {
+        const agent = agentsByPane.get(paneId);
+        const pane = panesById.get(paneId);
+        const ref = agentSession(agent);
+        if (agent === undefined || pane === undefined || ref === undefined) return undefined;
+        const bound = routes.bind(ref);
+        paneByAgentRoute.set(bound.route, paneId);
+        return { sessionId: bound.route, paneId, pane, agent };
+    }
+
     async function waitForPublishedAgent(paneId: string, timeoutMs: number): Promise<CurrentSession> {
         const deadline = Date.now() + timeoutMs;
+        const interactive = waitForInteractiveAgent(paneId, timeoutMs).catch(() => undefined);
         while (Date.now() < deadline) {
             await refreshSnapshot();
-            const session = currentSessionByPane(paneId);
-            if (session?.agent !== undefined) return session;
-            await sleep(200);
+            const session = bindListedPane(paneId);
+            if (session !== undefined) {
+                await routes.flush();
+                return session;
+            }
+            await Promise.race([sleep(200), interactive]);
+        }
+        await interactive;
+        await refreshSnapshot();
+        const session = bindListedPane(paneId);
+        if (session !== undefined) {
+            await routes.flush();
+            return session;
         }
         throw new Error('Herdr did not publish the current Agent Name and session.');
     }
@@ -1235,8 +1265,8 @@ export async function createHerdrSessionSource(
         let acceptance: SessionSnapshot['acceptance'];
         if (accepted) {
             acceptance = { outcome: 'accepted', state: lifecycleOf(session) };
-            const agentName = session.agent?.name;
-            if (agentName !== undefined && agentName !== null) acceptance.agentName = agentName;
+            const agentName = publicListedName(session.agent);
+            if (agentName !== undefined) acceptance.agentName = agentName;
         }
         return {
             info: infoFor(session),
@@ -1411,10 +1441,11 @@ export async function createHerdrSessionSource(
         const changedAt = Date.parse(options.lifecycle?.latestFor(session.sessionId)?.at ?? '');
         const taskTitle = taskTitleForSession(session);
         const displayAgent = session.agent?.display_agent ?? undefined;
+        const listedName = publicListedName(session.agent);
         return {
             sessionId: session.sessionId,
             cwd: cwdForSession(session.sessionId) ?? '',
-            ...(session.agent?.name === undefined || session.agent.name === null ? {} : { agentName: session.agent.name }),
+            ...(listedName === undefined ? {} : { agentName: listedName }),
             ...(taskTitle === undefined ? {} : { taskTitle }),
             ...(session.agent?.agent === undefined || session.agent.agent === null ? {} : { agentKind: session.agent.agent }),
             ...(displayAgent === undefined ? {} : { displayAgent }),
@@ -2090,15 +2121,16 @@ export async function createHerdrSessionSource(
                         const taskTitle = session === undefined ? undefined : taskTitleForSession(session);
                         const agentKind = session?.agent?.agent ?? undefined;
                         const cwd = pane.foreground_cwd ?? pane.cwd ?? undefined;
+                        const listedName = publicListedName(session?.agent);
                         return {
                             paneId: pane.pane_id,
                             tabId,
                             ...(pane.label === undefined || pane.label === null ? {} : { label: pane.label }),
                             ...(cwd === undefined ? {} : { cwd }),
                             ...(agentKind === undefined ? {} : { agentKind }),
-                            ...(session?.agent?.name === undefined || session.agent.name === null
+                            ...(listedName === undefined
                                 ? {}
-                                : { agentName: session.agent.name }),
+                                : { agentName: listedName }),
                             ...(session?.agent?.display_agent === undefined || session.agent.display_agent === null
                                 ? {}
                                 : { displayAgent: session.agent.display_agent }),

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -1356,7 +1356,7 @@ export async function createHerdrSessionSource(
         try {
             const launchName = `pp_${randomBytes(8).toString('hex')}`;
             await client.call('agent.start', { name: launchName, kind, pane_id: paneId, timeout_ms: 60_000 }, 70_000);
-            const session = await waitForPublishedAgent(paneId, 30_000);
+            const session = await waitForPublishedAgent(paneId, 60_000);
             const expectedRef = agentSession(session.agent)!;
             transition(session, 'starting', 'start-requested');
             emitState(session.sessionId);

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -1273,14 +1273,22 @@ export async function createHerdrSessionSource(
 
         const kind = startOptions.kind ?? 'pi';
         const requestedLabel = startOptions.label?.trim() || startOptions.taskTitle?.trim();
-        const earlyFailure = (): SessionStartResult => ({
-            acceptance: {
-                outcome: 'failed',
-                state: 'failed',
-                code: 'start-launch-failed',
-                message: 'Agent could not start.',
-            },
-        });
+        const earlyFailure = (): SessionStartResult => {
+            const publishedKind = publicAgentKind(kind);
+            options.onAgentReadinessDiagnostic?.('not-promptable', false, {
+                ...(publishedKind === undefined ? {} : { kind: publishedKind }),
+                lifecycle: 'failed',
+                gate: 'no-agent',
+            });
+            return {
+                acceptance: {
+                    outcome: 'failed',
+                    state: 'failed',
+                    code: 'start-launch-failed',
+                    message: 'Agent could not start.',
+                },
+            };
+        };
 
         let cwd = startOptions.cwd;
         let workspaceId: string | undefined;
@@ -1348,7 +1356,7 @@ export async function createHerdrSessionSource(
         try {
             const launchName = `pp_${randomBytes(8).toString('hex')}`;
             await client.call('agent.start', { name: launchName, kind, pane_id: paneId, timeout_ms: 60_000 }, 70_000);
-            const session = await waitForPublishedAgent(paneId, 5_000);
+            const session = await waitForPublishedAgent(paneId, 30_000);
             const expectedRef = agentSession(session.agent)!;
             transition(session, 'starting', 'start-requested');
             emitState(session.sessionId);

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -173,7 +173,12 @@ export interface CreateHerdrSessionSourceOptions {
     onAgentReadinessDiagnostic?: (
         reason: 'starting' | 'ready' | 'not-promptable',
         promptable: boolean,
-        detail?: { kind?: string; lifecycle?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' },
+        detail?: { kind?: string; lifecycle?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' | 'unnamed' | 'no-session' },
+    ) => void;
+    /** Privacy-safe start miss: whether Herdr published a named, bound Agent. */
+    onAgentLaunchDiagnostic?: (
+        outcome: 'ok' | 'rejected',
+        detail?: { kind?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' | 'unnamed' | 'no-session' },
     ) => void;
 }
 
@@ -1273,12 +1278,24 @@ export async function createHerdrSessionSource(
 
         const kind = startOptions.kind ?? 'pi';
         const requestedLabel = startOptions.label?.trim() || startOptions.taskTitle?.trim();
-        const earlyFailure = (): SessionStartResult => {
+        const launchMissGate = (paneId?: string): 'no-agent' | 'no-session' | 'unnamed' | 'unbound' => {
+            if (paneId === undefined) return 'no-agent';
+            const agent = agentsByPane.get(paneId);
+            if (agent === undefined) return 'no-agent';
+            if (agentSession(agent) === undefined) return 'no-session';
+            if (!namedAgent(agent)) return 'unnamed';
+            return 'unbound';
+        };
+        const earlyFailure = (gate: 'no-agent' | 'no-session' | 'unnamed' | 'unbound' = 'no-agent'): SessionStartResult => {
             const publishedKind = publicAgentKind(kind);
-            options.onAgentReadinessDiagnostic?.('not-promptable', false, {
+            const detail = {
                 ...(publishedKind === undefined ? {} : { kind: publishedKind }),
+                gate,
+            };
+            options.onAgentLaunchDiagnostic?.('rejected', detail);
+            options.onAgentReadinessDiagnostic?.('not-promptable', false, {
+                ...detail,
                 lifecycle: 'failed',
-                gate: 'no-agent',
             });
             return {
                 acceptance: {
@@ -1358,6 +1375,11 @@ export async function createHerdrSessionSource(
             await client.call('agent.start', { name: launchName, kind, pane_id: paneId, timeout_ms: 60_000 }, 70_000);
             const session = await waitForPublishedAgent(paneId, 60_000);
             const expectedRef = agentSession(session.agent)!;
+            const publishedKind = publicAgentKind(kind);
+            options.onAgentLaunchDiagnostic?.('ok', {
+                ...(publishedKind === undefined ? {} : { kind: publishedKind }),
+                gate: 'starting',
+            });
             transition(session, 'starting', 'start-requested');
             emitState(session.sessionId);
             void waitForInteractiveAgent(paneId, 60_000)
@@ -1378,8 +1400,10 @@ export async function createHerdrSessionSource(
                 });
             return snapshotFor(session, true);
         } catch {
+            await refreshSnapshot().catch(() => undefined);
+            const gate = launchMissGate(paneId);
             await client.call('pane.close', { pane_id: paneId }).catch(() => undefined);
-            return earlyFailure();
+            return earlyFailure(gate);
         }
     }
 

--- a/apps/host/src/agent/infrastructure/herdrSessionSource.ts
+++ b/apps/host/src/agent/infrastructure/herdrSessionSource.ts
@@ -49,7 +49,10 @@ import { HerdrClient } from './socketClient.js';
 import {
     AgentRouteStore,
     herdrAgentSessionKey,
+    isMuxrLaunchSession,
+    muxrLaunchSession,
     parseHerdrAgentSession,
+    shouldAdoptPublishedLaunch,
     type HerdrAgentSessionRef,
 } from './agentRouteStore.js';
 import { pluginInvalidationFrame, PluginCatalog, PluginRefreshGate, WriteReplayFence, Semaphore, rpcInputDigest, rpcReplayKey, runPluginProcess, type HerdrPlugin, type PluginBackendCallTarget } from './pluginCatalog.js';
@@ -76,6 +79,8 @@ import { rollupLifecycle } from '../domain/lifecycle.js';
 import { reportAgentOutcome } from '../application/reportAgentOutcome.js';
 import { agentKindsFromManifests } from '../domain/agentKinds.js';
 
+const PROMPT_READY_TIMEOUT_MS = 30_000;
+const PROMPT_REBIND_TIMEOUT_MS = 10_000;
 const PLUGIN_CALL_QUEUE_TIMEOUT_MS = 8_000;
 const MAX_PLUGIN_INVOCATIONS_PER_SCOPE = 64;
 const MAX_PLUGIN_INVOCATIONS_TOTAL = 1_024;
@@ -113,6 +118,8 @@ const COMMAND_ALIASES: Record<string, string[]> = {
     agy: ['agy', 'antigravity'],
     'antigravity-cli': ['antigravity-cli', 'antigravity'],
     kilo: ['kilo', 'kilocode'],
+    cursor: ['cursor-agent'],
+    kiro: ['kiro-cli'],
 };
 
 function execFileExitCode(error: { code?: unknown } | null): number | null {
@@ -178,7 +185,7 @@ export interface CreateHerdrSessionSourceOptions {
     /** Privacy-safe start miss: whether Herdr published a named, bound Agent. */
     onAgentLaunchDiagnostic?: (
         outcome: 'ok' | 'rejected',
-        detail?: { kind?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' | 'unnamed' | 'no-session' },
+        detail?: { kind?: string; detected?: string; gate?: 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' | 'unnamed' | 'no-session' },
     ) => void;
 }
 
@@ -548,6 +555,11 @@ export async function createHerdrSessionSource(
     /** Last pane authorized by an Agent Route. It survives a vanished agent
      * record while that pane remains live, so close can ask Herdr for truth. */
     const paneByAgentRoute = new Map<string, string>();
+    const pendingCreatedRoutes = new Set<string>();
+    const pendingLaunchByPane = new Map<string, HerdrAgentSessionRef>();
+    const seenLaunchPane = new Set<string>();
+    const launchSeedByPane = new Map<string, { pane: PaneRecord; agent: AgentRecord }>();
+
     const workspacesById = new Map<string, WorkspaceRecord>();
     const tabsById = new Map<string, TabRecord>();
     /** Local lifecycle epochs stop an older in-flight snapshot replacing a newer status event. */
@@ -577,12 +589,95 @@ export async function createHerdrSessionSource(
 
     const knownShells = new Set<string>();
 
-    function agentSession(agent: AgentRecord | undefined): HerdrAgentSessionRef | undefined {
+    function publishedAgentSession(agent: AgentRecord | undefined): HerdrAgentSessionRef | undefined {
         return parseHerdrAgentSession(agent?.agent_session);
     }
 
+    function agentSession(agent: AgentRecord | undefined): HerdrAgentSessionRef | undefined {
+        return publishedAgentSession(agent)
+            ?? (agent === undefined ? undefined : pendingLaunchByPane.get(agent.pane_id));
+    }
+
+    function forgetLaunch(paneId: string): void {
+        pendingLaunchByPane.delete(paneId);
+        seenLaunchPane.delete(paneId);
+        launchSeedByPane.delete(paneId);
+    }
+
+    function seedLaunchPane(paneId: string, pane: PaneRecord, agent?: AgentRecord): void {
+        const current = launchSeedByPane.get(paneId);
+        const nextPane = { ...current?.pane, ...pane, pane_id: paneId };
+        const nextAgent = {
+            ...current?.agent,
+            ...agent,
+            pane_id: paneId,
+        };
+        launchSeedByPane.set(paneId, { pane: nextPane, agent: nextAgent });
+        panesById.set(paneId, { ...panesById.get(paneId), ...nextPane });
+        if (agent !== undefined || current?.agent !== undefined) {
+            agentsByPane.set(paneId, { ...agentsByPane.get(paneId), ...nextAgent });
+        }
+    }
+
+    function restoreInFlightPane(paneId: string): void {
+        const pending = pendingLaunchByPane.get(paneId);
+        if (pending === undefined) return;
+        const seed = launchSeedByPane.get(paneId);
+        if (!panesById.has(paneId)) {
+            panesById.set(paneId, seed?.pane ?? { pane_id: paneId });
+        }
+        if (!agentsByPane.has(paneId)) {
+            agentsByPane.set(paneId, seed?.agent ?? {
+                pane_id: paneId,
+                name: pending.value,
+                agent: pending.agent,
+            });
+        }
+    }
+
+    function adoptPublishedLaunches(): void {
+        for (const [paneId, pending] of pendingLaunchByPane) {
+            const real = publishedAgentSession(agentsByPane.get(paneId));
+            if (real === undefined || !shouldAdoptPublishedLaunch(pending, real)) continue;
+            routes.adopt(pending, real);
+            forgetLaunch(paneId);
+        }
+    }
+
+    function rehydratePendingLaunches(): void {
+        for (const binding of routes.all()) {
+            if (!isMuxrLaunchSession(binding.agentSession)) continue;
+            const matches = [...agentsByPane.values()].filter((agent) => agent.name === binding.agentSession.value);
+            if (matches.length !== 1) continue;
+            const match = matches[0];
+            if (match === undefined) continue;
+            pendingLaunchByPane.set(match.pane_id, binding.agentSession);
+        }
+    }
+
+    function sweepStaleLaunches(): void {
+        for (const paneId of [...pendingLaunchByPane.keys()]) {
+            const live = agentsByPane.has(paneId) || panesById.has(paneId);
+            if (live) {
+                seenLaunchPane.add(paneId);
+                continue;
+            }
+            if (!seenLaunchPane.has(paneId)) continue;
+            forgetLaunch(paneId);
+        }
+    }
+
+    function restoreInFlightLaunches(): void {
+        for (const paneId of pendingLaunchByPane.keys()) {
+            if (seenLaunchPane.has(paneId)) continue;
+            restoreInFlightPane(paneId);
+        }
+    }
+
     function listedAgent(agent: AgentRecord | undefined): agent is AgentRecord {
-        return agentSession(agent) !== undefined && typeof agent?.name === 'string' && agent.name.length > 0;
+        if (agent === undefined || agentSession(agent) === undefined) return false;
+        if (typeof agent.name === 'string' && agent.name.length > 0) return true;
+        return pendingLaunchByPane.has(agent.pane_id) || publishedAgentSession(agent) !== undefined;
     }
 
     function namedAgent(agent: AgentRecord | undefined): agent is AgentRecord {
@@ -927,6 +1022,7 @@ export async function createHerdrSessionSource(
     }
 
     function removeRouteState(sessionId: string): void {
+        pendingCreatedRoutes.delete(sessionId);
         const watch = watches.get(sessionId);
         if (watch !== undefined) clearTimeout(watch);
         watches.delete(sessionId);
@@ -984,10 +1080,26 @@ export async function createHerdrSessionSource(
 
     /** Bind routes to current Herdr generations and remove every vanished generation first. */
     async function syncDiscovery(): Promise<void> {
-        const liveRefs = [...agentsByPane.values()].flatMap((agent) => {
+        rehydratePendingLaunches();
+        adoptPublishedLaunches();
+        sweepStaleLaunches();
+        restoreInFlightLaunches();
+        const liveRefs: HerdrAgentSessionRef[] = [];
+        const seenRefs = new Set<string>();
+        for (const agent of agentsByPane.values()) {
             const ref = agentSession(agent);
-            return ref === undefined ? [] : [ref];
-        });
+            if (ref === undefined) continue;
+            const key = herdrAgentSessionKey(ref);
+            if (seenRefs.has(key)) continue;
+            seenRefs.add(key);
+            liveRefs.push(ref);
+        }
+        for (const pending of pendingLaunchByPane.values()) {
+            const key = herdrAgentSessionKey(pending);
+            if (seenRefs.has(key)) continue;
+            seenRefs.add(key);
+            liveRefs.push(pending);
+        }
         for (const binding of routes.reconcile(liveRefs)) removeRouteState(binding.route);
 
         const createdRoutes: string[] = [];
@@ -1027,9 +1139,15 @@ export async function createHerdrSessionSource(
         knownShells.clear();
         for (const route of currentShells) knownShells.add(route);
 
-        for (const route of createdRoutes) {
+        // A route can be created a beat before its session resolves (a launch
+        // binds before Herdr publishes). Hold the event rather than drop it.
+        for (const route of [...pendingCreatedRoutes, ...createdRoutes]) {
             const session = currentSession(route);
-            if (session === undefined) continue;
+            if (session === undefined) {
+                pendingCreatedRoutes.add(route);
+                continue;
+            }
+            pendingCreatedRoutes.delete(route);
             publish(route, { type: 'session.created', session: infoFor(session) });
             emitState(route);
         }
@@ -1102,19 +1220,67 @@ export async function createHerdrSessionSource(
         void refreshSnapshot().then(emitAllStates).catch(() => {});
     });
 
+    function herdrStartRetryable(error: unknown): boolean {
+        const message = error instanceof Error ? error.message : '';
+        return message.includes('agent_pane_unavailable') || message.includes('agent_pane_busy');
+    }
+
+    function rememberLaunch(paneId: string, kind: string, launchName: string): HerdrAgentSessionRef {
+        const pending = muxrLaunchSession(publicAgentKind(kind) ?? 'agent', launchName);
+        pendingLaunchByPane.set(paneId, pending);
+        return pending;
+    }
+
+    function recordStartedAgent(paneId: string, kind: string, launchName: string, started?: AgentRecord): AgentRecord {
+        const launched: AgentRecord = {
+            ...agentsByPane.get(paneId),
+            ...started,
+            pane_id: paneId,
+            name: (typeof started?.name === 'string' && started.name.length > 0) ? started.name : launchName,
+        };
+        const kindName = started?.agent ?? publicAgentKind(kind);
+        if (kindName !== undefined) launched.agent = kindName;
+        agentsByPane.set(paneId, launched);
+        seedLaunchPane(paneId, panesById.get(paneId) ?? { pane_id: paneId }, launched);
+        return launched;
+    }
+
+    async function startManagedAgent(paneId: string, kind: string, launchName: string): Promise<void> {
+        const deadline = Date.now() + 5_000;
+        let lastError: unknown;
+        while (Date.now() < deadline) {
+            try {
+                const started = await client.call<{ agent?: AgentRecord }>(
+                    'agent.start',
+                    { name: launchName, kind, pane_id: paneId, timeout_ms: 60_000 },
+                    70_000,
+                );
+                recordStartedAgent(paneId, kind, launchName, started.agent);
+                return;
+            } catch (error) {
+                lastError = error;
+                if (!herdrStartRetryable(error)) throw error;
+                await sleep(150);
+            }
+        }
+        throw lastError instanceof Error ? lastError : new Error('herdr agent.start failed');
+    }
+
     function bindListedPane(paneId: string): CurrentSession | undefined {
+        restoreInFlightPane(paneId);
         const agent = agentsByPane.get(paneId);
         const pane = panesById.get(paneId);
-        const ref = agentSession(agent);
+        const ref = agentSession(agent) ?? pendingLaunchByPane.get(paneId);
         if (agent === undefined || pane === undefined || ref === undefined) return undefined;
         const bound = routes.bind(ref);
+        // Binding here consumes the created flag; syncDiscovery publishes it.
+        if (bound.created) pendingCreatedRoutes.add(bound.route);
         paneByAgentRoute.set(bound.route, paneId);
         return { sessionId: bound.route, paneId, pane, agent };
     }
 
-    async function waitForPublishedAgent(paneId: string, timeoutMs: number): Promise<CurrentSession> {
+    async function waitForListedAgent(paneId: string, timeoutMs: number): Promise<CurrentSession> {
         const deadline = Date.now() + timeoutMs;
-        const interactive = waitForInteractiveAgent(paneId, timeoutMs).catch(() => undefined);
         while (Date.now() < deadline) {
             await refreshSnapshot();
             const session = bindListedPane(paneId);
@@ -1122,9 +1288,8 @@ export async function createHerdrSessionSource(
                 await routes.flush();
                 return session;
             }
-            await Promise.race([sleep(200), interactive]);
+            await sleep(200);
         }
-        await interactive;
         await refreshSnapshot();
         const session = bindListedPane(paneId);
         if (session !== undefined) {
@@ -1134,15 +1299,85 @@ export async function createHerdrSessionSource(
         throw new Error('Herdr did not publish the current Agent Name and session.');
     }
 
-    async function waitForInteractiveAgent(paneId: string, timeoutMs: number): Promise<void> {
-        const result = await client.call<{ agent?: AgentRecord }>(
-            'agent.wait',
-            { target: paneId, until: ['idle', 'working', 'blocked', 'done'], timeout_ms: timeoutMs },
-            timeoutMs + 10_000,
-        );
-        if (result.agent?.interactive_ready !== true || result.agent.launch_pending === true) {
-            throw new Error('herdr agent did not become interactive');
+    async function waitForMatchingKind(paneId: string, kind: string, timeoutMs: number): Promise<CurrentSession> {
+        const requested = publicAgentKind(kind);
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            await refreshSnapshot();
+            const agent = agentsByPane.get(paneId);
+            const published = publishedAgentSession(agent);
+            const detected = publicAgentKind(agent?.agent ?? undefined) ?? publicAgentKind(published?.agent);
+            if (published !== undefined && requested !== undefined && detected !== undefined && detected !== requested) {
+                throw Object.assign(
+                    new Error(`herdr: agent_kind_mismatch: expected ${requested}, detected ${detected}`),
+                    { code: 'agent_kind_mismatch', detected },
+                );
+            }
+            if (published !== undefined && (requested === undefined || detected === requested)) {
+                const pending = pendingLaunchByPane.get(paneId);
+                if (pending !== undefined && shouldAdoptPublishedLaunch(pending, published)) {
+                    routes.adopt(pending, published);
+                    forgetLaunch(paneId);
+                }
+                const session = bindListedPane(paneId);
+                if (session !== undefined) {
+                    await routes.flush();
+                    return session;
+                }
+            }
+            await sleep(200);
         }
+        throw new Error('Herdr did not publish the requested agent.');
+    }
+
+    async function confirmLaunch(paneId: string, kind: string, sessionId: string): Promise<void> {
+        try {
+            await waitForMatchingKind(paneId, kind, 60_000);
+            await waitForInteractiveAgent(paneId, 60_000);
+            await refreshSnapshot();
+            const current = currentSession(sessionId);
+            if (current === undefined) return;
+            emitState(sessionId);
+        } catch (error) {
+            forgetLaunch(paneId);
+            const current = currentSession(sessionId);
+            if (current !== undefined) {
+                transition(current, 'failed', 'start-launch-failed');
+                emitState(sessionId);
+            }
+            // The phone already navigated to this pane; closing it strands the route.
+            const publishedKind = publicAgentKind(kind);
+            const detected = (error as { detected?: unknown }).detected;
+            options.onAgentLaunchDiagnostic?.('rejected', {
+                ...(publishedKind === undefined ? {} : { kind: publishedKind }),
+                ...(typeof detected === 'string' ? { detected } : {}),
+                gate: 'not-interactive',
+            });
+        }
+    }
+
+    /**
+     * agent.wait returns the moment a pane looks idle, which is earlier than
+     * promptable. Kinds that skip screen detection never report
+     * interactive_ready at all, so readiness uses the one promptable rule.
+     */
+    async function waitForInteractiveAgent(paneId: string, timeoutMs: number): Promise<void> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            const remaining = Math.max(1_000, deadline - Date.now());
+            const result = await client.call<{ agent?: AgentRecord }>(
+                'agent.wait',
+                { target: paneId, until: ['idle', 'working', 'blocked', 'done'], timeout_ms: remaining },
+                remaining + 10_000,
+            );
+            const agent = result.agent;
+            const status = agent?.agent_status;
+            const lifecycle: AgentLifecycle = status === 'idle' || status === 'working' || status === 'blocked'
+                || status === 'done' || status === 'failed' ? status : 'unknown';
+            if (agent !== undefined && herdrAgentIsPromptable(agent, lifecycle)) return;
+            await sleep(300);
+        }
+        throw new Error('herdr agent did not become interactive');
     }
 
     client.onEvent((event) => {
@@ -1248,6 +1483,7 @@ export async function createHerdrSessionSource(
     function forgetClosedSession(sessionId: string, paneId?: string): void {
         const resolvedPaneId = paneId ?? closePaneId(sessionId);
         if (resolvedPaneId !== undefined) {
+            forgetLaunch(resolvedPaneId);
             statusWatches.get(resolvedPaneId)?.();
             statusWatches.delete(resolvedPaneId);
             lifecycleEpochByPane.delete(resolvedPaneId);
@@ -1312,11 +1548,14 @@ export async function createHerdrSessionSource(
             if (paneId === undefined) return 'no-agent';
             const agent = agentsByPane.get(paneId);
             if (agent === undefined) return 'no-agent';
-            if (agentSession(agent) === undefined) return 'no-session';
+            if (publishedAgentSession(agent) === undefined && pendingLaunchByPane.get(paneId) === undefined) return 'no-session';
             if (!namedAgent(agent)) return 'unnamed';
             return 'unbound';
         };
-        const earlyFailure = (gate: 'no-agent' | 'no-session' | 'unnamed' | 'unbound' = 'no-agent'): SessionStartResult => {
+        const earlyFailure = (
+            gate: 'no-agent' | 'no-session' | 'unnamed' | 'unbound' = 'no-agent',
+            message = 'Agent could not start.',
+        ): SessionStartResult => {
             const publishedKind = publicAgentKind(kind);
             const detail = {
                 ...(publishedKind === undefined ? {} : { kind: publishedKind }),
@@ -1332,7 +1571,7 @@ export async function createHerdrSessionSource(
                     outcome: 'failed',
                     state: 'failed',
                     code: 'start-launch-failed',
-                    message: 'Agent could not start.',
+                    message,
                 },
             };
         };
@@ -1402,9 +1641,19 @@ export async function createHerdrSessionSource(
 
         try {
             const launchName = `pp_${randomBytes(8).toString('hex')}`;
-            await client.call('agent.start', { name: launchName, kind, pane_id: paneId, timeout_ms: 60_000 }, 70_000);
-            const session = await waitForPublishedAgent(paneId, 60_000);
-            const expectedRef = agentSession(session.agent)!;
+            seedLaunchPane(paneId, {
+                pane_id: paneId,
+                tab_id: tab.tab.tab_id,
+                workspace_id: workspaceId,
+            });
+            tabsById.set(tab.tab.tab_id, {
+                tab_id: tab.tab.tab_id,
+                workspace_id: workspaceId,
+                ...(requestedLabel === undefined ? {} : { label: requestedLabel }),
+            });
+            rememberLaunch(paneId, kind, launchName);
+            await startManagedAgent(paneId, kind, launchName);
+            const session = bindListedPane(paneId) ?? await waitForListedAgent(paneId, 5_000);
             const publishedKind = publicAgentKind(kind);
             options.onAgentLaunchDiagnostic?.('ok', {
                 ...(publishedKind === undefined ? {} : { kind: publishedKind }),
@@ -1412,28 +1661,18 @@ export async function createHerdrSessionSource(
             });
             transition(session, 'starting', 'start-requested');
             emitState(session.sessionId);
-            void waitForInteractiveAgent(paneId, 60_000)
-                .then(async () => {
-                    await refreshSnapshot();
-                    const current = currentSession(session.sessionId);
-                    const currentRef = agentSession(current?.agent);
-                    if (current === undefined || currentRef === undefined
-                        || herdrAgentSessionKey(currentRef) !== herdrAgentSessionKey(expectedRef)) return;
-                    emitState(current.sessionId);
-                })
-                .catch(() => {
-                    const current = currentSession(session.sessionId);
-                    if (current !== undefined) {
-                        transition(current, 'failed', 'start-launch-failed');
-                        emitState(current.sessionId);
-                    }
-                });
+            void confirmLaunch(paneId, kind, session.sessionId);
             return snapshotFor(session, true);
-        } catch {
+        } catch (error) {
+            forgetLaunch(paneId);
             await refreshSnapshot().catch(() => undefined);
             const gate = launchMissGate(paneId);
             await client.call('pane.close', { pane_id: paneId }).catch(() => undefined);
-            return earlyFailure(gate);
+            const code = herdrFailureCode(error);
+            return earlyFailure(
+                gate,
+                code === 'unsupported_agent_kind' ? 'That agent is not installed.' : 'Agent could not start.',
+            );
         }
     }
 
@@ -1478,8 +1717,24 @@ export async function createHerdrSessionSource(
             : { accepted: true, agent: realtimeAgentFor(session) };
     }
 
+    /**
+     * A just-started agent reports promptable a beat after it is listed, and it
+     * can flap once more while it settles. Wait that out instead of losing the
+     * message the phone already accepted.
+     */
     async function promptSession(sessionId: string, text: string): Promise<void> {
-        const session = await resolvePane(sessionId);
+        let session = await resolvePane(sessionId);
+        if (!agentPromptable(session)) {
+            // Cheap event-driven wait first, then a short poll for the route
+            // rebind that adoption performs a beat later.
+            await waitForInteractiveAgent(session.paneId, PROMPT_READY_TIMEOUT_MS).catch(() => undefined);
+            const deadline = Date.now() + PROMPT_REBIND_TIMEOUT_MS;
+            do {
+                session = await resolvePane(sessionId);
+                if (agentPromptable(session)) break;
+                await sleep(500);
+            } while (Date.now() < deadline);
+        }
         const promptable = agentPromptable(session);
         if (!promptable) options.onAgentReadinessDiagnostic?.('not-promptable', false, readinessDetail(session));
         await promptPromptableHerdrAgent(client, session, promptable, text);
@@ -2184,16 +2439,15 @@ export async function createHerdrSessionSource(
             }
             await tagSpawn(newPaneId, splitOptions.sessionId);
             const launchName = `pp_${randomBytes(8).toString('hex')}`;
-            await client.call('agent.start', {
-                name: launchName,
-                kind: splitOptions.kind,
-                pane_id: newPaneId,
-                timeout_ms: 30_000,
-            }, 40_000);
+            seedLaunchPane(newPaneId, { pane_id: newPaneId });
+            rememberLaunch(newPaneId, splitOptions.kind, launchName);
             try {
-                const found = await waitForPublishedAgent(newPaneId, 30_000);
+                await startManagedAgent(newPaneId, splitOptions.kind, launchName);
+                const found = bindListedPane(newPaneId) ?? await waitForListedAgent(newPaneId, 5_000);
+                void confirmLaunch(newPaneId, splitOptions.kind, found.sessionId);
                 return { paneId: newPaneId, sessionId: found.sessionId };
             } catch {
+                forgetLaunch(newPaneId);
                 return { paneId: newPaneId };
             }
         },
@@ -2420,11 +2674,27 @@ export async function createHerdrSessionSource(
                 return;
             }
             const launchName = `pp_${randomBytes(8).toString('hex')}`;
-            void client
-                .call('agent.start', { name: launchName, kind: options.kind, pane_id: paneId, timeout_ms: 60_000 })
-                .then(() => refreshSnapshot())
-                .then(emitAllStates)
-                .catch(() => undefined);
+            seedLaunchPane(paneId, {
+                pane_id: paneId,
+                tab_id: tab.tab.tab_id,
+                workspace_id: workspaceId,
+            });
+            tabsById.set(tab.tab.tab_id, {
+                tab_id: tab.tab.tab_id,
+                workspace_id: workspaceId,
+                ...(requestedLabel === undefined ? {} : { label: requestedLabel }),
+            });
+            rememberLaunch(paneId, options.kind, launchName);
+            try {
+                await startManagedAgent(paneId, options.kind, launchName);
+                const session = bindListedPane(paneId) ?? await waitForListedAgent(paneId, 5_000);
+                emitState(session.sessionId);
+                void confirmLaunch(paneId, options.kind, session.sessionId);
+            } catch {
+                forgetLaunch(paneId);
+                await refreshSnapshot().catch(() => undefined);
+                emitState(shellRoute(paneId));
+            }
         },
 
         sendKeys: sendSessionKeys,

--- a/apps/host/src/agent/infrastructure/layoutSelfCheck.ts
+++ b/apps/host/src/agent/infrastructure/layoutSelfCheck.ts
@@ -11,7 +11,7 @@ import {
     type HerdrLayoutNode,
 } from '../domain/layout.js';
 import { lifecycleReasonForObservation } from '../domain/lifecycle.js';
-import { AgentRouteStore, type HerdrAgentSessionRef } from './agentRouteStore.js';
+import { AgentRouteStore, isMuxrLaunchSession, shouldAdoptPublishedLaunch, type HerdrAgentSessionRef } from './agentRouteStore.js';
 import { runPluginProcess } from './pluginCatalog.js';
 import { RealtimeCodingCoordinator } from './realtimeCoordinator.js';
 import { closeExactPane, closeExactTab, closeExactWorkspace, herdrAgentIsPromptable, isRetryableCloseFailure, mergeHerdrAgentEvent, promptHerdrAgent, promptPromptableHerdrAgent, resolveClosePaneId, sendKeysToLiveAgent } from './herdrSessionSource.js';
@@ -146,6 +146,46 @@ async function demo(): Promise<void> {
     const movedBadger = { ...badger, pane_id: 'w9:p7' };
     assert(routeStore.bind(movedBadger.agent_session).route === routeA && movedBadger.name === 'Badger',
         'Badger session A keeps its route across a pane move');
+    const launchSession: HerdrAgentSessionRef = {
+        source: 'muxr:launch',
+        agent: 'cursor',
+        kind: 'id',
+        value: 'launch-generation',
+    };
+    const publishedLaunch: HerdrAgentSessionRef = {
+        source: 'herdr:cursor',
+        agent: 'cursor',
+        kind: 'id',
+        value: 'generation-cursor',
+    };
+    const launchRoute = routeStore.bind(launchSession).route;
+    assert(isMuxrLaunchSession(launchSession) === true, 'muxr launch identity is marked as a launch session');
+    assert(routeStore.reconcile([sessionA, launchSession]).length === 0
+        && routeStore.get(launchRoute)?.source === launchSession.source
+        && routeStore.get(launchRoute)?.value === launchSession.value,
+        'reconcile keeps an in-flight launch generation');
+    assert(routeStore.adopt(launchSession, publishedLaunch)?.route === launchRoute
+        && routeStore.route(publishedLaunch) === launchRoute
+        && routeStore.get(launchRoute)?.value === publishedLaunch.value,
+        'a launch generation keeps its route when Herdr publishes the session');
+    assert(routeStore.reconcile([sessionA, publishedLaunch]).length === 0
+        && routeStore.get(launchRoute)?.source === 'herdr:cursor',
+        'reconcile keeps the adopted Herdr session');
+    assert(routeStore.reconcile([sessionA])[0]?.route === launchRoute && routeStore.get(launchRoute) === undefined,
+        'reconcile drops a vanished launch route');
+    const mismatchedLaunch: HerdrAgentSessionRef = {
+        source: 'herdr:codex',
+        agent: 'codex',
+        kind: 'id',
+        value: 'generation-codex',
+    };
+    assert(shouldAdoptPublishedLaunch(launchSession, publishedLaunch) === true
+        && shouldAdoptPublishedLaunch(launchSession, mismatchedLaunch) === false,
+        'kind mismatch does not adopt a published session onto the launch route');
+    assert(herdrAgentIsPromptable({}, 'idle') === true
+        && herdrAgentIsPromptable({ launch_pending: true }, 'idle') === false
+        && herdrAgentIsPromptable({ interactive_ready: false }, 'idle') === false,
+        'a kind that never reports interactive_ready is still promptable once idle');
 
     const removed = routeStore.reconcile([sessionB]);
     const pelican = {

--- a/apps/host/src/diagnostics/infrastructure/journal.ts
+++ b/apps/host/src/diagnostics/infrastructure/journal.ts
@@ -32,7 +32,7 @@ export type HostDiagnosticEvent =
     | { at: string; event: 'peer.broker'; operation: DiagnosticBrokerOperation; outcome: DiagnosticOutcome; durationMs: number; code?: string }
     | { at: string; event: 'realtime.prompt'; provider: string; action: 'prompt'; requestedAgentName: string; resolvedAgentName: string | null; outcome: DiagnosticRealtimePromptOutcome }
     | { at: string; event: 'agent.readiness'; reason: 'starting' | 'ready' | 'not-promptable'; promptable: boolean; kind?: string; lifecycle?: string; gate?: DiagnosticReadinessGate }
-    | { at: string; event: 'agent.launch'; outcome: DiagnosticOutcome; kind?: string; gate?: DiagnosticReadinessGate };
+    | { at: string; event: 'agent.launch'; outcome: DiagnosticOutcome; kind?: string; detected?: string; gate?: DiagnosticReadinessGate };
 
 interface HostDiagnosticState {
     version: 1;
@@ -229,15 +229,17 @@ export class HostDiagnosticsJournal {
 
     agentLaunch(
         outcome: DiagnosticOutcome,
-        detail?: { kind?: string; gate?: DiagnosticReadinessGate },
+        detail?: { kind?: string; detected?: string; gate?: DiagnosticReadinessGate },
     ): void {
         const kind = safeAgentKind(detail?.kind);
+        const detected = safeAgentKind(detail?.detected);
         const gate = safeReadinessGate(detail?.gate);
         this.record({
             at: this.timestamp(),
             event: 'agent.launch',
             outcome,
             ...(kind === undefined ? {} : { kind }),
+            ...(detected === undefined ? {} : { detected }),
             ...(gate === undefined ? {} : { gate }),
         });
     }

--- a/apps/host/src/diagnostics/infrastructure/journal.ts
+++ b/apps/host/src/diagnostics/infrastructure/journal.ts
@@ -60,6 +60,7 @@ const safeCodes = new Set([
     'agent-not-ready', 'timeout', 'unavailable',
     'not-connected', 'connection-lost', 'client-closed', 'request-timeout',
     'dead-socket', 'stale', 'disconnected', 'takeover',
+    'start-launch-failed',
 ]);
 const loggedRequests = new Set<RequestType>([
     'machines.list', 'herdr.tree', 'terminal.attach', 'terminal.detach',

--- a/apps/host/src/diagnostics/infrastructure/journal.ts
+++ b/apps/host/src/diagnostics/infrastructure/journal.ts
@@ -15,7 +15,7 @@ export type DiagnosticBrokerOperation = 'list' | 'read' | 'status' | 'watch' | '
 export type DiagnosticPeerConnectionPhase = 'grant-refresh' | 'ticket-issue' | 'socket-open' | 'liveness-proof';
 export type DiagnosticPeerIngressOutcome = 'received' | 'decrypt-rejected' | 'decoded';
 export type DiagnosticRealtimePromptOutcome = 'queued' | 'rejected' | 'failed';
-export type DiagnosticReadinessGate = 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent';
+export type DiagnosticReadinessGate = 'ready' | 'starting' | 'not-interactive' | 'unbound' | 'no-agent' | 'unnamed' | 'no-session';
 
 
 type ClientCounts = Record<DiagnosticClientKind, number>;
@@ -31,7 +31,8 @@ export type HostDiagnosticEvent =
     | { at: string; event: 'peer.ingress'; direction: 'inbound'; outcome: DiagnosticPeerIngressOutcome }
     | { at: string; event: 'peer.broker'; operation: DiagnosticBrokerOperation; outcome: DiagnosticOutcome; durationMs: number; code?: string }
     | { at: string; event: 'realtime.prompt'; provider: string; action: 'prompt'; requestedAgentName: string; resolvedAgentName: string | null; outcome: DiagnosticRealtimePromptOutcome }
-    | { at: string; event: 'agent.readiness'; reason: 'starting' | 'ready' | 'not-promptable'; promptable: boolean; kind?: string; lifecycle?: string; gate?: DiagnosticReadinessGate };
+    | { at: string; event: 'agent.readiness'; reason: 'starting' | 'ready' | 'not-promptable'; promptable: boolean; kind?: string; lifecycle?: string; gate?: DiagnosticReadinessGate }
+    | { at: string; event: 'agent.launch'; outcome: DiagnosticOutcome; kind?: string; gate?: DiagnosticReadinessGate };
 
 interface HostDiagnosticState {
     version: 1;
@@ -85,7 +86,7 @@ function safeLifecycle(value: string | undefined): string | undefined {
 }
 
 function safeReadinessGate(value: string | undefined): DiagnosticReadinessGate | undefined {
-    if (value === 'ready' || value === 'starting' || value === 'not-interactive' || value === 'unbound' || value === 'no-agent') {
+    if (value === 'ready' || value === 'starting' || value === 'not-interactive' || value === 'unbound' || value === 'no-agent' || value === 'unnamed' || value === 'no-session') {
         return value;
     }
     return undefined;
@@ -223,6 +224,21 @@ export class HostDiagnosticsJournal {
             requestedAgentName: safeSemanticName(requestedAgentName, 'unspecified')!,
             resolvedAgentName: safeSemanticName(resolvedAgentName, 'unknown'),
             outcome,
+        });
+    }
+
+    agentLaunch(
+        outcome: DiagnosticOutcome,
+        detail?: { kind?: string; gate?: DiagnosticReadinessGate },
+    ): void {
+        const kind = safeAgentKind(detail?.kind);
+        const gate = safeReadinessGate(detail?.gate);
+        this.record({
+            at: this.timestamp(),
+            event: 'agent.launch',
+            outcome,
+            ...(kind === undefined ? {} : { kind }),
+            ...(gate === undefined ? {} : { gate }),
         });
     }
 

--- a/apps/host/src/main.ts
+++ b/apps/host/src/main.ts
@@ -604,6 +604,8 @@ async function main(): Promise<void> {
                 ),
                 onAgentReadinessDiagnostic: (reason, promptable, detail) =>
                     diagnostics.agentReadiness(reason, promptable, detail),
+                onAgentLaunchDiagnostic: (outcome, detail) =>
+                    diagnostics.agentLaunch(outcome, detail),
             }),
         });
     }

--- a/apps/host/src/peer/application/peerFlow.test.ts
+++ b/apps/host/src/peer/application/peerFlow.test.ts
@@ -574,6 +574,7 @@ describe('host peer collaboration flow', () => {
         diagnostics.agentReadiness('not-promptable', false, { kind: 'omp', lifecycle: 'idle', gate: 'not-interactive' });
         diagnostics.agentReadiness('not-promptable', false, { kind: 'w1EW:pH', lifecycle: 'idle', gate: 'unbound' });
         diagnostics.request('session.prompt', 'native', 'rejected', 8, 'agent-not-ready');
+        diagnostics.request('session.start', 'native', 'rejected', 5300, 'start-launch-failed');
         diagnostics.request('terminal.attach', 'native', 'rejected', 11, 'socket-timeout');
         for (let index = 0; index < 600; index += 1) diagnostics.request('herdr.tree', 'native', 'ok', 1);
         await broker.close();
@@ -589,6 +590,7 @@ describe('host peer collaboration flow', () => {
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'peer.connection', phase: 'liveness-proof', outcome: 'timeout' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'peer.prepare', code: 'peer-recovery-pending' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'session.prompt', outcome: 'rejected', code: 'agent-not-ready' }));
+        expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'session.start', outcome: 'rejected', code: 'start-launch-failed' }));
         expect(diagnosticEvents).toEqual(expect.arrayContaining([
             expect.objectContaining({ event: 'agent.readiness', reason: 'starting', promptable: false }),
             expect.objectContaining({ event: 'agent.readiness', reason: 'ready', promptable: true }),

--- a/apps/host/src/peer/application/peerFlow.test.ts
+++ b/apps/host/src/peer/application/peerFlow.test.ts
@@ -575,6 +575,8 @@ describe('host peer collaboration flow', () => {
         diagnostics.agentReadiness('not-promptable', false, { kind: 'w1EW:pH', lifecycle: 'idle', gate: 'unbound' });
         diagnostics.request('session.prompt', 'native', 'rejected', 8, 'agent-not-ready');
         diagnostics.request('session.start', 'native', 'rejected', 5300, 'start-launch-failed');
+        diagnostics.agentLaunch('rejected', { kind: 'cursor', gate: 'unnamed' });
+        diagnostics.agentLaunch('rejected', { kind: 'w1EW:pH', gate: 'no-session' });
         diagnostics.request('terminal.attach', 'native', 'rejected', 11, 'socket-timeout');
         for (let index = 0; index < 600; index += 1) diagnostics.request('herdr.tree', 'native', 'ok', 1);
         await broker.close();
@@ -591,6 +593,8 @@ describe('host peer collaboration flow', () => {
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'peer.prepare', code: 'peer-recovery-pending' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'session.prompt', outcome: 'rejected', code: 'agent-not-ready' }));
         expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'client.request', request: 'session.start', outcome: 'rejected', code: 'start-launch-failed' }));
+        expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'agent.launch', outcome: 'rejected', kind: 'cursor', gate: 'unnamed' }));
+        expect(diagnosticEvents).toContainEqual(expect.objectContaining({ event: 'agent.launch', outcome: 'rejected', gate: 'no-session' }));
         expect(diagnosticEvents).toEqual(expect.arrayContaining([
             expect.objectContaining({ event: 'agent.readiness', reason: 'starting', promptable: false }),
             expect.objectContaining({ event: 'agent.readiness', reason: 'ready', promptable: true }),

--- a/apps/host/src/requests/application/createRequestDispatcher.test.ts
+++ b/apps/host/src/requests/application/createRequestDispatcher.test.ts
@@ -100,6 +100,38 @@ describe('agent lifecycle request flow', () => {
         });
         expect(JSON.stringify(stale)).not.toMatch(/\/|prompt|pane-|stable-session/);
     });
+
+    it('rejects a start that never published an agent so the journal can keep start-launch-failed', async () => {
+        const cwd = mkdtempSync(join(tmpdir(), 'muxr-start-fail-'));
+        const source = {
+            async start() {
+                return {
+                    acceptance: {
+                        outcome: 'failed',
+                        state: 'failed',
+                        code: 'start-launch-failed',
+                        message: 'Agent could not start.',
+                    },
+                };
+            },
+        } as unknown as SessionSource;
+        const { dispatch } = createRequestDispatcher({
+            source,
+            domain: {} as never,
+            machineId: 'm1',
+            hostVersion: '0.0.0',
+        });
+        const failed = await dispatch({
+            type: 'session.start', requestId: 'fail', params: { cwd, kind: 'pi' },
+        } as never);
+        expect(failed).toEqual({
+            type: 'result',
+            requestId: 'fail',
+            ok: false,
+            error: 'Agent could not start.',
+            code: 'start-launch-failed',
+        });
+    });
 });
 
 describe('session.stop dispatcher flow', () => {

--- a/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
+++ b/apps/mobile/sources/catalog/infrastructure/connectionDiagnostics.ts
@@ -7,7 +7,7 @@
  * ticket, or error text.
  */
 
-export type ConnectionDiagnosticRequest = 'herdr.tree' | 'terminal.attach' | 'terminal.detach' | 'session.prompt';
+export type ConnectionDiagnosticRequest = 'herdr.tree' | 'terminal.attach' | 'terminal.detach' | 'session.prompt' | 'session.start';
 export type ConnectionDiagnosticOutcome = 'ok' | 'rejected' | 'timeout' | 'unavailable';
 export type ConnectionDiagnosticCode =
     | 'not-connected'
@@ -22,7 +22,8 @@ export type ConnectionDiagnosticCode =
     | 'stale'
     | 'takeover'
     | 'disconnected'
-    | 'unavailable';
+    | 'unavailable'
+    | 'start-launch-failed';
 export type ConnectionDiagnosticSocketState = 'connecting' | 'open' | 'stale' | 'closed';
 export type ConnectionDiagnosticReconnectReason = 'dead-socket' | 'stale' | 'closed';
 export type ConnectionDiagnosticChannelPhase = 'attach' | 'socket-open' | 'live' | 'reconnecting' | 'disconnected';
@@ -38,7 +39,7 @@ export type ConnectionDiagnosticEvent =
 
 const MAX_EVENTS = 64;
 const STORAGE_KEY = 'connection-diagnostics-v1';
-const TRACKED = new Set<string>(['herdr.tree', 'terminal.attach', 'terminal.detach', 'session.prompt']);
+const TRACKED = new Set<string>(['herdr.tree', 'terminal.attach', 'terminal.detach', 'session.prompt', 'session.start']);
 const SOCKET_STATES = new Set<string>(['connecting', 'open', 'stale', 'closed']);
 const RECONNECT_REASONS = new Set<string>(['dead-socket', 'stale', 'closed']);
 const CHANNEL_PHASES = new Set<string>(['attach', 'socket-open', 'live', 'reconnecting', 'disconnected']);
@@ -49,6 +50,7 @@ const CODES = new Set<string>([
     'not-connected', 'connection-lost', 'client-closed', 'request-timeout',
     'ticket-required', 'grant-expired', 'e2ee-required', 'agent-not-ready',
     'dead-socket', 'stale', 'takeover', 'disconnected', 'unavailable',
+    'start-launch-failed',
 ]);
 
 let events: ConnectionDiagnosticEvent[] = loadPersisted();

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
@@ -147,6 +147,10 @@ describe('connection diagnostic codes', () => {
             ok: false,
             error: Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' }),
         }, 0);
+        recordTrackedRpc('session.start', {
+            ok: false,
+            error: Object.assign(new Error('Agent could not start.'), { code: 'start-launch-failed' }),
+        }, 30373);
         recordTerminalChannel('disconnected', { ok: false, code: 'disconnected' });
         recordAgentGate({ kind: 'omp', lifecycle: 'idle', promptable: false, gate: 'not-interactive' });
         recordAgentGate({ kind: 'w1EW:pH', lifecycle: 'idle', promptable: false, gate: 'missing' });
@@ -154,6 +158,7 @@ describe('connection diagnostic codes', () => {
             expect.objectContaining({ event: 'socket.reconnect', reason: 'dead-socket' }),
             expect.objectContaining({ event: 'rpc', request: 'terminal.attach', outcome: 'timeout', code: 'request-timeout' }),
             expect.objectContaining({ event: 'rpc', request: 'session.prompt', outcome: 'rejected', code: 'agent-not-ready' }),
+            expect.objectContaining({ event: 'rpc', request: 'session.start', outcome: 'rejected', code: 'start-launch-failed' }),
             expect.objectContaining({ event: 'terminal.channel', phase: 'disconnected', outcome: 'unavailable', code: 'disconnected' }),
             expect.objectContaining({ event: 'agent.gate', kind: 'omp', lifecycle: 'idle', promptable: false, gate: 'not-interactive' }),
             expect.objectContaining({ event: 'agent.gate', lifecycle: 'idle', promptable: false, gate: 'missing' }),
@@ -162,6 +167,7 @@ describe('connection diagnostic codes', () => {
         const report = formatConnectionDiagnosticsForReport();
         expect(report).toMatch(/socket\.reconnect dead-socket/);
         expect(report).toMatch(/rpc session\.prompt rejected agent-not-ready/);
+        expect(report).toMatch(/rpc session\.start rejected start-launch-failed/);
         expect(report).toMatch(/agent\.gate omp idle promptable=false not-interactive/);
         expect(report).not.toMatch(/pp_|pwt-|devtok_|machine-|session-|w1EW:pH/);
     });

--- a/apps/mobile/sources/settings/presentation/NativeSettingsMenu.android.tsx
+++ b/apps/mobile/sources/settings/presentation/NativeSettingsMenu.android.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DropdownMenu, DropdownMenuItem } from '@expo/ui/jetpack-compose';
-import { View } from 'react-native';
+import { Text, View } from 'react-native';
 import type { NativeSettingsMenuProps } from './NativeSettingsMenu.types';
 
 export function NativeSettingsMenu({ groups, children, style, flat = false }: NativeSettingsMenuProps) {
@@ -14,7 +14,9 @@ export function NativeSettingsMenu({ groups, children, style, flat = false }: Na
                             onClick={() => group.onSelect(option.key)}
                         >
                             <DropdownMenuItem.Text>
-                                {`${flat ? '' : `${group.label}: `}${option.key === group.selectedKey ? '✓ ' : ''}${option.label}`}
+                                <Text>
+                                    {`${flat ? '' : `${group.label}: `}${option.key === group.selectedKey ? '✓ ' : ''}${option.label}`}
+                                </Text>
                             </DropdownMenuItem.Text>
                         </DropdownMenuItem>
                     )))}

--- a/apps/mobile/sources/spawn/application/homeDockEnvironment.ts
+++ b/apps/mobile/sources/spawn/application/homeDockEnvironment.ts
@@ -89,39 +89,14 @@ export function applyWorktreeSelection(key: string): { sessionType: NewSessionSe
 
 export function visibleDockAgents(
     hostAgentKinds: string[] | null,
-    authoritative: boolean,
+    _authoritative: boolean,
     agentType: NewSessionAgentType,
 ): DockOption[] {
     const visibleKeys = new Set(hostAgentKinds ?? ['shell', agentType]);
-    if (!authoritative) visibleKeys.add(agentType);
+    visibleKeys.add(agentType);
     return DOCK_AGENTS.filter((agent) => visibleKeys.has(agent.key));
 }
 
 export function currentDockAgent(available: DockOption[], agentType: NewSessionAgentType): DockOption {
     return available.find((agent) => agent.key === agentType) ?? available[0] ?? DOCK_AGENTS[0];
-}
-
-/** When the host catalog no longer includes the draft Agent, pick the first working one. */
-export function agentTypeIfHostDisallows(
-    agentType: NewSessionAgentType,
-    hostAgentKinds: string[] | null,
-    authoritative: boolean,
-    availableAgents: DockOption[],
-): NewSessionAgentType | null {
-    if (!authoritative) return null;
-
-    const hostHasWorkingAgent = hostAgentKinds !== null && hostAgentKinds.some((kind) => kind !== 'shell');
-    if (hostHasWorkingAgent && hostAgentKinds !== null && !hostAgentKinds.includes(agentType)) {
-        const hostPick = hostAgentKinds.find((kind) => kind !== 'shell');
-        if (hostPick !== undefined) return hostPick as NewSessionAgentType;
-    }
-
-    const catalogHasWorkingAgent = availableAgents.some((agent) => agent.key !== 'shell');
-    const currentIsVisible = availableAgents.some((agent) => agent.key === agentType);
-    if (catalogHasWorkingAgent && !currentIsVisible) {
-        const catalogPick = availableAgents.find((agent) => agent.key !== 'shell');
-        if (catalogPick !== undefined) return catalogPick.key as NewSessionAgentType;
-    }
-
-    return null;
 }

--- a/apps/mobile/sources/spawn/presentation/HomeDock.tsx
+++ b/apps/mobile/sources/spawn/presentation/HomeDock.tsx
@@ -36,7 +36,6 @@ import { sync } from '@/catalog/sync';
 import { resolveAgentCatalog } from '@/catalog';
 import {
     applyWorktreeSelection,
-    agentTypeIfHostDisallows,
     currentDockAgent,
     projectDockOptions,
     resolveDockOption,
@@ -569,7 +568,11 @@ export const HomeDock = React.memo(({
         });
         return () => { cancelled = true; };
     }, [socketStatus.status]);
-    const availableAgents = visibleDockAgents(hostAgentKinds, hostAgentKindsAuthoritative, agentType);
+    // A fresh array each render re-renders the option list forever.
+    const availableAgents = React.useMemo(
+        () => visibleDockAgents(hostAgentKinds, hostAgentKindsAuthoritative, agentType),
+        [hostAgentKinds, hostAgentKindsAuthoritative, agentType],
+    );
     const currentAgent = currentDockAgent(availableAgents, agentType);
     const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
@@ -705,11 +708,6 @@ export const HomeDock = React.memo(({
     const selectAgent = React.useCallback((agent: NewSessionAgentType) => {
         setAgentType(agent);
     }, [setAgentType]);
-
-    React.useEffect(() => {
-        const next = agentTypeIfHostDisallows(agentType, hostAgentKinds, hostAgentKindsAuthoritative, availableAgents);
-        if (next !== null) selectAgent(next);
-    }, [agentType, availableAgents, hostAgentKinds, hostAgentKindsAuthoritative, selectAgent]);
 
     type SettingsRow = {
         page: string;


### PR DESCRIPTION
Starting an agent from the phone was unreliable in several independent ways. Each one is a separate root cause, found by driving real starts on a device and reading the host journal.

## What was broken

**Cursor / Kiro never started.** muxr probed the *kind name* on `PATH`, but Herdr launches a different binary — `cursor-agent`, `kiro-cli`. The catalog reported them missing, and the dock then silently rewrote the pick to whatever the host did report. That is why choosing Pi or Cursor could land you in Codex.

**A launch was accepted as soon as *any* session appeared.** A Codex detection could be adopted onto a Pi launch. Adoption now requires the published kind to match the requested one.

**Kinds that skip screen detection never start.** `omp` and `mastracode` never report `interactive_ready`, but readiness demanded `=== true`, so the launch was rejected ~1s in while the agent was still coming up. Readiness now uses the single `herdrAgentIsPromptable` rule everywhere instead of two disagreeing predicates.

**The first prompt was dropped.** It was sent before the agent could accept it and died as `Agent is not ready yet`. `promptSession` now waits for the agent to actually become promptable, then sends.

**A literal `~` cwd failed.** Clients that never learned the machine's home directory send `~` as-is. Expanded host-side in `startAgent`, where every start path routes through.

**`session.created` could be lost.** `routes.bind()` consumes its `created` flag, and in the new start path that happens before `syncDiscovery` runs. The event is now held until its session resolves.

## Diagnostics

`agent.launch` records the `detected` kind next to the requested one, so a mismatch names both sides instead of only saying `rejected`. This is what made the `omp` failure findable.

## Verification

Real agents on a live stack, started through the host and prompted immediately:

- `omp` → `PROMPT OK after 3342ms`, agent replied *"Hi! What can I help you with in /home/umer/bot?"*
- `cursor` → `PROMPT OK after 4098ms`, agent replied *"Hi. What do you want to work on?"*
- Cursor starts as `cursor` with `interactive_ready: true` — previously never started.

`tsc --build` clean; `layoutSelfCheck` passes; suite at 32/34.

The two failing suites (`e2e: herdr backend loop`, `e2e: worktree session`) fail on `Agent close plugin RPC is unavailable or changed`, which **also fails on a clean tree** — verified by stashing this branch and re-running. Pre-existing, not from this change. An earlier revision of this branch did regress `session.created`; that was caught by the same suite and is fixed here.

## Mobile

- Keep the chosen agent instead of substituting an available one.
- Wrap the dropdown label in `<Text>` — it was throwing *"Text strings must be rendered within a `<Text>` component"* and the resulting dev redbox blocked the dock.
- Memoize `availableAgents`; a fresh array each render re-rendered the option list continuously.

Mobile changes are compiled and type-checked but not yet proven on a device build.
