### PR TITLE
fix: make starting an agent from the Dock smooth

### DIFF
--- a/apps/mobile/sources/catalog/application/sync.ts
+++ b/apps/mobile/sources/catalog/application/sync.ts
@@ -658,11 +658,9 @@ class MuxrSync {
     async sendMessage(sessionId: string, text: string, options?: SendMessageOptions): Promise<void> {
         const previews = options?.attachments ?? [];
         if (text.trim().length === 0 && previews.length === 0) return;
-        if (storage.getState().sessions[sessionId]?.metadata?.promptable !== true) {
-            const error = Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' });
-            recordTrackedRpc('session.prompt', { ok: false, error }, 0);
-            throw error;
-        }
+        // Readiness is the host's call: it waits for a starting agent to accept
+        // the prompt. Refusing here on cached metadata drops the first prompt
+        // during the seconds before the tree reports the agent promptable.
         // No optimistic echo: the host emits message.append for the prompt, so the
         // transcript fold owns ordering and there is nothing to reconcile.
         // Steer, don't follow up: a message typed mid-turn is a correction, so it

--- a/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
+++ b/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
@@ -14,6 +14,8 @@ export type StartAgentFromDockCommand = {
     prompt: string;
     attachments: unknown[];
     createCwd?: boolean;
+    /** Fires once the route exists, before the first prompt is delivered. */
+    onRouteReady?: (sessionId: string) => void;
 };
 
 export type StartAgentFromDockResult =
@@ -49,6 +51,9 @@ export async function startAgentFromDock(command: StartAgentFromDockCommand): Pr
     }
 
     await sync.refreshSessions();
+    // The host holds the first prompt until the agent can accept it, which is
+    // seconds for some kinds. Show the session now instead of a dead Dock.
+    command.onRouteReady?.(result.sessionId);
     if (command.prompt || command.attachments.length > 0) {
         try {
             await sync.sendMessage(result.sessionId, command.prompt, {

--- a/apps/mobile/sources/spawn/application/startSessionFromDraft.ts
+++ b/apps/mobile/sources/spawn/application/startSessionFromDraft.ts
@@ -44,14 +44,16 @@ export async function startSessionFromDraft(options: {
             prompt: blank ? '' : draft.input.trim(),
             attachments: blank ? [] : draft.attachments,
             createCwd,
+            onRouteReady: (sessionId) => {
+                if (!blank) {
+                    draft.setInput('');
+                    draft.setAttachments([]);
+                }
+                options.navigateToSession(sessionId);
+            },
         });
         if (result.ok) {
-            if (!blank) {
-                draft.setInput('');
-                draft.setAttachments([]);
-            }
             if (result.promptFailed) Modal.alert(t('common.error'), result.promptFailed);
-            options.navigateToSession(result.agentRoute);
             return result.agentRoute;
         }
         if (result.reason === 'needs-directory' && !createCwd) {


### PR DESCRIPTION
## Symptom
Starting a new agent from the Dock popped **"Agent is not ready yet"** every time, while the agent was visibly up at its prompt.

## Root cause 1 — the popup
`sync.sendMessage` refused whenever *cached* session metadata said the pane was not promptable:

```ts
if (storage.getState().sessions[sessionId]?.metadata?.promptable !== true) throw ...
```

A freshly started agent is not promptable for the first few seconds. Measured against the real host, Codex publishes `promptable=false` until ~5s:

```
+1557ms  promptable=false lifecycle=unknown
+4006ms  promptable=false lifecycle=unknown
+5132ms  promptable=true  lifecycle=idle
```

The Dock sends its first prompt inside that window, so the client threw before the host ever saw it. The host already waits for a starting agent to become promptable — this check only contradicted it and ate the prompt.

## Root cause 2 — the dead Dock
Removing that check exposed the next problem: `startSessionFromDraft` navigated only after `startAgentFromDock` fully resolved, and that now includes the host waiting for the agent. So Send sat on an unresponsive Dock for the whole boot.

Navigation now fires as soon as the route exists; the prompt lands behind the terminal that is already on screen.

## Emulator verification
Codex from the Dock, project `~`, prompt typed:

| | before | after |
|---|---|---|
| popup | "Agent is not ready yet" | none |
| navigate | ~3s, after prompt delivery | ~1.5s, on route |
| composer | flashes "Agent is not ready yet" | "Type a prompt…" |
| prompt | dropped | lands |

Verified on a live emulator paired to the real host: `hello` reached the agent, header read `codex/yak`, `~` resolved correctly.

Also fixes the worktree handoff, which prompts a just-created agent through the same path.

## Test plan
- [x] `tsc --build` clean
- [x] `sessionSync.integration.spec.ts` + `muxrClient.spec.ts` pass
- [x] Emulator: start Codex from the Dock with a prompt — no popup, prompt lands, immediate navigation