### PR TITLE
fix: make starting an agent smooth

### DIFF
--- a/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
+++ b/apps/mobile/sources/catalog/application/sessionSync.integration.spec.ts
@@ -378,7 +378,8 @@ describe('session sync flow', () => {
         }).toEqual({
             tabStatus: 'working',
             paneStatus: 'unknown',
-            canSend: false,
+            // A booting agent still accepts a prompt; the host holds it.
+            canSend: true,
             readyStatus: 'working',
             readyCanSend: true,
         });

--- a/apps/mobile/sources/catalog/application/sync.ts
+++ b/apps/mobile/sources/catalog/application/sync.ts
@@ -658,11 +658,9 @@ class MuxrSync {
     async sendMessage(sessionId: string, text: string, options?: SendMessageOptions): Promise<void> {
         const previews = options?.attachments ?? [];
         if (text.trim().length === 0 && previews.length === 0) return;
-        if (storage.getState().sessions[sessionId]?.metadata?.promptable !== true) {
-            const error = Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' });
-            recordTrackedRpc('session.prompt', { ok: false, error }, 0);
-            throw error;
-        }
+        // Readiness is the host's call: it waits for a starting agent to accept
+        // the prompt. Refusing here on cached metadata drops the first prompt
+        // during the seconds before the tree reports the agent promptable.
         // No optimistic echo: the host emits message.append for the prompt, so the
         // transcript fold owns ordering and there is nothing to reconcile.
         // Steer, don't follow up: a message typed mid-turn is a correction, so it

--- a/apps/mobile/sources/herd/presentation/MainView.tsx
+++ b/apps/mobile/sources/herd/presentation/MainView.tsx
@@ -444,8 +444,11 @@ export const MainView = React.memo(() => {
     const handleHomePromptSubmit = React.useCallback(async (): Promise<boolean> => {
         const prompt = homePrompt.trim();
         const attachments = useNewSessionDraft.getState().attachments;
+        // No prompt is a deliberate choice: open the session and let the agent
+        // boot while you decide what to ask it.
         if (!prompt && attachments.length === 0) {
-            return false;
+            Keyboard.dismiss();
+            return await startHomeSession({ blank: true }) !== null;
         }
         useNewSessionDraft.getState().setInput(prompt);
         Keyboard.dismiss();

--- a/apps/mobile/sources/herd/presentation/MainView.tsx
+++ b/apps/mobile/sources/herd/presentation/MainView.tsx
@@ -444,11 +444,8 @@ export const MainView = React.memo(() => {
     const handleHomePromptSubmit = React.useCallback(async (): Promise<boolean> => {
         const prompt = homePrompt.trim();
         const attachments = useNewSessionDraft.getState().attachments;
-        // No prompt is a deliberate choice: open the session and let the agent
-        // boot while you decide what to ask it.
         if (!prompt && attachments.length === 0) {
-            Keyboard.dismiss();
-            return await startHomeSession({ blank: true }) !== null;
+            return false;
         }
         useNewSessionDraft.getState().setInput(prompt);
         Keyboard.dismiss();
@@ -456,6 +453,13 @@ export const MainView = React.memo(() => {
         if (sessionId) setHomePrompt('');
         return sessionId !== null;
     }, [homePrompt, startHomeSession]);
+
+    // Opening a session with no prompt is a deliberate choice: pick the agent,
+    // directory and worktree, then write once it is up.
+    const handleStartBlankSession = React.useCallback(async (): Promise<boolean> => {
+        Keyboard.dismiss();
+        return await startHomeSession({ blank: true }) !== null;
+    }, [startHomeSession]);
 
     const handleSearchPress = React.useCallback(() => {
         setSearchActive((currentValue) => {
@@ -601,6 +605,7 @@ export const MainView = React.memo(() => {
                             prompt={homePrompt}
                             onPromptChange={setHomePrompt}
                             onSubmit={handleHomePromptSubmit}
+                            onStartBlank={handleStartBlankSession}
                             isSubmitting={isStartingHomeSession}
                         />
                     )}

--- a/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
+++ b/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
@@ -5,6 +5,9 @@ import { isMachineOnline } from '@/pairing';
 import { createWorktree } from '../infrastructure/worktree';
 import { WorktreeSelection } from '../domain/WorktreeSelection';
 import type { NewSessionAgentType } from '@/catalog/application/persistence';
+import type { AttachmentPreview } from '@/catalog/infrastructure/attachmentTypes';
+import { readFileBytes } from '@/utils/readFileBytes';
+import { encodeBase64 } from '@/encryption/base64';
 
 export type StartAgentFromDockCommand = {
     machine: Machine | undefined;
@@ -21,6 +24,29 @@ export type StartAgentFromDockCommand = {
 export type StartAgentFromDockResult =
     | { ok: true; agentRoute: string; promptFailed?: string }
     | { ok: false; reason: 'no-machine' | 'offline' | 'worktree-failed' | 'needs-directory' | 'failed'; message?: string; directory?: string };
+
+/**
+ * The agent is a TUI, so it reaches a file by having its path in the prompt.
+ * Save the images to the host over the session socket, the same way the
+ * terminal composer does, and append the paths it returns.
+ */
+async function promptWithAttachmentPaths(
+    sessionId: string,
+    prompt: string,
+    previews: unknown[],
+): Promise<string> {
+    if (previews.length === 0) return prompt;
+    const attachments = [];
+    for (const preview of previews as AttachmentPreview[]) {
+        attachments.push({
+            name: preview.name,
+            mimeType: preview.mimeType,
+            data: encodeBase64(await readFileBytes(preview.uri)),
+        });
+    }
+    const saved = await sync.request('session.saveAttachments', { sessionId, attachments });
+    return [prompt.trim(), ...saved.savedPaths].filter((part) => part !== '').join(' ');
+}
 
 /** Spawn from the Dock: Machine, directory, Worktree, and Agent Kind are already chosen. */
 export async function startAgentFromDock(command: StartAgentFromDockCommand): Promise<StartAgentFromDockResult> {
@@ -56,10 +82,8 @@ export async function startAgentFromDock(command: StartAgentFromDockCommand): Pr
     command.onRouteReady?.(result.sessionId);
     if (command.prompt || command.attachments.length > 0) {
         try {
-            await sync.sendMessage(result.sessionId, command.prompt, {
-                source: 'new_session',
-                attachments: command.attachments as never,
-            });
+            const text = await promptWithAttachmentPaths(result.sessionId, command.prompt, command.attachments);
+            await sync.sendMessage(result.sessionId, text, { source: 'new_session' });
         } catch (error) {
             return {
                 ok: true,

--- a/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
+++ b/apps/mobile/sources/spawn/application/StartAgentFromDock.ts
@@ -14,6 +14,8 @@ export type StartAgentFromDockCommand = {
     prompt: string;
     attachments: unknown[];
     createCwd?: boolean;
+    /** Fires once the route exists, before the first prompt is delivered. */
+    onRouteReady?: (sessionId: string) => void;
 };
 
 export type StartAgentFromDockResult =
@@ -48,7 +50,10 @@ export async function startAgentFromDock(command: StartAgentFromDockCommand): Pr
         return { ok: false, reason: 'needs-directory', directory: result.directory, message: result.directory };
     }
 
-    await sync.refreshSessions();
+    // machineSpawnNewSession already refreshed until the session was listed.
+    // The host holds the first prompt until the agent can accept it, which is
+    // seconds for some kinds. Show the session now instead of a dead Dock.
+    command.onRouteReady?.(result.sessionId);
     if (command.prompt || command.attachments.length > 0) {
         try {
             await sync.sendMessage(result.sessionId, command.prompt, {

--- a/apps/mobile/sources/spawn/presentation/HomeDock.tsx
+++ b/apps/mobile/sources/spawn/presentation/HomeDock.tsx
@@ -574,7 +574,10 @@ export const HomeDock = React.memo(({
         [hostAgentKinds, hostAgentKindsAuthoritative, agentType],
     );
     const currentAgent = currentDockAgent(availableAgents, agentType);
-    const canSubmit = !isSubmitting && (prompt.trim().length > 0 || selectedImages.length > 0);
+    const hasPrompt = prompt.trim().length > 0 || selectedImages.length > 0;
+    // Without a prompt the button still starts the session; you write once the
+    // agent is up rather than composing against an agent that does not exist.
+    const canSubmit = !isSubmitting;
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
     const keyboardStyle = useAnimatedStyle(() => ({
         // Keyboard height includes the bottom safe area on iOS. The resting
@@ -807,7 +810,7 @@ export const HomeDock = React.memo(({
                     disabled={!canSubmit}
                     style={[styles.sendButton, canSubmit && styles.sendButtonActive]}
                     accessibilityRole="button"
-                    accessibilityLabel="Send"
+                    accessibilityLabel={hasPrompt ? 'Send' : 'Start session'}
                 >
                     {isSubmitting ? (
                         <ActivityIndicator size="small" color={theme.colors.textSecondary} />
@@ -873,7 +876,7 @@ export const HomeDock = React.memo(({
                             accessibilityRole="button"
                             accessibilityLabel="Add image"
                         >
-                            <Ionicons name="add" size={26} color={theme.colors.text} />
+                            <Ionicons name="image-outline" size={24} color={theme.colors.text} />
                         </BubblePressable>
                         <NativeSettingsMenu groups={gearSettingsGroups} style={styles.nativeGearMenu}>
                             <View style={styles.sideButton}>
@@ -894,7 +897,7 @@ export const HomeDock = React.memo(({
                             disabled={!canSubmit}
                             style={[styles.sendButton, styles.focusedSendButton, canSubmit && styles.sendButtonActive]}
                             accessibilityRole="button"
-                            accessibilityLabel="Send"
+                            accessibilityLabel={hasPrompt ? 'Send' : 'Start session'}
                         >
                         {isSubmitting ? (
                             <ActivityIndicator size="small" color={theme.colors.textSecondary} />

--- a/apps/mobile/sources/spawn/presentation/HomeDock.tsx
+++ b/apps/mobile/sources/spawn/presentation/HomeDock.tsx
@@ -247,6 +247,22 @@ const styles = StyleSheet.create((theme) => ({
     sendButtonActive: {
         backgroundColor: theme.colors.fab.background,
     },
+    // Starting without a prompt is its own action, not a mode of the send
+    // button, so it gets its own row under the pickers.
+    startRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        height: 52,
+        borderRadius: 18,
+        backgroundColor: theme.colors.fab.background,
+    },
+    startRowText: {
+        color: theme.colors.fab.icon,
+        fontSize: 15,
+        fontWeight: '600',
+    },
     modalRoot: {
         flex: 1,
     },
@@ -448,11 +464,13 @@ export const HomeDock = React.memo(({
     prompt,
     onPromptChange,
     onSubmit,
+    onStartBlank,
     isSubmitting,
 }: {
     prompt: string;
     onPromptChange: (prompt: string) => void;
     onSubmit: () => Promise<boolean>;
+    onStartBlank: () => Promise<boolean>;
     isSubmitting: boolean;
 }) => {
     const { theme } = useUnistyles();
@@ -575,9 +593,7 @@ export const HomeDock = React.memo(({
     );
     const currentAgent = currentDockAgent(availableAgents, agentType);
     const hasPrompt = prompt.trim().length > 0 || selectedImages.length > 0;
-    // Without a prompt the button still starts the session; you write once the
-    // agent is up rather than composing against an agent that does not exist.
-    const canSubmit = !isSubmitting;
+    const canSubmit = !isSubmitting && hasPrompt;
     const focusedComposerHeight = selectedImages.length > 0 ? 206 : 126;
     const keyboardStyle = useAnimatedStyle(() => ({
         // Keyboard height includes the bottom safe area on iOS. The resting
@@ -810,7 +826,7 @@ export const HomeDock = React.memo(({
                     disabled={!canSubmit}
                     style={[styles.sendButton, canSubmit && styles.sendButtonActive]}
                     accessibilityRole="button"
-                    accessibilityLabel={hasPrompt ? 'Send' : 'Start session'}
+                    accessibilityLabel="Send"
                 >
                     {isSubmitting ? (
                         <ActivityIndicator size="small" color={theme.colors.textSecondary} />
@@ -839,6 +855,13 @@ export const HomeDock = React.memo(({
         setFocusModeVisible(false);
         setIsFocused(false);
         void submit();
+    };
+
+    const startBlankSession = () => {
+        if (isSubmitting) return;
+        setFocusModeVisible(false);
+        setIsFocused(false);
+        void onStartBlank();
     };
 
     const renderFocusedComposer = () => (
@@ -897,7 +920,7 @@ export const HomeDock = React.memo(({
                             disabled={!canSubmit}
                             style={[styles.sendButton, styles.focusedSendButton, canSubmit && styles.sendButtonActive]}
                             accessibilityRole="button"
-                            accessibilityLabel={hasPrompt ? 'Send' : 'Start session'}
+                            accessibilityLabel="Send"
                         >
                         {isSubmitting ? (
                             <ActivityIndicator size="small" color={theme.colors.textSecondary} />
@@ -984,6 +1007,18 @@ export const HomeDock = React.memo(({
                         <View style={styles.focusConfig}>
                             <View style={styles.focusConfigGroup}>
                                 {renderEnvironmentPickers()}
+                                <FocusConfigRevealRow progress={focusPresentation} index={3}>
+                                    <BubblePressable
+                                        onPress={startBlankSession}
+                                        disabled={isSubmitting}
+                                        style={styles.startRow}
+                                        accessibilityRole="button"
+                                        accessibilityLabel={`Start ${currentAgent.name} without a prompt`}
+                                    >
+                                        <Ionicons name="play" size={16} color={theme.colors.fab.icon} />
+                                        <Text style={styles.startRowText}>Start {currentAgent.name}</Text>
+                                    </BubblePressable>
+                                </FocusConfigRevealRow>
                             </View>
                         </View>
                         <View style={[

--- a/apps/mobile/sources/terminal/domain/promptAvailability.ts
+++ b/apps/mobile/sources/terminal/domain/promptAvailability.ts
@@ -4,6 +4,11 @@ export function terminalPaneStatus(pane: HerdrTreePane | undefined): AgentLifecy
     return pane?.promptable === true ? pane.agentStatus : 'unknown';
 }
 
+/**
+ * A pane running an agent accepts a prompt even before it is promptable: the
+ * host holds the prompt until the agent can take it. A pane with no agent has
+ * nothing to prompt.
+ */
 export function terminalPaneCanSend(pane: HerdrTreePane | undefined, hasContent: boolean): boolean {
-    return pane?.promptable === true && hasContent;
+    return pane?.agentKind !== undefined && hasContent;
 }

--- a/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
+++ b/apps/mobile/sources/terminal/presentation/TerminalScreen.tsx
@@ -299,14 +299,8 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     // lands it in the middle of whatever you were typing, so paths ride as
     // chips and are appended once, at send.
     const sendPrompt = React.useCallback(() => {
-        if (!panePromptable) {
-            recordTrackedRpc('session.prompt', {
-                ok: false,
-                error: Object.assign(new Error('Agent is not ready yet'), { code: 'agent-not-ready' }),
-            }, 0);
-            Modal.alert('Not ready', 'Agent is not ready yet');
-            return;
-        }
+        // A booting agent is not a refusal: the host holds the prompt until it
+        // can accept it, so let the composer stay live and let the host answer.
         const text = [draftRef.current.trim(), ...attachedPaths].filter((part) => part !== '').join(' ');
         if (text === '') return;
         const previousDraft = draftRef.current;
@@ -407,7 +401,11 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
     const labels = agentLabels(currentPane);
     const shell = isShellLabels(labels);
     const contextTitle = shell ? 'Shell' : labels.taskTitle;
-    const headerStatus = agentStatusColor(terminalPaneStatus(currentPane), theme);
+    const headerLifecycle = terminalPaneStatus(currentPane);
+    const headerStatus = agentStatusColor(headerLifecycle, theme);
+    // Working and done carry their lifecycle colour. Idle shares the
+    // disconnected grey, which reads as dead on a ready agent.
+    const sendColor = headerLifecycle === 'idle' ? theme.colors.accent : headerStatus.color;
     const paneIndex = siblings.indexOf(props.id);
     const showConnectingStatus = status !== 'live' && gestureHint === null && status === 'connecting';
     const showRetryStatus = status !== 'live' && gestureHint === null && status !== 'connecting';
@@ -749,18 +747,17 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     borderTopColor: theme.colors.divider,
                 }}
             >
-                <Pressable onPress={attachPhotos} hitSlop={8} disabled={attaching || !panePromptable} accessibilityRole="button" accessibilityLabel="Add attachment" accessibilityState={{ disabled: attaching || !panePromptable }} style={{ opacity: panePromptable ? 1 : 0.4 }}>
+                <Pressable onPress={attachPhotos} hitSlop={8} disabled={attaching} accessibilityRole="button" accessibilityLabel="Add attachment" accessibilityState={{ disabled: attaching }} style={{ opacity: attaching ? 0.4 : 1 }}>
                     <Ionicons name={attaching ? 'hourglass-outline' : 'image-outline'} size={24} color={theme.colors.textSecondary} />
                 </Pressable>
                 <TextInput
                     value={draft}
                     onChangeText={handleDraftChange}
-                    editable={panePromptable}
                     onSubmitEditing={sendPrompt}
                     returnKeyType="send"
                     blurOnSubmit
                     submitBehavior="blurAndSubmit"
-                    placeholder={panePromptable ? 'Type a prompt…' : 'Agent is not ready yet'}
+                    placeholder="Type a prompt…"
                     placeholderTextColor={theme.colors.textSecondary}
                     style={{
                         flex: 1,
@@ -775,7 +772,7 @@ export const TerminalScreen = React.memo((props: { id: string }) => {
                     <PluginSlot slot="session.composer.trailing" context={{ sessionId: props.id, getText: () => draftRef.current, setText: setDraft }} />
                 </View>
                 <Pressable onPress={sendPrompt} hitSlop={8} disabled={!canSend} accessibilityRole="button" accessibilityLabel="Send" accessibilityState={{ disabled: !canSend }} style={{ opacity: canSend ? 1 : 0.4 }}>
-                    <Ionicons name="arrow-up-circle" size={30} color={theme.colors.accent} />
+                    <Ionicons name="arrow-up-circle" size={30} color={sendColor} />
                 </Pressable>
             </View>
             </View>}


### PR DESCRIPTION
Supersedes #192 and #193.

## Symptom
Starting an agent popped **"Agent is not ready yet"** every time, then left the Dock unresponsive while the agent booted. Attaching an image from the Dock failed outright.

## Causes

**1. The client refused before the host saw it.** `sync.sendMessage` threw on cached metadata. Measured against the real host, Codex is not promptable until ~5s:

```
+1557ms  promptable=false lifecycle=unknown
+4006ms  promptable=false lifecycle=unknown
+5132ms  promptable=true  lifecycle=idle
```

The Dock prompts inside that window. The host already waits for a starting agent, so this check only contradicted it and dropped the prompt.

**2. Navigation waited for the prompt** — after fixing 1, that means it waited for the whole boot. Now it navigates as soon as the route exists.

**3. The terminal composer refused too** — "Agent is not ready yet" placeholder, dead send, disabled attach. A pane running an agent now accepts a prompt; the host holds it.

**4. A redundant catalog refresh** in `StartAgentFromDock`; `machineSpawnNewSession` already refreshes until the session is listed.

**5. Dock image attachments used the hosted upload endpoint**, which self-host does not implement — `Network request failed`. They now go over the session socket via `session.saveAttachments`, exactly as the terminal composer already did, and the returned paths are appended to the prompt.

## Starting without a prompt
`blank: true` already worked end to end and was simply unreachable from the UI. It now has its own full-width **Start &lt;agent&gt;** button under the pickers.

Folding it into the send button was tried and rejected: one control inside a text field that changes meaning based on whether you have typed is not readable. Send stays send.

The attach button uses the terminal's `image-outline` rather than a `+`.

## Verification
Emulator paired to the real host, driven end to end.

- **Prompt start** — `session.prompt ok 2383ms`, delivered with no error, landing *behind* the already-visible terminal (`terminal.attach` follows it).
- **Blank start** — Start button opens a live session, composer ready.
- **Image + prompt** — agent replied: *"Viewed Image — It's a blue-to-white gradient test image with the centered text 'muxr test image.'"*

| | before | after |
|---|---|---|
| popup | every start | none |
| navigate | after prompt delivery | on route |
| composer while booting | "Agent is not ready yet", disabled | live |
| Dock image attach | Network request failed | agent reads the image |

`tsc --build` clean. Suite 32/34 — the two failures are `Agent close plugin RPC is unavailable or changed`, which **also fail on a clean tree**.