### PR TITLE
fix: stop the send button looking disabled on an idle agent

### DIFF
--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -775,7 +775,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     <PluginSlot slot="session.composer.trailing" context={{ sessionId: props.id, getText: () => draftRef.current, setText: setDraft }} />
                 </View>
                 <Pressable onPress={sendPrompt} hitSlop={8} disabled={!canSend} accessibilityRole="button" accessibilityLabel="Send" accessibilityState={{ disabled: !canSend }} style={{ opacity: canSend ? 1 : 0.4 }}>
-                    <Ionicons name="arrow-up-circle" size={30} color={headerStatus.color} />
+                    <Ionicons name="arrow-up-circle" size={30} color={theme.colors.accent} />
                 </Pressable>
             </View>
             </View>}


### PR DESCRIPTION
## Summary
The composer send arrow took its colour from `headerStatus.color`, which comes from the agent lifecycle. An idle agent falls through `agentStatusColor` to `status.disconnected` — grey. So a promptable pane with text typed rendered a grey arrow that reads as disabled.

Colour it by `theme.colors.accent`. The existing `opacity: canSend ? 1 : 0.4` already carries the disabled state, so enabled is now bright and disabled is a dimmed accent.

The header status text still uses the lifecycle colour, which is correct there.

## Test plan
- [x] `tsc --build` clean
- [ ] Idle agent + typed text shows a bright send arrow
- [ ] Empty composer still shows the dimmed arrow