### PR TITLE
fix: make setup failures actionable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,12 +10,19 @@ body:
     validations:
       required: true
   - type: textarea
+    id: report
+    attributes:
+      label: muxr report
+      description: Run `muxr report`, paste the generated Markdown here, or say why the command is unavailable. It contains environment versions, doctor check names, and bounded redacted diagnostics; raw daemon logs are not required.
+    validations:
+      required: true
+  - type: textarea
     id: host
     attributes:
-      label: Host vs herdr
-      description: Paste `herdr agent list` if this is live behavior, and say whether it agrees with the app. Host log slice from `journalctl --user -u muxr.service` if you have it.
+      label: App vs Herdr
+      description: For live agent behavior, paste `herdr agent list` and say whether it agrees with the app. Omit this for setup/install issues.
   - type: input
     id: version
     attributes:
-      label: Version
-      description: git sha, APK build, or `node scripts/cli.mjs version`
+      label: App version
+      description: Android/iOS app version and build if the report does not already identify it.

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -32,8 +32,9 @@ muxr update                    # check, confirm, update, and restart
 muxr update --check            # check without changing anything
 muxr --skill                   # print the compact agent skill
 muxr skill collaboration       # load one focused reference on demand
-muxr doctor                    # current setup health
+muxr doctor                    # current setup health and checked repairs
 muxr diagnostics               # bounded redacted host/client history for agents
+muxr report > muxr-report.md   # local redacted issue draft; never submits
 muxr pair                      # pair another phone
 muxr pair --browser            # pair an 8-hour control browser
 muxr pair --browser-view       # pair an 8-hour view-only browser
@@ -44,6 +45,8 @@ muxr devices revoke <number>
 muxr never installs skills or edits agent instruction files. Run `muxr --skill`
 for the compact canonical workflow, then `muxr skill <topic>` only when the
 current task needs that reference.
+
+`muxr report` gathers environment versions, doctor check names, and the latest 50 redacted diagnostic events without prompts, terminal output, paths, secrets, or internal ids. It only writes a local draft: review every line, describe what happened, and explicitly decide whether you want to post it. muxr never opens or submits an issue.
 
 muxr state lives under `~/.muxr` unless `MUXR_HOME` is set. Use `muxr setup --dry-run` to preview managed-file changes. `muxr uninstall` removes every muxr-owned operational component—including machine identity, pairings, grants, provider keys, runtime state, services, ingress, and managed integrations—then optionally removes the global CLI. It keeps Herdr, Herdr sessions, repositories, worktrees, received attachments, exports, signing keys, and unrecognized files. The narrower `muxr daemon uninstall` and `muxr integrations uninstall` commands remain available for advanced maintenance.
 

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import { existsSync, realpathSync, readdirSync, readFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { dirname, join, relative } from 'node:path';
-import { homedir } from 'node:os';
+import { homedir, release as kernelRelease } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import {
     BACK,
@@ -13,6 +13,7 @@ import {
     connectEnrollment,
     connectRemoteRelay,
     daemonIsRunning,
+    daemonMode,
     enableBrowserHosting,
     hasPendingRemoteConnect,
     heading,
@@ -46,7 +47,7 @@ import {
     showPluginDocs,
     updatePlugin,
 } from './plugin/index.mjs';
-import { dumpDiagnostics } from './diagnostics/index.mjs';
+import { dumpDiagnostics, readDiagnostics } from './diagnostics/index.mjs';
 import { updateCli } from './release/index.mjs';
 
 const HELP = `muxr — every coding agent on your phone
@@ -57,6 +58,7 @@ Get started
   muxr setup                     install, connect, and pair this machine
   muxr doctor                    check the complete local setup
   muxr diagnostics               show bounded redacted host history for agents
+  muxr report                    prepare a local redacted bug report draft
   muxr pair [--browser|--browser-view] pair a phone or control/view-only browser
   muxr connect --enrollment ...  connect this agent machine to a shared relay
   muxr shared-relay              host an always-on relay for other machines
@@ -103,6 +105,7 @@ const COMMAND_HELP = {
     pair: `muxr pair [--browser|--browser-view]\n\nCreate a two-minute native QR/string, an eight-hour control-browser link (--browser), or an eight-hour view-only browser link (--browser-view).\n`,
     doctor: `muxr doctor\n\nCheck Node, Herdr, integrations, managed files, and the self-host relay without printing secrets.\n`,
     diagnostics: `muxr diagnostics\n\nPrint seven days of bounded redacted host, client, relay, collaboration, and broker history as JSON. No prompts, terminal output, paths, secrets, or internal ids are recorded.\n`,
+    report: `muxr report > muxr-report.md\n\nPrepare a local GitHub issue draft with environment versions, redacted doctor check names, and the latest 50 bounded diagnostic events. The command only prints a draft. Review every line, add what happened, and explicitly decide whether to post it; muxr never opens or submits an issue.\n`,
     status: `muxr status\n\nAlias for muxr doctor.\n`,
     restart: `muxr restart\n\nRestart the supervised relay and host (same as muxr daemon restart).\n`,
     uninstall: `muxr uninstall [--yes|--resume]\n\nRemove all muxr-owned services, ingress, identity, pairings, grants, relay/plugin state, provider keys, logs, caches, and managed integrations. Herdr, its sessions, repositories, worktrees, exports, signing keys, and unrecognized files stay. The globally installed CLI can be removed last.\n`,
@@ -121,6 +124,49 @@ function printHelp(command) {
 function versionString() {
     const require = createRequire(import.meta.url);
     try { return require('./package.json').version; } catch { return require('../package.json').version; }
+}
+
+function commandVersion(command) {
+    const result = spawnSync(command, ['--version'], { encoding: 'utf8', timeout: 5_000 });
+    return `${result.stdout ?? ''}\n${result.stderr ?? ''}`.match(/\b\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?\b/)?.[0] ?? 'unavailable';
+}
+
+function operatingSystem() {
+    if (process.platform !== 'linux' || !existsSync('/etc/os-release')) return `${process.platform} ${process.arch} · kernel ${kernelRelease()}`;
+    const value = readFileSync('/etc/os-release', 'utf8').match(/^PRETTY_NAME=(.*)$/m)?.[1]?.trim();
+    const name = value?.replace(/^"|"$/g, '') || 'Linux';
+    return `${name} ${process.arch} · kernel ${kernelRelease()}`;
+}
+
+function issueReport() {
+    const doctor = spawnSync(process.execPath, [realpathSync(process.argv[1]), 'doctor'], {
+        encoding: 'utf8',
+        timeout: 90_000,
+        env: { ...process.env, MUXR_NO_TUI: '1' },
+    });
+    const checks = `${doctor.stdout ?? ''}\n${doctor.stderr ?? ''}`.split('\n').flatMap((line) => {
+        const match = line.match(/^\s*(ok|warn|FAIL)\s{2,}(.+?)\s{2,}/);
+        return match ? [`- ${match[1].toUpperCase()} ${match[2].trim()}`] : [];
+    });
+    if (checks.length === 0) checks.push(`- UNAVAILABLE ${doctor.error?.code === 'ETIMEDOUT' ? 'doctor timed out after 90 seconds' : 'doctor returned no checks'}`);
+
+    let diagnostics;
+    try {
+        const state = readDiagnostics();
+        diagnostics = JSON.stringify({
+            ...state,
+            note: `${state.note}; report includes the latest 50 events only`,
+            events: state.events.slice(-50).map(({
+                requestedAgentName: _requestedAgentName,
+                resolvedAgentName: _resolvedAgentName,
+                ...event
+            }) => event),
+        }, null, 2);
+    } catch (cause) {
+        diagnostics = JSON.stringify({ unavailable: cause instanceof Error ? cause.message : String(cause) }, null, 2);
+    }
+
+    process.stdout.write(`<!-- DRAFT ONLY: muxr never opens or submits an issue.\nReview every line for sensitive information. If an agent generated this draft, it must show it to the user and ask whether they want to post it before taking any external action.\n-->\n## What happened\n\n<!-- What did you do, what did you expect, and what happened instead? -->\n\n## Steps to reproduce\n\n1. \n\n## Expected behavior\n\n<!-- What should muxr have done? -->\n\n## Environment\n\n- muxr: ${versionString()}\n- Node: ${process.version}\n- OS: ${operatingSystem()}\n- Mode: ${daemonMode() ?? 'not configured'}\n- Herdr: ${commandVersion('herdr')}\n- Tailscale: ${commandVersion('tailscale')}\n\n## Health summary\n\nDoctor ${doctor.status === 0 ? 'completed without blocking failures' : 'found blocking problems or could not finish'}:\n\n${checks.join('\n')}\n\n## Redacted diagnostics\n\n\`\`\`json\n${diagnostics}\n\`\`\`\n`);
 }
 
 function muxrSkillDirectory() {
@@ -395,6 +441,10 @@ async function dispatch(command, args = []) {
     if (command === 'diagnostics') {
         try { dumpDiagnostics(); return 0; }
         catch (error) { process.stderr.write(`muxr diagnostics: ${error instanceof Error ? error.message : String(error)}\n`); return 1; }
+    }
+    if (command === 'report') {
+        try { issueReport(); return 0; }
+        catch (error) { process.stderr.write(`muxr report: ${error instanceof Error ? error.message : String(error)}\n`); return 1; }
     }
     if (command === 'update') return applyUpdate(args);
     if (command === 'daemon') return runDaemon(args);

--- a/scripts/diagnostics/application/checkPackageSmoke.mjs
+++ b/scripts/diagnostics/application/checkPackageSmoke.mjs
@@ -88,6 +88,7 @@ function run(command, args, options = {}) {
 function assertCompactSkillOutput(output) {
     assert.match(output, /^---\nname: muxr\ndescription: /);
     assert.match(output, /## Task router/);
+    assert.match(output, /checked safe repairs/);
     assert.match(output, /muxr skill collaboration/);
     assert.doesNotMatch(output, /muxr-skill-reference|# Cross-machine agent collaboration|## Installed Herdr CLI reference/);
 }
@@ -290,17 +291,34 @@ try {
     assert.match(sourceHelp, /muxr --skill \| muxr skill\s+print the compact muxr agent skill/);
     assert.match(sourceHelp, /muxr peers list\|read\|status\|watch\|prompt/);
     assert.match(sourceHelp, /muxr diagnostics\s+show bounded redacted host history/);
+    assert.match(sourceHelp, /muxr report\s+prepare a local redacted bug report draft/);
     const diagnosticsDir = join(home, '.muxr', 'host');
     mkdirSync(diagnosticsDir, { recursive: true });
     const diagnosticsPath = join(diagnosticsDir, 'diagnostics.json');
-    writeFileSync(diagnosticsPath, `${JSON.stringify({ version: 1, current: { updatedAt: '2026-08-26T00:00:00.000Z' }, events: [{ at: '2026-08-26T00:00:00.000Z', event: 'relay.state', state: 'open' }] })}\n`, { mode: 0o600 });
+    writeFileSync(diagnosticsPath, `${JSON.stringify({
+        version: 1,
+        current: { updatedAt: '2026-08-26T00:00:00.000Z' },
+        events: Array.from({ length: 60 }, (_, sequence) => ({
+            at: '2026-08-26T00:00:00.000Z', event: 'relay.state', state: 'open', sequence,
+            ...(sequence === 59 ? { requestedAgentName: 'private customer task', resolvedAgentName: 'private customer task' } : {}),
+        })),
+    })}\n`, { mode: 0o600 });
     chmodSync(diagnosticsPath, 0o600);
     const sourceDiagnostics = JSON.parse(run(process.execPath, ['scripts/cli.mjs', 'diagnostics'], { env: sourceEnv }).stdout);
     assert.equal(sourceDiagnostics.events[0].event, 'relay.state');
     assert.doesNotMatch(JSON.stringify(sourceDiagnostics), /machineId|deviceId|sessionId|prompt/i);
+    const sourceReport = run(process.execPath, ['scripts/cli.mjs', 'report'], { env: sourceEnv }).stdout;
+    assert.match(sourceReport, /## Environment[\s\S]*## Health summary[\s\S]*## Redacted diagnostics/);
+    assert.match(sourceReport, /relay\.state/);
+    const sourceReportDiagnostics = JSON.parse(sourceReport.match(/```json\n([\s\S]*?)\n```/)?.[1] ?? '{}');
+    assert.equal(sourceReportDiagnostics.events.length, 50);
+    assert.equal(sourceReportDiagnostics.events[0].sequence, 10);
+    assert.match(sourceReport, /DRAFT ONLY[\s\S]*show it to the user and ask whether they want to post/);
+    assert.doesNotMatch(sourceReport, /gh issue create|requestedAgentName|resolvedAgentName|private customer task|machineId|deviceId|sessionId|credential|secret|prompt|\/home\//i);
     const sourceSkill = run(process.execPath, ['scripts/cli.mjs', '--skill'], { env: sourceEnv }).stdout;
     assertCompactSkillOutput(sourceSkill);
     assert.equal(run(process.execPath, ['scripts/cli.mjs', 'skill'], { env: sourceEnv }).stdout, sourceSkill, 'source skill alias diverged from --skill');
+    assert.match(run(process.execPath, ['scripts/cli.mjs', 'skill', 'onboarding'], { env: sourceEnv }).stdout, /## Diagnose and recover[\s\S]*muxr doctor[\s\S]*muxr diagnostics/);
     assert.match(run(process.execPath, ['scripts/cli.mjs', 'skill', 'collaboration'], { env: sourceEnv }).stdout, /muxr peers prompt/);
     assertUnifiedSkillOutput(run(process.execPath, ['scripts/cli.mjs', 'skill', 'all'], { env: sourceEnv }).stdout);
     const fallbackHome = join(scratch, 'skill-fallback-home');
@@ -425,10 +443,17 @@ try {
     assert.match(rootHelp, /muxr --skill \| muxr skill\s+print the compact muxr agent skill/);
     assert.match(rootHelp, /muxr peers list\|read\|status\|watch\|prompt/);
     assert.match(rootHelp, /muxr diagnostics\s+show bounded redacted host history/);
+    assert.match(rootHelp, /muxr report\s+prepare a local redacted bug report draft/);
     assert.equal(JSON.parse(run(cli, ['diagnostics'], { cwd: installDir, env: cliEnv() }).stdout).events[0].event, 'relay.state');
+    const installedReport = run(cli, ['report'], { cwd: installDir, env: cliEnv() }).stdout;
+    assert.match(installedReport, /## Environment[\s\S]*## Health summary[\s\S]*## Redacted diagnostics/);
+    assert.equal(JSON.parse(installedReport.match(/```json\n([\s\S]*?)\n```/)?.[1] ?? '{}').events.length, 50);
+    assert.match(installedReport, /DRAFT ONLY[\s\S]*show it to the user and ask whether they want to post/);
+    assert.doesNotMatch(installedReport, /gh issue create|requestedAgentName|resolvedAgentName|private customer task|machineId|deviceId|sessionId|credential|secret|prompt|\/home\//i);
     const installedSkill = run(cli, ['--skill'], { cwd: installDir, env: cliEnv() }).stdout;
     assertCompactSkillOutput(installedSkill);
     assert.equal(run(cli, ['skill'], { cwd: installDir, env: cliEnv() }).stdout, installedSkill, 'packed skill alias diverged from --skill');
+    assert.match(run(cli, ['skill', 'onboarding'], { cwd: installDir, env: cliEnv() }).stdout, /## Diagnose and recover[\s\S]*muxr doctor[\s\S]*muxr diagnostics/);
     assert.match(run(cli, ['skill', 'collaboration'], { cwd: installDir, env: cliEnv() }).stdout, /muxr peers prompt/);
     assertUnifiedSkillOutput(run(cli, ['skill', 'all'], { cwd: installDir, env: cliEnv() }).stdout);
     const unavailablePeers = run(cli, ['peers', 'list'], { cwd: installDir, env: cliEnv(), allowFailure: true });

--- a/scripts/diagnostics/application/checkSelfhostState.mjs
+++ b/scripts/diagnostics/application/checkSelfhostState.mjs
@@ -3,18 +3,19 @@
  * `muxr` and `muxr doctor` with a raw stack trace — the one command whose job
  * is diagnosing a broken install. Corrupt must also never look like "not
  * configured": reconfiguring would mint a new machine identity and destroy
- * every pairing.
+ * every pairing. This flow also proves an unresponsive local relay port fails
+ * promptly instead of leaving setup waiting forever.
  */
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createServer } from 'node:net';
 
 const scratch = mkdtempSync(join(tmpdir(), 'muxr-selfhost-state-'));
 process.env.MUXR_HOME = scratch;
 process.env.MUXR_NO_SERVICE_COMMANDS = '1';
-const { inspectSetup } = await import('../../setup/index.mjs');
-const { selfhostConfigured, selfhostStateUnreadable, startSelfHost } = await import('../../setup/index.mjs');
+const { ensureSelfhostRelay, inspectSetup, selfhostConfigured, selfhostStateUnreadable, startSelfHost } = await import('../../setup/index.mjs');
 
 assert.equal(selfhostConfigured(), false);
 assert.equal(selfhostStateUnreadable(), false);
@@ -28,4 +29,21 @@ assert.equal(await inspectSetup(), 1, 'doctor must fail over corrupt selfhost st
 writeFileSync(join(scratch, 'selfhost.json'), '{"version":1,"relayPort":8792}\n');
 assert.equal(selfhostConfigured(), true);
 assert.equal(selfhostStateUnreadable(), false);
-process.stdout.write('selfhost state parsing passed\n');
+
+const sockets = new Set();
+const blackhole = createServer((socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+});
+await new Promise((resolve) => blackhole.listen(0, '127.0.0.1', resolve));
+const started = Date.now();
+try {
+    await assert.rejects(ensureSelfhostRelay(blackhole.address().port), /accepts connections but did not answer/);
+    assert.ok(Date.now() - started < 5_000, 'an unresponsive local port stalled setup');
+    assert.equal(existsSync(join(scratch, 'relay', 'relay.pid')), false, 'stalled setup left a relay process behind');
+} finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => blackhole.close(resolve));
+}
+
+process.stdout.write('selfhost state and stalled relay checks passed\n');

--- a/scripts/diagnostics/application/dumpDiagnostics.mjs
+++ b/scripts/diagnostics/application/dumpDiagnostics.mjs
@@ -6,7 +6,7 @@ function diagnosticsPath() {
     return join(process.env.MUXR_HOME?.trim() || join(homedir(), '.muxr'), 'host', 'diagnostics.json');
 }
 
-export function dumpDiagnostics() {
+export function readDiagnostics() {
     const path = diagnosticsPath();
     if (!existsSync(path)) throw new Error('no host diagnostics yet; start muxr and try again');
     const info = lstatSync(path);
@@ -19,8 +19,12 @@ export function dumpDiagnostics() {
     if (state?.version !== 1 || typeof state.current !== 'object' || !Array.isArray(state.events)) {
         throw new Error('host diagnostics use an unsupported schema; update muxr');
     }
-    process.stdout.write(`${JSON.stringify({
+    return {
         note: 'recentClients are unique clients seen during the 15-minute window ending at current.updatedAt, not exact live sockets',
         ...state,
-    }, null, 2)}\n`);
+    };
+}
+
+export function dumpDiagnostics() {
+    process.stdout.write(`${JSON.stringify(readDiagnostics(), null, 2)}\n`);
 }

--- a/scripts/diagnostics/index.mjs
+++ b/scripts/diagnostics/index.mjs
@@ -1,3 +1,3 @@
-export { dumpDiagnostics } from './application/dumpDiagnostics.mjs';
+export { dumpDiagnostics, readDiagnostics } from './application/dumpDiagnostics.mjs';
 export { waitForRelay } from './application/waitForRelay.mjs';
 

--- a/scripts/setup/application/startSelfHost.mjs
+++ b/scripts/setup/application/startSelfHost.mjs
@@ -91,6 +91,7 @@ export async function startSelfHost(args = []) {
         if (web && !existsSync(join(webRoot, 'index.html'))) throw new Error(`web client missing at ${webRoot}; install a package with the web client or pass --web-root`);
         // Missing Tailscale is fine. Broken/unsafe Tailscale status must fail
         // closed; another transport is chosen explicitly, never as a guess.
+        print('  … checking network connection and ingress');
         const tailscale = tailscaleIngress(args);
         const advertise = sameConfiguration && connectionMode === 'cloudflare' && typeof state.relayUrl === 'string' && cloudflaredAlive(state.ingress)
             ? { url: state.relayUrl, note: 'existing Cloudflare quick tunnel', ingress: state.ingress }
@@ -100,6 +101,7 @@ export async function startSelfHost(args = []) {
         if (web && !advertise.url.startsWith('wss://')) throw new Error('--web requires HTTPS (Tailscale Serve, a named HTTPS tunnel, or --advertise wss://...)');
         const bindHost = tailscale || args.includes('--tunnel') || web || explicitAdvertise?.startsWith('wss://') ? '127.0.0.1' : '0.0.0.0';
         const webOrigin = web ? advertise.url.replace(/^wss/, 'https') : undefined;
+        print(`  … checking local relay port ${port}`);
         await ensureSelfhostRelay(port, web ? webRoot : undefined, bindHost, webOrigin, {
             machineId: state.machine.id,
             name: state.machine.name,
@@ -131,6 +133,7 @@ export async function startSelfHost(args = []) {
         if (web) print(`  ✓ web client ${advertise.url.replace(/^ws/, 'http')}`);
         if (relayOnly) {
             if (managedRelay) {
+                print('  … registering and starting the background relay service');
                 if (env('MUXR_NO_SERVICE_COMMANDS') !== '1') await stopOwnedSelfhostRelay();
                 try { await startMuxrDaemon('relay', args, !sameConfiguration || !hostWasRunning); }
                 catch (cause) {
@@ -145,6 +148,7 @@ export async function startSelfHost(args = []) {
             }
             return 0;
         }
+        print('  … registering and starting the background host service');
         if (env('MUXR_NO_SERVICE_COMMANDS') !== '1' && (!sameConfiguration || !hostWasRunning)) await stopOwnedSelfhostRelay();
         await startMuxrDaemon('selfhost', args, !sameConfiguration || !hostWasRunning);
         if (noPair) {

--- a/scripts/setup/index.mjs
+++ b/scripts/setup/index.mjs
@@ -84,6 +84,7 @@ export {
     browserHostingCanEnable,
     browserHostingReady,
     enrollmentPayload,
+    ensureSelfhostRelay,
     hasPendingRemoteConnect,
     resolveAdvertise,
     restartSelfhostRelayIfRunning,

--- a/scripts/setup/infrastructure/daemon.mjs
+++ b/scripts/setup/infrastructure/daemon.mjs
@@ -348,7 +348,7 @@ export async function startMuxrDaemon(mode, args = [], restartRunning = true) {
             const needsRelay = mode === 'selfhost' || mode === 'relay';
             let relayReady = !needsRelay;
             if (needsRelay) {
-                relayReady = await selfhostRelayHealthy(readSelfhostState());
+                relayReady = await selfhostRelayHealthy(readSelfhostState(), 250);
             }
             if (relayReady) {
                 const relayDetail = needsRelay ? '; relay reachable' : '';

--- a/scripts/setup/infrastructure/herdr.mjs
+++ b/scripts/setup/infrastructure/herdr.mjs
@@ -103,7 +103,7 @@ export function runHerdrInstaller() {
             throw new Error('MUXR_HERDR_INSTALLER must be an executable regular file');
         }
         print(`  run reviewed local Herdr installer: ${localInstaller}`);
-        const installed = spawnSync(localInstaller, [], { stdio: 'inherit' });
+        const installed = spawnSync(localInstaller, [], { stdio: 'inherit', timeout: 300_000 });
         if (installed.status !== 0) throw new Error('local Herdr installation failed');
         return;
     }
@@ -112,9 +112,9 @@ export function runHerdrInstaller() {
     const installer = join(scratch, 'install.sh');
     try {
         print(`  download Herdr installer: ${HERDR_INSTALL_URL}`);
-        const downloaded = spawnSync('curl', ['-fsSL', HERDR_INSTALL_URL, '-o', installer], { stdio: 'inherit' });
+        const downloaded = spawnSync('curl', ['-fsSL', '--connect-timeout', '10', '--max-time', '60', HERDR_INSTALL_URL, '-o', installer], { stdio: 'inherit', timeout: 65_000 });
         if (downloaded.status !== 0) throw new Error('Herdr installer download failed');
-        const installed = spawnSync('sh', [installer], { stdio: 'inherit' });
+        const installed = spawnSync('sh', [installer], { stdio: 'inherit', timeout: 300_000 });
         if (installed.status !== 0) throw new Error('Herdr installation failed');
     } finally {
         rmSync(scratch, { recursive: true, force: true });

--- a/scripts/setup/infrastructure/runtime.mjs
+++ b/scripts/setup/infrastructure/runtime.mjs
@@ -148,12 +148,15 @@ export function executable(command) {
 }
 
 export function run(command, args, options = {}) {
-    const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+    const timeout = options.timeout ?? 30_000;
+    const result = spawnSync(command, args, { encoding: 'utf8', ...options, timeout });
     return {
         ok: result.status === 0,
         status: result.status ?? 1,
         stdout: result.stdout?.trim() ?? '',
-        stderr: result.stderr?.trim() ?? '',
+        stderr: result.stderr?.trim() || (result.error?.code === 'ETIMEDOUT'
+            ? `${command} timed out after ${timeout / 1000} seconds`
+            : result.error?.message ?? ''),
         errorCode: result.error?.code,
     };
 }

--- a/scripts/setup/infrastructure/selfhost.mjs
+++ b/scripts/setup/infrastructure/selfhost.mjs
@@ -28,6 +28,7 @@ export function tailscaleBin() {
 export function runTailscale(args, options = {}) {
     const { env: childEnv, ...rest } = options;
     return spawnSync(tailscaleBin() || 'tailscale', args, {
+        timeout: 15_000,
         ...rest,
         env: { ...process.env, TAILSCALE_BE_CLI: '1', ...childEnv },
     });
@@ -77,9 +78,10 @@ export function selfhostCredential(state) {
     return state?.machineCredential;
 }
 
-export async function selfhostRelayHealthy(state) {
+export async function selfhostRelayHealthy(state, timeoutMs = 2_000) {
     if (state === undefined) return false;
-    return fetch(`${selfhostControlBase(state)}/health`).then((response) => response.ok).catch(() => false);
+    return fetch(`${selfhostControlBase(state)}/health`, { signal: AbortSignal.timeout(timeoutMs) })
+        .then((response) => response.ok).catch(() => false);
 }
 
 export async function advertisedRelayHealthy(state) {
@@ -105,8 +107,8 @@ export function tailscaleIngress(args) {
     const status = runTailscale(['status', '--json'], { encoding: 'utf8' });
     if (status.error?.code === 'ENOENT') return undefined;
     if (status.status !== 0) {
-        // A spawn error (EACCES, …) gives status:null and no stderr stream.
-        const detail = (status.stderr ?? status.error?.message ?? '').trim();
+        // A spawn error (EACCES, timeout, …) gives status:null and no stderr stream.
+        const detail = (status.stderr || status.error?.message || '').trim();
         throw new Error(`Tailscale is installed but unavailable: ${detail || 'sign in or use --advertise'}`);
     }
     try {
@@ -146,7 +148,8 @@ export function inspectTailscaleServeRoot(port, dnsName, expectedProxy) {
     const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8' });
     if (current.error?.code === 'ENOENT') return { status: 'unknown', missing: true, reason: 'tailscale not found' };
     if (current.status !== 0) {
-        return { status: 'unknown', reason: `cannot inspect Tailscale Serve ownership: ${current.stderr.trim() || 'status failed'}` };
+        const detail = (current.stderr || current.error?.message || 'status failed').trim();
+        return { status: 'unknown', reason: `cannot inspect Tailscale Serve ownership: ${detail}` };
     }
     let rootProxy;
     try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), dnsName); }
@@ -191,7 +194,7 @@ export async function stopOwnedSelfhostRelay() {
     const state = readSelfhostState();
     if (state === undefined || state.relayLocation === 'remote') return undefined;
     const port = Number(state.relayPort);
-    const health = await fetch(`http://127.0.0.1:${port}/health`).then((response) => {
+    const health = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2_000) }).then((response) => {
         if (!response.ok) return undefined;
         return response.json();
     }).catch(() => undefined);
@@ -210,7 +213,9 @@ export async function stopOwnedSelfhostRelay() {
         throw cause;
     }
     for (let attempt = 0; attempt < 30; attempt += 1) {
-        const stopped = await fetch(`http://127.0.0.1:${port}/health`).then(() => false).catch(() => true);
+        const stopped = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(500) })
+            .then(() => false)
+            .catch((cause) => cause?.name !== 'TimeoutError');
         if (stopped) return { state, health, port };
         await new Promise((resolve) => setTimeout(resolve, 100));
     }

--- a/scripts/setup/infrastructure/selfhostRelay.mjs
+++ b/scripts/setup/infrastructure/selfhostRelay.mjs
@@ -109,7 +109,8 @@ export async function resolveAdvertise(args, port, tailscale) {
         return { url: parsed.toString().replace(/\/$/, ''), note: 'explicit --advertise' };
     }
     if (args.includes('--tunnel')) {
-        const check = spawnSync('cloudflared', ['--version'], { encoding: 'utf8' });
+        const check = spawnSync('cloudflared', ['--version'], { encoding: 'utf8', timeout: 15_000 });
+        if (check.error?.code === 'ETIMEDOUT') throw new Error('cloudflared version check timed out after 15 seconds; restart it or choose another connection');
         if (check.error) throw new Error('cloudflared not found; install it or use --advertise=<url>');
         const logPath = join(stateDir(), 'logs', 'cloudflared.log');
         ensurePrivateDir(dirname(logPath));
@@ -141,7 +142,12 @@ export async function resolveAdvertise(args, port, tailscale) {
         const serve = ownership.status === 'ours'
             ? { status: 0, stdout: '', stderr: '' }
             : runTailscale(['serve', '--yes', '--bg', '--https=443', expected], { encoding: 'utf8' });
-        if (serve.status !== 0) throw new Error(`tailscale serve failed: ${serve.stderr.trim() || serve.stdout.trim() || 'check operator permissions'}; use --tailscale-direct for direct tailnet mode`);
+        if (serve.status !== 0) {
+            const detail = serve.error?.code === 'ETIMEDOUT'
+                ? 'command timed out after 15 seconds'
+                : (serve.stderr || serve.stdout || serve.error?.message || 'check operator permissions').trim();
+            throw new Error(`tailscale serve failed: ${detail}; use --tailscale-direct for direct tailnet mode`);
+        }
         return {
             url: `wss://${tailscale.dnsName}`,
             note: 'Tailscale Serve (private tailnet HTTPS)',
@@ -149,6 +155,7 @@ export async function resolveAdvertise(args, port, tailscale) {
         };
     }
     const status = runTailscale(['status', '--json'], { encoding: 'utf8' });
+    if (status.error?.code === 'ETIMEDOUT') throw new Error('Tailscale status timed out after 15 seconds; restart tailscaled or choose LAN');
     if (status.status === 0) {
         try {
             const ip = JSON.parse(status.stdout)?.Self?.TailscaleIPs?.find((value) => /^100\./.test(value));
@@ -170,7 +177,15 @@ export function relayDiscovery(state) {
 }
 
 export async function ensureSelfhostRelay(port, webRoot, host = '0.0.0.0', webOrigin, discovery) {
-    const health = await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok ? r.json() : undefined).catch(() => undefined);
+    let health;
+    try {
+        health = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2_000) })
+            .then((response) => response.ok ? response.json() : undefined);
+    } catch (cause) {
+        if (cause?.name === 'TimeoutError') {
+            throw new Error(`port ${port} accepts connections but did not answer muxr's health check; stop the process using it or rerun setup with --port <free-port>`);
+        }
+    }
     const healthy = health?.ok === true;
     const dataDir = join(stateDir(), 'relay');
     if (healthy) {
@@ -210,7 +225,8 @@ export async function ensureSelfhostRelay(port, webRoot, host = '0.0.0.0', webOr
     proc.unref();
     for (let i = 0; i < 25; i++) {
         await new Promise((resolve) => setTimeout(resolve, 400));
-        if (await fetch(`http://127.0.0.1:${port}/health`).then((r) => r.ok).catch(() => false)) return;
+        if (await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(500) })
+            .then((response) => response.ok).catch(() => false)) return;
     }
     throw new Error(`self-host relay did not come up on :${port}; see ${logPath}`);
 }

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -24,7 +24,7 @@ function command(name, args = []) {
 }
 
 function interactiveCommand(name, args = []) {
-    const result = spawnSync(name, args, { stdio: 'inherit' });
+    const result = spawnSync(name, args, { stdio: 'inherit', timeout: 300_000 });
     return { ok: result.status === 0, output: result.error?.message ?? result.signal ?? '' };
 }
 
@@ -441,7 +441,7 @@ async function offerTailscaleConnect(found) {
 async function applyTailscaleConnect(found) {
     let up;
     if (process.platform === 'darwin') {
-        up = spawnSync('open', ['-a', 'Tailscale'], { stdio: 'inherit' });
+        up = spawnSync('open', ['-a', 'Tailscale'], { stdio: 'inherit', timeout: 15_000 });
         if (up.status === 0 && await prompt('Approve the Tailscale system extension and sign in, then press Enter') === undefined) return false;
     } else {
         // USER can be unset (sudo, cron, containers); an empty --operator makes
@@ -450,7 +450,7 @@ async function applyTailscaleConnect(found) {
         if (!operator) {
             try { operator = userInfo().username; } catch { operator = undefined; }
         }
-        up = spawnSync('sudo', [tailscaleBin() || 'tailscale', 'up', ...(operator ? [`--operator=${operator}`] : [])], { stdio: 'inherit' });
+        up = spawnSync('sudo', [tailscaleBin() || 'tailscale', 'up', ...(operator ? [`--operator=${operator}`] : [])], { stdio: 'inherit', timeout: 300_000 });
     }
     found.tailscale = probeTailscale();
     if (found.tailscale.connected) status('Tailscale', `connected — ${found.tailscale.ip}`, 'ok');
@@ -544,6 +544,7 @@ export async function applyMachineSetup(args = []) {
     const prerequisites = await runLocalPrerequisites(prerequisiteArgs);
     if (prerequisites !== 0) return prerequisites;
     const pluginResult = await installPlugins(plugins);
+    status('Network', 'checking Tailscale Serve ownership and local relay port', 'off');
     let result = 1;
     for (;;) {
         const recovered = await recoverOccupiedServe({ plan, found, current, tailscalePlanned, args });

--- a/skills/muxr/SKILL.md
+++ b/skills/muxr/SKILL.md
@@ -54,7 +54,7 @@ work.
 | Connect computers; list, read, watch, or prompt a remote agent; voice | `muxr skill collaboration` · [source](references/collaboration.md) |
 | Hand a browser login, 2FA, or CAPTCHA to the phone | `muxr skill browser-takeover` · [source](references/browser-takeover.md) |
 | Build, install, debug, or override a plugin | `muxr skill plugins` · [source](references/plugins.md) |
-| Troubleshoot | run `muxr doctor`, then `muxr diagnostics`; load the relevant topic's Pitfalls and Verify sections |
+| Troubleshoot, recover, or report a bug | run interactive `muxr doctor` for checked safe repairs, then `muxr diagnostics` locally or `muxr report` for a draft; show the complete draft and ask before any external action |
 | Full plugin manifest contract | run `muxr plugin docs` and read the printed PLUGINS.md |
 
 ## Pane attachments (always-on convention)
@@ -89,7 +89,14 @@ they preview natively.
 - Herdr wait commands have no default timeout and can block forever — always
   pass `--timeout MS`.
 - muxr state lives under `~/.muxr` unless `MUXR_HOME` is set; check it before
-  assuming the default path.
+  assuming the default path. Never delete or hand-edit state as first aid.
+- If setup stalls, Ctrl-C is safe. Run interactive `muxr doctor`, approve only
+  its offered repairs, rerun it, then retry setup; commands now fail with a
+  phase and deadline instead of waiting forever.
+- `muxr diagnostics` is bounded and redacted for local/agent inspection.
+  `muxr report` creates a local draft only. Show the complete draft, ask whether
+  the user wants to post it, and take no external action without an explicit
+  yes. A diagnosis/report request is never posting approval. Keep raw logs local.
 - Secrets belong in plugin write-RPC input only — never in manifests,
   declarative state, or rendered output.
 - The pane id contains a colon — always quote paths built from it.
@@ -98,5 +105,5 @@ they preview natively.
 ## Verify
 
 - `muxr --version` prints the installed CLI version.
-- `muxr doctor` prints current setup health; `muxr diagnostics` prints bounded redacted host history.
+- `muxr doctor` prints current setup health; `muxr diagnostics` prints bounded redacted host history; `muxr report` prints a local review-only issue draft.
 - `herdr status` confirms the Herdr server is up.

--- a/skills/muxr/references/onboarding.md
+++ b/skills/muxr/references/onboarding.md
@@ -8,6 +8,7 @@ host, and the pairing between them and the app.
 [Prerequisites](#prerequisites) · [Install](#install) · [First run](#first-run) ·
 [Connection choices](#connection-choices) · [Pairing](#pairing) ·
 [Shared relay](#shared-relay-on-a-vps) · [Maintenance](#maintenance) ·
+[Recovery](#diagnose-and-recover) · [Report](#report-an-issue) ·
 [Uninstall](#uninstall) · [Verify](#verify)
 
 ## Prerequisites
@@ -117,13 +118,86 @@ endpoint from their pairing grant. Plugin and agent changes sync live.
 ```bash
 muxr update                    # check, confirm, update, and restart
 muxr update --check            # check without changing anything
-muxr doctor                    # current setup health
+muxr doctor                    # current setup health and checked repairs
 muxr diagnostics               # bounded redacted host/client history
+muxr report > muxr-report.md   # local redacted issue draft; never submits
 muxr daemon status|logs|start|stop|restart
 muxr setup --dry-run           # preview managed-file changes
 ```
 
 muxr state lives under `~/.muxr` unless `MUXR_HOME` is set.
+
+## Diagnose and recover
+
+Use the checked recovery path before changing files or reinstalling:
+
+1. Run `muxr doctor` in an interactive terminal. It checks the runtime, Herdr,
+   integrations, managed files, service registration, relay, connection,
+   pairing, and local peer access. When a failed check has a known safe repair,
+   doctor lists the repair and asks before running it.
+2. Approve only the repairs doctor offers, then rerun `muxr doctor`. A repair is
+   not complete until the failing check becomes healthy.
+3. Run `muxr diagnostics` for seven days of bounded, redacted host/client/relay
+   history. Redirect this JSON when escalation is needed. Review `muxr doctor`
+   output before posting it because connection names or addresses may be local.
+4. Use `muxr daemon logs` only for local diagnosis; review it before sharing.
+
+If setup appears stuck, press Ctrl-C. Setup can be rerun and now prints its
+current network, relay, or service phase; each non-interactive dependency has a
+bounded deadline. Then follow the matching remedy:
+
+| Failed phase or doctor check | Safe next action |
+|---|---|
+| Herdr server or lifecycle integrations | accept doctor's offered repair, or run `muxr integrations sync`; rerun doctor |
+| muxr service, relay, or local peer access | `muxr daemon restart`, then `muxr doctor` |
+| Tailscale Serve | restart `tailscaled` only when another connection can survive the interruption, or rerun setup with LAN / `muxr self-host --tailscale-direct` |
+| Local relay port | `curl --max-time 3 http://127.0.0.1:8792/health`; inspect the owner with `ss -ltnp 'sport = :8792'` on Linux or `lsof -nP -iTCP:8792 -sTCP:LISTEN` on macOS; stop only a process you recognize or rerun `muxr setup --port <free-port>` |
+| Expired or interrupted pairing | `muxr pair` for a new single-use code |
+| Connection choice or tunnel | rerun interactive `muxr`; do not edit `~/.muxr` |
+
+On Linux, a Tailscale daemon stall can be confirmed without waiting forever:
+
+```bash
+timeout 15s tailscale status --json
+timeout 15s tailscale serve status --json
+```
+
+Exit status `124` means the local Tailscale command timed out. Capture
+`journalctl -u tailscaled -b --no-pager` locally before restarting it. Do not
+restart `tailscaled` from a session reachable only through Tailscale.
+
+Do not delete or hand-edit `~/.muxr` as a repair. If doctor reports corrupt or
+incomplete state, stop and back up the exact file it names before moving it
+aside; that state contains machine identity and pairing authority. `muxr
+uninstall` is destructive recovery, not first aid.
+
+## Report an issue
+
+Create one local draft instead of collecting commands by hand:
+
+```bash
+muxr report > muxr-report.md
+```
+
+`muxr report` works even when first setup never completed or host diagnostics do
+not exist. It includes muxr, Node, OS/kernel, Herdr, and Tailscale versions; only
+the names and states of doctor checks; and at most the latest 50 events from the
+bounded redacted diagnostic journal. It never includes prompts, terminal/file
+content, paths, credentials, keys, raw daemon logs, or internal ids. The command
+only writes the draft; it never opens or submits an issue.
+
+Before any post:
+
+1. Read the complete draft and fill in What happened, Steps to reproduce, and
+   Expected behavior.
+2. Show the complete title and body to the user. Do not summarize away fields
+   they need to review.
+3. Ask explicitly whether they want to post that exact draft.
+4. Take no browser, GitHub CLI, or API action unless they answer yes. Asking to
+   diagnose, summarize, or prepare a report is never approval to post.
+
+If they prefer to submit it themselves, give them the Bug form URL:
+`https://github.com/umeranjum17/muxr/issues/new/choose`.
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary

- bound setup subprocesses and relay health checks so onboarding fails with an actionable phase instead of appearing frozen
- add visible network, relay, and service progress plus safe recovery guidance in the bundled muxr skill
- add `muxr report`, which produces a local review-only issue draft with environment versions, doctor check states, and the latest 50 redacted events
- keep issue submission human-controlled: the draft contains no submission command, strips agent/task names, and requires an explicit review-and-ask step before any external action
- update the bug template to accept the report while preserving optional app-vs-Herdr context

Closes #197

## Verification

- `node scripts/diagnostics/application/checkSelfhostState.mjs`
- `node scripts/diagnostics/application/checkTailscaleIngress.mjs`
- `node scripts/diagnostics/application/checkArchitecture.mjs`
- `node scripts/diagnostics/application/checkPackageSmoke.mjs`
- focused report check proving semantic agent names and internal fields do not reach the draft

## Review

Reviewed with `claude-bridge/claude-opus-5`. No blocking findings. Its privacy finding about prompt-derived agent/task names and its app-vs-Herdr template finding were addressed before opening this PR.
