### PR TITLE
fix: keep the send button lifecycle colour, brighten only idle

### DIFF
--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -407,7 +407,11 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     const labels = agentLabels(currentPane);
     const shell = isShellLabels(labels);
     const contextTitle = shell ? 'Shell' : labels.taskTitle;
-    const headerStatus = agentStatusColor(terminalPaneStatus(currentPane), theme);
+    const headerLifecycle = terminalPaneStatus(currentPane);
+    const headerStatus = agentStatusColor(headerLifecycle, theme);
+    // Working and done carry their lifecycle colour. Idle shares the
+    // disconnected grey, which reads as dead on a ready agent.
+    const sendColor = headerLifecycle === 'idle' ? theme.colors.accent : headerStatus.color;
     const paneIndex = siblings.indexOf(props.id);
     const showConnectingStatus = status !== 'live' && gestureHint === null && status === 'connecting';
     const showRetryStatus = status !== 'live' && gestureHint === null && status !== 'connecting';
@@ -775,7 +779,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     <PluginSlot slot="session.composer.trailing" context={{ sessionId: props.id, getText: () => draftRef.current, setText: setDraft }} />
                 </View>
                 <Pressable onPress={sendPrompt} hitSlop={8} disabled={!canSend} accessibilityRole="button" accessibilityLabel="Send" accessibilityState={{ disabled: !canSend }} style={{ opacity: canSend ? 1 : 0.4 }}>
-                    <Ionicons name="arrow-up-circle" size={30} color={theme.colors.accent} />
+                    <Ionicons name="arrow-up-circle" size={30} color={sendColor} />
                 </Pressable>
             </View>
             </View>}


### PR DESCRIPTION
## Summary
0.1.25 fixed the dull idle send button by painting every state with the accent. That was too broad — it threw away the working blue and done green, which were the good part.

Idle is the only state that reads wrong: `agentStatusColor` has no `idle` case, so it falls through to `status.disconnected` grey and a ready agent looks dead. Give idle the accent and leave every other lifecycle colour alone.

| lifecycle | colour |
|---|---|
| working / starting | `status.working` blue |
| done | `status.done` green |
| blocked / failed | `status.error` red |
| **idle** | **accent (was disconnected grey)** |

The header status text keeps the full lifecycle colour including grey for idle, which is correct there.

## Test plan
- [x] `tsc --build` clean
- [x] Emulator: done agent shows the green filled arrow again
- [ ] Idle agent with text shows the bright arrow