### PR TITLE
docs: pin TestFlight 0.1.24 build 45

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ muxr
 Then install the mobile companion:
 
 - **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the latest signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS)
-- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now
+- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — 0.1.24 (build 45); Apple is not accepting new testers right now
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
 - **All builds:** [muxr 0.1.24 release](https://github.com/umeranjum17/muxr/releases/tag/v0.1.24)
 

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -17,7 +17,7 @@ The convenience installer at `https://raw.githubusercontent.com/umeranjum17/muxr
 
 First run:
 
-1. Install muxr on Android from Google Play testing or the [signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk), verified by [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS). On iOS, open the [public TestFlight link](https://testflight.apple.com/join/aJSbs8pN); Apple is not accepting new testers right now.
+1. Install muxr on Android from Google Play testing or the [signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk), verified by [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS). On iOS, open the [public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) for 0.1.24 (build 45); Apple is not accepting new testers right now.
 2. Run `muxr`. It checks the computer, installs Herdr if needed, and asks how the phone should connect. Start with LAN when both devices use the same wifi.
 3. Review the short plan, choose **Apply setup**, then scan the one-use QR from the phone app.
 


### PR DESCRIPTION
## Summary
- Pin README and npm install copy to iOS TestFlight **0.1.24 (build 45)** now that the Mac IPA is TestFlight-visible.
- Public link is unchanged: https://testflight.apple.com/join/aJSbs8pN
- GitHub release `v0.1.24` notes already updated (Android APK build 52 + TestFlight build 45). This PR is the repo copy only.

## Release proof
- Marketing version: `0.1.24`
- iOS build number: `45`
- IPA SHA-256: `884e383f899a38182af88a9e7b3e71f3d071cc9fb0aa24b592cdfcbc9bad1e30`
- Source commit: `ff9207dcf8c5fb091bbac67888e449ed43924922`
- ASC processingState: `VALID` / TestFlight-visible
- Play Internal upload remains skipped.

## Test plan
- [x] README iOS line names 0.1.24 (build 45)
- [x] `docs/npm-readme.md` names the same build
- [ ] Confirm the public TestFlight link still opens

Made with [Cursor](https://cursor.com)