### PR TITLE
fix: detect unavailable Tailscale Serve before setup

### DIFF
--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -52,6 +52,8 @@ are:
 | `--tailscale-direct` | Rollback path using the tailnet IP directly. |
 | *(choose Local network)* | LAN address. Phone must be on the same network. |
 
+Before recommending Serve, the wizard checks that it is available and not already owned. If Serve is disabled for the tailnet, muxr shows Tailscale's enablement link and offers direct Tailscale or LAN instead of waiting indefinitely.
+
 muxr never enables Funnel. Restrict the Serve endpoint with a tailnet grant/ACL to intended devices even though muxr pairing and E2EE remain authoritative. `--web` requires a secure `wss://` route; insecure LAN HTTP is refused.
 
 Set `MUXR_TRUST_PROXY=1` when the relay sits behind cloudflared/nginx so rate

--- a/scripts/diagnostics/application/checkTailscaleIngress.mjs
+++ b/scripts/diagnostics/application/checkTailscaleIngress.mjs
@@ -21,8 +21,8 @@ const originalPath = process.env.PATH;
 const originalHome = process.env.HOME;
 const originalMuxrHome = process.env.MUXR_HOME;
 const originalPlatform = process.env.MUXR_PLATFORM;
-const configure = (status, serveStatus = '{}') => {
-    writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(log)}\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}' ;;\n  "serve --yes --bg --https=443 http://127.0.0.1:8792") exit 0 ;;\n  "serve --https=443 off") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
+const configure = (status, serveStatus = '{}', serveApply = 'exit 0', serveStatusExit = 0) => {
+    writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(log)}\ncase "$*" in\n  "status --json") printf '%s' '${JSON.stringify(status)}' ;;\n  "serve status --json") printf '%s' '${serveStatus.replaceAll("'", "'\\''")}'; exit ${serveStatusExit} ;;\n  "serve --yes --bg --https=443 http://127.0.0.1:8792") ${serveApply} ;;\n  "serve --https=443 off") exit 0 ;;\n  *) exit 1 ;;\nesac\n`);
     chmodSync(fake, 0o755);
 };
 const commandsSince = (offset) => (existsSync(log) ? readFileSync(log, 'utf8') : '').slice(offset);
@@ -37,6 +37,21 @@ try {
         note: 'Tailscale Serve (private tailnet HTTPS)',
         ingress: { kind: 'tailscale-serve', port: 8792, dnsName: 'dev.tailnet.ts.net', proxy: 'http://127.0.0.1:8792' },
     });
+
+    const disabledNotice = 'Serve is not enabled on your tailnet.\nTo enable, visit: https://login.tailscale.com/f/serve-test';
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, disabledNotice, 'exit 0', 1);
+    const unavailable = inspectTailscaleServeRoot(8792, 'dev.tailnet.ts.net');
+    assert.equal(unavailable.status, 'unknown');
+    assert.match(unavailable.reason, /Serve is not enabled.*login\.tailscale\.com.*direct Tailscale or LAN/s);
+
+    configure(
+        { Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } },
+        '{}',
+        `printf '%s\\n' '${disabledNotice.replaceAll("'", "'\\''")}' >&2; exec sleep 30`,
+    );
+    const blockedAt = Date.now();
+    await assert.rejects(resolveAdvertise([], 8792, tailscaleIngress([])), /Serve is not enabled.*login\.tailscale\.com.*direct Tailscale or LAN/s);
+    assert.ok(Date.now() - blockedAt < 20_000, 'disabled Tailscale Serve left setup blocked');
 
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.' } }, JSON.stringify({ TCP: { '443': { HTTPS: true } }, Web: { 'dev.tailnet.ts.net:443': { Handlers: { '/': { Proxy: 'http://127.0.0.1:9999' } } } } }));
     await assert.rejects(resolveAdvertise([], 8792, tailscaleIngress([])), /already owned/);

--- a/scripts/diagnostics/application/checkTailscaleIngress.mjs
+++ b/scripts/diagnostics/application/checkTailscaleIngress.mjs
@@ -41,8 +41,11 @@ try {
     const disabledNotice = 'Serve is not enabled on your tailnet.\nTo enable, visit: https://login.tailscale.com/f/serve-test';
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, disabledNotice, 'exit 0', 1);
     const unavailable = inspectTailscaleServeRoot(8792, 'dev.tailnet.ts.net');
-    assert.equal(unavailable.status, 'unknown');
+    assert.equal(unavailable.status, 'disabled');
     assert.match(unavailable.reason, /Serve is not enabled.*login\.tailscale\.com.*direct Tailscale or LAN/s);
+
+    configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } }, 'not json');
+    assert.equal(inspectTailscaleServeRoot(8792, 'dev.tailnet.ts.net').status, 'inconclusive');
 
     configure(
         { Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } },

--- a/scripts/setup/application/connectEnrollment.mjs
+++ b/scripts/setup/application/connectEnrollment.mjs
@@ -32,6 +32,16 @@ import {
 } from '../infrastructure/selfhostRelay.mjs';
 import { mintDeviceGrant, pairDevice } from './pairDevice.mjs';
 
+async function waitForRemoteHost(state, timeoutMs = 10_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const remaining = deadline - Date.now();
+        if (await remoteHostOnline(state, Math.max(1, Math.min(1_000, remaining)))) return true;
+        await new Promise((resolve) => setTimeout(resolve, Math.min(250, Math.max(0, deadline - Date.now()))));
+    }
+    return false;
+}
+
 export async function resumeRemoteConnect(args = []) {
     if (!hasPendingRemoteConnect()) throw new Error('no interrupted remote enrollment is waiting to resume');
     const parsed = parsePendingRemote(JSON.parse(readFileSync(pendingRemotePath(), 'utf8')));
@@ -46,8 +56,7 @@ export async function resumeRemoteConnect(args = []) {
     writeSelfhostState(pending);
     rmSync(pendingRemotePath(), { force: true });
     await startMuxrDaemon('selfhost', args, true);
-    for (let attempt = 0; attempt < 40 && !(await remoteHostOnline(pending)); attempt += 1) await new Promise((resolve) => setTimeout(resolve, 250));
-    if (!(await remoteHostOnline(pending))) throw new Error('remote enrollment was restored, but the host did not authenticate; run `muxr doctor`');
+    if (!(await waitForRemoteHost(pending))) throw new Error('remote enrollment was restored, but the host did not authenticate; run `muxr doctor`');
     rmSync(join(stateDir(), 'selfhost.previous.json'), { force: true });
     print('  ✓ resumed the remote relay connection');
     return 0;
@@ -111,10 +120,7 @@ export async function connectEnrollment(args = []) {
         catch (cause) {
             throw new Error(`enrollment completed and the scoped credential was saved, but the local service did not start: ${cause instanceof Error ? cause.message : String(cause)}; choose Restart muxr after fixing the reported service issue`);
         }
-        for (let attempt = 0; attempt < 40 && !(await remoteHostOnline(state)); attempt += 1) {
-            await new Promise((resolve) => setTimeout(resolve, 250));
-        }
-        if (!(await remoteHostOnline(state))) throw new Error('the scoped credential was saved, but the local host did not authenticate with the shared relay; run `muxr doctor`');
+        if (!(await waitForRemoteHost(state))) throw new Error('the scoped credential was saved, but the local host did not authenticate with the shared relay; run `muxr doctor`');
         rmSync(join(stateDir(), 'selfhost.previous.json'), { force: true });
         print(`  ✓ connected this machine to ${enrollment.relay}`);
         print(`  ✓ machine credential expires ${new Date(state.credentialExpiresAt).toLocaleDateString()}`);

--- a/scripts/setup/infrastructure/daemon.mjs
+++ b/scripts/setup/infrastructure/daemon.mjs
@@ -108,7 +108,7 @@ export function serviceCommand(action) {
         }
         if (action === 'stop' || action === 'unload') return run('launchctl', ['bootout', service]);
         if (action === 'status') {
-            const printed = run('launchctl', ['print', service]);
+            const printed = run('launchctl', ['print', service], { timeout: 2_000 });
             return { ...printed, ok: printed.ok && /\bstate = running\b/.test(printed.stdout) };
         }
     }
@@ -122,7 +122,7 @@ export function serviceCommand(action) {
         return run('systemctl', ['--user', 'restart', 'muxr.service']);
     }
     if (action === 'stop') return run('systemctl', ['--user', 'stop', 'muxr.service']);
-    if (action === 'status') return run('systemctl', ['--user', 'status', 'muxr.service', '--no-pager']);
+    if (action === 'status') return run('systemctl', ['--user', 'status', 'muxr.service', '--no-pager'], { timeout: 2_000 });
     if (action === 'unload') return run('systemctl', ['--user', 'disable', '--now', 'muxr.service']);
     return { ok: false, stdout: '', stderr: `unknown service action ${action}` };
 }

--- a/scripts/setup/infrastructure/herdr.mjs
+++ b/scripts/setup/infrastructure/herdr.mjs
@@ -137,7 +137,7 @@ export async function ensureHerdr({ dryRun, noInstall, installRequested }) {
     const versionResult = run(binary, ['--version']);
     const version = parseVersion(versionResult.stdout);
     if (!versionResult.ok || !version || !versionIsCompatible(version)) {
-        throw new Error(`herdr >= 0.8.0 is required; found ${versionResult.stdout || 'an unreadable version'}. Run \`herdr update\` after reviewing the upgrade.`);
+        throw new Error(`herdr >= 0.8.0 is required; found ${versionResult.stdout || versionResult.stderr || 'an unreadable version'}. Run \`herdr update\` after reviewing the upgrade.`);
     }
     print(`  ✓ herdr ${version.join('.')} (adopted; config and sessions unchanged)`);
     return binary;
@@ -155,7 +155,10 @@ function runBundledPluginBackfill(root, binary, enabled, dryRun) {
         env: { ...process.env, HERDR_BIN_PATH: binary },
         timeout: 30_000,
     });
-    if (result.status !== 0) throw new Error(result.stderr || result.stdout || `failed to backfill ${basename(root)}`);
+    if (result.status !== 0 || result.error) {
+        const detail = result.stderr || result.stdout || (result.error?.code === 'ETIMEDOUT' ? 'timed out after 30 seconds' : result.error?.message);
+        throw new Error(detail || `failed to backfill ${basename(root)}`);
+    }
 }
 
 export async function ensureBundledPlugins(binary, dryRun) {

--- a/scripts/setup/infrastructure/runtime.mjs
+++ b/scripts/setup/infrastructure/runtime.mjs
@@ -151,7 +151,7 @@ export function run(command, args, options = {}) {
     const timeout = options.timeout ?? 30_000;
     const result = spawnSync(command, args, { encoding: 'utf8', ...options, timeout });
     return {
-        ok: result.status === 0,
+        ok: result.status === 0 && result.error === undefined,
         status: result.status ?? 1,
         stdout: result.stdout?.trim() ?? '',
         stderr: result.stderr?.trim() || (result.error?.code === 'ETIMEDOUT'
@@ -238,10 +238,11 @@ export function machineIdentity(existing) {
 }
 
 export async function api(base, path, options = {}) {
+    const { headers, signal = AbortSignal.timeout(15_000), ...request } = options;
     const response = await fetch(`${base.replace(/\/+$/, '')}${path}`, {
-        ...options,
-        headers: { 'content-type': 'application/json', ...options.headers },
-        signal: AbortSignal.timeout(15_000),
+        ...request,
+        headers: { 'content-type': 'application/json', ...headers },
+        signal,
     });
     const body = await response.json().catch(() => ({}));
     return { response, body };

--- a/scripts/setup/infrastructure/selfhost.mjs
+++ b/scripts/setup/infrastructure/selfhost.mjs
@@ -156,13 +156,17 @@ export function tailscaleServeFailure(result) {
 export function inspectTailscaleServeRoot(port, dnsName, expectedProxy, timeout = 15_000) {
     const expected = expectedProxy ?? `http://127.0.0.1:${port}`;
     const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8', timeout });
-    if (current.error?.code === 'ENOENT') return { status: 'unknown', missing: true, reason: 'tailscale not found' };
+    if (current.error?.code === 'ENOENT') return { status: 'inconclusive', missing: true, reason: 'tailscale not found' };
     if (current.status !== 0 || current.error) {
-        return { status: 'unknown', reason: tailscaleServeFailure(current) };
+        const output = [current.stderr, current.stdout].filter(Boolean).join('\n');
+        return {
+            status: /serve is not enabled on your tailnet/i.test(output) ? 'disabled' : 'inconclusive',
+            reason: tailscaleServeFailure(current),
+        };
     }
     let rootProxy;
     try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), dnsName); }
-    catch { return { status: 'unknown', reason: 'Tailscale Serve returned invalid status JSON' }; }
+    catch { return { status: 'inconclusive', reason: 'Tailscale Serve returned invalid status JSON' }; }
     if (rootProxy === undefined) return { status: 'free' };
     if (rootProxy === expected) return { status: 'ours' };
     return { status: 'occupied' };
@@ -192,7 +196,7 @@ export function cleanupManagedIngress(state) {
     const expected = typeof ingress.proxy === 'string' ? ingress.proxy : `http://127.0.0.1:${ingress.port}`;
     const ownership = inspectTailscaleServeRoot(ingress.port, ingress.dnsName, expected);
     if (ownership.missing || ownership.status === 'free' || ownership.status === 'occupied') return;
-    if (ownership.status === 'unknown') {
+    if (ownership.status === 'disabled' || ownership.status === 'inconclusive') {
         throw new Error('cannot inspect the previous muxr Tailscale Serve route; leaving it unchanged');
     }
     const disabled = runTailscale(['serve', '--https=443', 'off'], { encoding: 'utf8' });

--- a/scripts/setup/infrastructure/selfhost.mjs
+++ b/scripts/setup/infrastructure/selfhost.mjs
@@ -26,10 +26,10 @@ export function tailscaleBin() {
 }
 
 export function runTailscale(args, options = {}) {
-    const { env: childEnv, ...rest } = options;
+    const { env: childEnv, timeout = 15_000, ...rest } = options;
     return spawnSync(tailscaleBin() || 'tailscale', args, {
-        timeout: 15_000,
         ...rest,
+        timeout,
         env: { ...process.env, TAILSCALE_BE_CLI: '1', ...childEnv },
     });
 }
@@ -143,13 +143,22 @@ export function tailscaleRootProxy(value, dnsName) {
 
 export const SERVE_OWNED_ERROR = 'Tailscale Serve root is already owned by another service; use --tailscale-direct or remove it yourself';
 
-export function inspectTailscaleServeRoot(port, dnsName, expectedProxy) {
+export function tailscaleServeFailure(result) {
+    const output = [result.stderr, result.stdout].map((value) => value?.trim()).filter(Boolean).join('\n').slice(0, 2_000);
+    if (/serve is not enabled on your tailnet/i.test(output)) {
+        const enableUrl = output.match(/https:\/\/login\.tailscale\.com\/[^\s<>"']+/)?.[0];
+        return `Tailscale Serve is not enabled on your tailnet. ${enableUrl ? `Enable it at ${enableUrl}` : 'Enable it in the Tailscale admin console'}, then rerun \`muxr setup\`; or choose direct Tailscale or LAN.`;
+    }
+    if (result.error?.code === 'ETIMEDOUT') return `${output ? `${output}\n` : ''}Tailscale Serve did not finish before the timeout; restart Tailscale or choose direct Tailscale or LAN.`;
+    return output || result.error?.message || 'Tailscale Serve command failed';
+}
+
+export function inspectTailscaleServeRoot(port, dnsName, expectedProxy, timeout = 15_000) {
     const expected = expectedProxy ?? `http://127.0.0.1:${port}`;
-    const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8' });
+    const current = runTailscale(['serve', 'status', '--json'], { encoding: 'utf8', timeout });
     if (current.error?.code === 'ENOENT') return { status: 'unknown', missing: true, reason: 'tailscale not found' };
-    if (current.status !== 0) {
-        const detail = (current.stderr || current.error?.message || 'status failed').trim();
-        return { status: 'unknown', reason: `cannot inspect Tailscale Serve ownership: ${detail}` };
+    if (current.status !== 0 || current.error) {
+        return { status: 'unknown', reason: tailscaleServeFailure(current) };
     }
     let rootProxy;
     try { rootProxy = tailscaleRootProxy(JSON.parse(current.stdout || '{}'), dnsName); }

--- a/scripts/setup/infrastructure/selfhostRelay.mjs
+++ b/scripts/setup/infrastructure/selfhostRelay.mjs
@@ -138,7 +138,7 @@ export async function resolveAdvertise(args, port, tailscale) {
     }
     if (tailscale) {
         const ownership = inspectTailscaleServeRoot(port, tailscale.dnsName);
-        if (ownership.status === 'unknown') throw new Error(ownership.reason);
+        if (ownership.status === 'disabled' || ownership.status === 'inconclusive') throw new Error(ownership.reason);
         if (ownership.status === 'occupied') throw new Error(SERVE_OWNED_ERROR);
         const expected = `http://127.0.0.1:${port}`;
         const serve = ownership.status === 'ours'

--- a/scripts/setup/infrastructure/selfhostRelay.mjs
+++ b/scripts/setup/infrastructure/selfhostRelay.mjs
@@ -34,6 +34,7 @@ import {
     selfhostRelayHealthy,
     SERVE_OWNED_ERROR,
     stopOwnedSelfhostRelay,
+    tailscaleServeFailure,
     writeSelfhostState,
 } from './selfhost.mjs';
 
@@ -64,10 +65,11 @@ export function browserHostingReady() {
     return parsed.ok && parsed.value.browserHostingReady();
 }
 
-export async function remoteHostOnline(state) {
+export async function remoteHostOnline(state, timeoutMs = 15_000) {
     if (state?.relayLocation !== 'remote' || env('MUXR_REMOTE_HOST_ONLINE') === '1') return true;
     const result = await api(selfhostControlBase(state), '/v1/selfhost/machine-status', {
         headers: { authorization: `Bearer ${selfhostCredential(state)}` },
+        signal: AbortSignal.timeout(timeoutMs),
     }).catch(() => undefined);
     return result?.response.ok === true && result.body.online === true;
 }
@@ -142,12 +144,7 @@ export async function resolveAdvertise(args, port, tailscale) {
         const serve = ownership.status === 'ours'
             ? { status: 0, stdout: '', stderr: '' }
             : runTailscale(['serve', '--yes', '--bg', '--https=443', expected], { encoding: 'utf8' });
-        if (serve.status !== 0) {
-            const detail = serve.error?.code === 'ETIMEDOUT'
-                ? 'command timed out after 15 seconds'
-                : (serve.stderr || serve.stdout || serve.error?.message || 'check operator permissions').trim();
-            throw new Error(`tailscale serve failed: ${detail}; use --tailscale-direct for direct tailnet mode`);
-        }
+        if (serve.status !== 0 || serve.error) throw new Error(tailscaleServeFailure(serve));
         return {
             url: `wss://${tailscale.dnsName}`,
             note: 'Tailscale Serve (private tailnet HTTPS)',
@@ -228,6 +225,7 @@ export async function ensureSelfhostRelay(port, webRoot, host = '0.0.0.0', webOr
         if (await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(500) })
             .then((response) => response.ok).catch(() => false)) return;
     }
+    proc.kill('SIGTERM');
     throw new Error(`self-host relay did not come up on :${port}; see ${logPath}`);
 }
 

--- a/scripts/setup/presentation/hostUp.mjs
+++ b/scripts/setup/presentation/hostUp.mjs
@@ -65,7 +65,7 @@ function start(entry, env = process.env, args = []) {
 
 async function waitForRelay(port) {
     for (let attempt = 0; attempt < 30; attempt += 1) {
-        const ready = await fetch(`http://127.0.0.1:${port}/health`).then((response) => response.ok).catch(() => false);
+        const ready = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(500) }).then((response) => response.ok).catch(() => false);
         if (ready) return;
         await new Promise((resolve) => setTimeout(resolve, 250));
     }

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -14,10 +14,12 @@ import { inspectTailscaleServeRoot, runTailscale, tailscaleBin } from '../infras
 import { advertisedUrlForMode, connectionLabel, ingressPlan, modeAllowsBrowserHosting } from '../domain/dist/index.js';
 
 function command(name, args = []) {
-    const result = spawnSync(name, args, { encoding: 'utf8', timeout: 120_000 });
+    const result = spawnSync(name, args, { encoding: 'utf8', timeout: 15_000 });
+    const stdout = result.stdout?.trim() ?? '';
+    const stderr = result.stderr?.trim() ?? '';
     return {
-        ok: result.status === 0,
-        output: (result.stdout || result.stderr || '').trim(),
+        ok: result.status === 0 && result.error === undefined,
+        output: result.status === 0 ? stdout : stderr || stdout || result.error?.message || '',
         missing: result.error?.code === 'ENOENT',
         errorCode: result.error?.code,
     };
@@ -120,7 +122,7 @@ export function probeMachine() {
     const integration = herdrVersion.ok ? command(binary, ['integration', 'status']) : { ok: false, output: '' };
     const agents = integrationSummary(integration);
     return {
-        herdr: { installed: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrVersion.ok && herdrServerIsReady(binary) },
+        herdr: { installed: !herdrVersion.missing, working: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrVersion.ok && herdrServerIsReady(binary) },
         agents,
         tailscale: probeTailscale(),
         cloudflared: probeCloudflared(),
@@ -138,7 +140,11 @@ function agentIntegrationDetail(found) {
 
 function renderInspection(found) {
     heading('Checking this machine');
-    status('Herdr', found.herdr.installed ? found.herdr.version : 'not installed — will be installed during setup', found.herdr.installed ? 'ok' : 'warn');
+    let herdrDetail = 'not installed — will be installed during setup';
+    if (found.herdr.installed) herdrDetail = found.herdr.working
+        ? found.herdr.version
+        : `installed but unavailable — ${found.herdr.version || 'run muxr doctor'}`;
+    status('Herdr', herdrDetail, found.herdr.working ? 'ok' : 'warn');
     status('Herdr server', found.herdr.running ? 'running' : 'will be started', found.herdr.running ? 'ok' : 'warn');
     status('Agent integrations', agentIntegrationDetail(found), found.agents.checked && found.agents.current.length ? 'ok' : 'warn');
     status('Tailscale', found.tailscale.connected ? `connected — ${found.tailscale.ip}` : found.tailscale.detail, found.tailscale.connected ? 'ok' : 'off');
@@ -233,20 +239,23 @@ function choices(found, tailscalePlanned = false, serveRoot = { status: 'unknown
     // reason and remedy attached, so the user sees what is standing in the way.
     const options = [];
     const serveOccupied = serveRoot.status === 'occupied';
+    const serveUnavailable = serveRoot.status === 'unknown' && !tailscalePlanned;
     if (found.tailscale.connected || tailscalePlanned) {
-        if (serveOccupied) {
+        if (serveOccupied || serveUnavailable) {
+            let directDescription = 'connect during Apply · reach this computer over the tailnet address';
+            if (!tailscalePlanned) directDescription = serveOccupied
+                ? 'private tailnet address · leaves the existing Serve service unchanged'
+                : 'private tailnet address · does not require Tailscale Serve';
             options.push({
                 value: 'tailscale',
                 title: 'Tailscale Serve',
-                description: 'already used by another service · left unchanged',
+                description: serveOccupied ? 'already used by another service · left unchanged' : serveRoot.reason || 'availability check failed',
                 disabled: true,
             });
             options.push({
                 value: 'tailscale-direct',
                 title: 'Tailscale · recommended',
-                description: tailscalePlanned
-                    ? 'connect during Apply · reach this computer over the tailnet address'
-                    : 'private tailnet address · leaves the existing Serve service unchanged',
+                description: directDescription,
             });
         } else {
             options.push({ value: 'tailscale', title: 'Tailscale · recommended', description: tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly' });
@@ -296,7 +305,7 @@ export function selfhostArgsFromSetupPlan({ mode, port, web, pairing, found, end
 
 function serveRootFor(found, port) {
     if (!found.tailscale.connected && !found.tailscale.dnsName) return { status: 'unknown' };
-    return inspectTailscaleServeRoot(port, found.tailscale.dnsName);
+    return inspectTailscaleServeRoot(port, found.tailscale.dnsName, undefined, 3_000);
 }
 
 async function chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args }) {
@@ -320,6 +329,10 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
     }
     if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected && !tailscalePlanned) {
         process.stderr.write(`Tailscale is unavailable: ${found.tailscale.detail}; or pick a different relay\n`);
+        return 1;
+    }
+    if (mode === 'tailscale' && serveRoot.status === 'unknown' && !tailscalePlanned) {
+        process.stderr.write(`${serveRoot.reason || 'Tailscale Serve availability could not be verified'}\n`);
         return 1;
     }
     if (mode === 'lan' && !found.lan) {
@@ -392,18 +405,25 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
     return { mode, port, endpoint, web, pairing };
 }
 
-async function recoverOccupiedServe({ plan, found, current, tailscalePlanned, args }) {
+async function recoverTailscaleServe({ plan, found, current, tailscalePlanned, args }) {
     if (plan.mode !== 'tailscale') return plan;
-    if (serveRootFor(found, plan.port).status !== 'occupied') return plan;
-    setupStep(5, 5, 'Tailscale Serve is already in use');
-    heading('Tailscale Serve is already in use');
-    note([
+    const serveRoot = serveRootFor(found, plan.port);
+    if (serveRoot.status === 'free' || serveRoot.status === 'ours') return plan;
+    const occupied = serveRoot.status === 'occupied';
+    const title = occupied ? 'Tailscale Serve is already in use' : 'Tailscale Serve is unavailable';
+    setupStep(5, 5, title);
+    heading(title);
+    note(occupied ? [
         'Another service already owns the Tailscale Serve root.',
         'muxr left that service unchanged.',
         'You can use direct Tailscale networking, or go back and choose a different connection.',
+    ] : [
+        serveRoot.reason || 'muxr could not verify that Tailscale Serve is available.',
+        'muxr made no Serve changes.',
+        'You can use direct Tailscale networking, or go back and choose LAN or another connection.',
     ]);
     const action = await select('How do you want to continue?', [
-        { value: 'direct', title: 'Use direct Tailscale networking', description: 'reach this computer over its tailnet address · leaves the other service unchanged' },
+        { value: 'direct', title: 'Use direct Tailscale networking', description: 'reach this computer over its tailnet address · does not require Serve' },
         { value: 'back', title: 'Change how your phone connects', description: 'go back and pick a different connection' },
     ]);
     if (aborted(action)) return undefined;
@@ -547,7 +567,7 @@ export async function applyMachineSetup(args = []) {
     status('Network', 'checking Tailscale Serve ownership and local relay port', 'off');
     let result = 1;
     for (;;) {
-        const recovered = await recoverOccupiedServe({ plan, found, current, tailscalePlanned, args });
+        const recovered = await recoverTailscaleServe({ plan, found, current, tailscalePlanned, args });
         if (recovered === undefined) return cancelSetup();
         if (recovered === 1) return 1;
         plan = recovered;

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -233,15 +233,15 @@ const RELAY_KIND = {
 };
 const relayKind = (mode) => RELAY_KIND[mode] ?? mode;
 
-function choices(found, tailscalePlanned = false, serveRoot = { status: 'unknown' }) {
+function choices(found, tailscalePlanned = false, serveRoot = { status: 'inconclusive' }) {
     // The relay is the one real choice in setup: it is how the phone reaches
     // the host. Never delete an option silently — show it disabled with the
     // reason and remedy attached, so the user sees what is standing in the way.
     const options = [];
     const serveOccupied = serveRoot.status === 'occupied';
-    const serveUnavailable = serveRoot.status === 'unknown' && !tailscalePlanned;
+    const serveDisabled = serveRoot.status === 'disabled' && !tailscalePlanned;
     if (found.tailscale.connected || tailscalePlanned) {
-        if (serveOccupied || serveUnavailable) {
+        if (serveOccupied || serveDisabled) {
             let directDescription = 'connect during Apply · reach this computer over the tailnet address';
             if (!tailscalePlanned) directDescription = serveOccupied
                 ? 'private tailnet address · leaves the existing Serve service unchanged'
@@ -249,7 +249,7 @@ function choices(found, tailscalePlanned = false, serveRoot = { status: 'unknown
             options.push({
                 value: 'tailscale',
                 title: 'Tailscale Serve',
-                description: serveOccupied ? 'already used by another service · left unchanged' : serveRoot.reason || 'availability check failed',
+                description: serveOccupied ? 'already used by another service · left unchanged' : serveRoot.reason,
                 disabled: true,
             });
             options.push({
@@ -258,7 +258,13 @@ function choices(found, tailscalePlanned = false, serveRoot = { status: 'unknown
                 description: directDescription,
             });
         } else {
-            options.push({ value: 'tailscale', title: 'Tailscale · recommended', description: tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly' });
+            options.push({
+                value: 'tailscale',
+                title: 'Tailscale · recommended',
+                description: serveRoot.status === 'inconclusive'
+                    ? 'private connection · availability will be verified during Apply'
+                    : tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly',
+            });
         }
     } else {
         options.push({ value: 'tailscale', title: 'Tailscale', description: found.tailscale.detail, disabled: true });
@@ -304,8 +310,8 @@ export function selfhostArgsFromSetupPlan({ mode, port, web, pairing, found, end
 }
 
 function serveRootFor(found, port) {
-    if (!found.tailscale.connected && !found.tailscale.dnsName) return { status: 'unknown' };
-    return inspectTailscaleServeRoot(port, found.tailscale.dnsName, undefined, 3_000);
+    if (!found.tailscale.connected && !found.tailscale.dnsName) return { status: 'inconclusive' };
+    return inspectTailscaleServeRoot(port, found.tailscale.dnsName, undefined, 8_000);
 }
 
 async function chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args }) {
@@ -329,10 +335,6 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
     }
     if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected && !tailscalePlanned) {
         process.stderr.write(`Tailscale is unavailable: ${found.tailscale.detail}; or pick a different relay\n`);
-        return 1;
-    }
-    if (mode === 'tailscale' && serveRoot.status === 'unknown' && !tailscalePlanned) {
-        process.stderr.write(`${serveRoot.reason || 'Tailscale Serve availability could not be verified'}\n`);
         return 1;
     }
     if (mode === 'lan' && !found.lan) {
@@ -408,7 +410,7 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
 async function recoverTailscaleServe({ plan, found, current, tailscalePlanned, args }) {
     if (plan.mode !== 'tailscale') return plan;
     const serveRoot = serveRootFor(found, plan.port);
-    if (serveRoot.status === 'free' || serveRoot.status === 'ours') return plan;
+    if (serveRoot.status === 'free' || serveRoot.status === 'ours' || serveRoot.status === 'inconclusive') return plan;
     const occupied = serveRoot.status === 'occupied';
     const title = occupied ? 'Tailscale Serve is already in use' : 'Tailscale Serve is unavailable';
     setupStep(5, 5, title);

--- a/scripts/setup/presentation/up.mjs
+++ b/scripts/setup/presentation/up.mjs
@@ -47,6 +47,7 @@ async function provisionTokens() {
             method: 'POST',
             headers: { 'content-type': 'application/json', ...(token ? { authorization: `Bearer ${token}` } : {}) },
             body: JSON.stringify(body),
+            signal: AbortSignal.timeout(15_000),
         });
         if (res.status !== 201) throw new Error(`${path} returned ${res.status}`);
         return res.json();

--- a/skills/muxr/references/onboarding.md
+++ b/skills/muxr/references/onboarding.md
@@ -150,7 +150,7 @@ bounded deadline. Then follow the matching remedy:
 |---|---|
 | Herdr server or lifecycle integrations | accept doctor's offered repair, or run `muxr integrations sync`; rerun doctor |
 | muxr service, relay, or local peer access | `muxr daemon restart`, then `muxr doctor` |
-| Tailscale Serve | restart `tailscaled` only when another connection can survive the interruption, or rerun setup with LAN / `muxr self-host --tailscale-direct` |
+| Tailscale Serve | if Tailscale says Serve is not enabled, use its printed `login.tailscale.com` link or the Tailscale admin console to enable Serve, then rerun setup; otherwise choose LAN / `muxr self-host --tailscale-direct`. Restart `tailscaled` only when another connection can survive the interruption. |
 | Local relay port | `curl --max-time 3 http://127.0.0.1:8792/health`; inspect the owner with `ss -ltnp 'sport = :8792'` on Linux or `lsof -nP -iTCP:8792 -sTCP:LISTEN` on macOS; stop only a process you recognize or rerun `muxr setup --port <free-port>` |
 | Expired or interrupted pairing | `muxr pair` for a new single-use code |
 | Connection choice or tunnel | rerun interactive `muxr`; do not edit `~/.muxr` |


### PR DESCRIPTION
## Summary

- preserve the real disabled-tailnet notice and its Tailscale admin link, even when `tailscale serve` prints it and then blocks
- distinguish proven disabled Serve from inconclusive timeouts, permission failures, and malformed output
- keep Tailscale recommended when preflight is inconclusive; the bounded Apply remains authoritative
- leave occupied or disabled Serve unchanged and offer direct Tailscale as the safe fallback
- bound sibling readiness paths for the managed relay, service status, remote enrollment, and local token provisioning
- stop newly spawned relay processes when readiness expires and retain timeout details from Herdr checks

Follow-up to #197 and #198. This PR is deliberately limited to failure handling; the onboarding redesign is in a separate stacked PR.

## Safety

- preflight is read-only
- no Tailscale Serve mutation occurs before **Apply setup**
- existing Serve ownership, muxr identity, grants, and pairings remain untouched on failure
- every new external wait has a deadline

## Verification

- `node scripts/diagnostics/application/checkTailscaleIngress.mjs` — covers available, occupied, disabled, malformed, direct, apply, and cleanup flows; the blocking disabled-tailnet fixture exits within its bound
- `mise x node@22.23.2 -- yarn build`
- existing PR checks: CI suite and CodeQL passed at the previous head; they will rerun for the updated head

## Local-suite note

A prior full run was 32/34 locally. The two live-Herdr checks fail identically on `main` because the installed Herdr reports `Agent close plugin RPC is unavailable or changed`; one relay startup also flaked once. The focused changed-flow checks pass.
