### PR TITLE
feat: make phone connection setup automatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Then install the mobile companion:
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
 - **All builds:** [muxr 0.1.25 release](https://github.com/umeranjum17/muxr/releases/tag/v0.1.25)
 
-Verify a downloaded APK with `sha256sum --ignore-missing -c SHA256SUMS`, then run `muxr`, choose **Apply setup**, and scan the one-use QR from the phone. Start with LAN when both devices are on the same Wi-Fi.
+Verify a downloaded APK with `sha256sum --ignore-missing -c SHA256SUMS`, then run `muxr`. Setup explains one recommended route—the healthy current route, Tailscale, an existing private network, an installed temporary tunnel, or same Wi-Fi—and changes nothing until **Apply setup**. Scan the one-use QR from the phone when it is ready.
 
 [Read the step-by-step quickstart →](https://trymuxr.com/docs/quickstart)
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -12,10 +12,12 @@ npm install -g --ignore-scripts @trymuxr/cli
 muxr
 ```
 
-The interactive onboarding inspects the machine without changing it. You choose
-the connection method, local port or external URL, whether to host the control/view-only
-web client, agent integrations, optional plugins, and managed services. After a
-final **Apply setup** confirmation, muxr starts the selected relay and host, then:
+The interactive onboarding inspects the machine without changing it. It keeps a
+healthy current route or proposes one detected private route, explains why, and
+puts alternative transports under **Choose another way**. You then choose
+whether to host the control/view-only web client, agent integrations, optional
+plugins, and managed services. After a final **Apply setup** confirmation, muxr
+starts the selected relay and host, then:
 
 1. Stores strict E2EE relay state under `~/.muxr/relay`.
 2. Runs the selected phone, browser, or sequential pairing flow.
@@ -41,8 +43,11 @@ automation uses `muxr shared-relay`, `muxr machines enroll|list|revoke`, and
 
 ## Reaching the relay from your phone
 
-Interactive onboarding presents these choices. The equivalent automation flags
-are:
+Interactive onboarding does not begin with a transport menu. It recommends one
+ready route in this order: the healthy current route, Tailscale Serve, direct
+Tailscale when Serve is proven disabled or occupied, a detected private overlay
+such as NetBird or WireGuard, an installed temporary tunnel, then same Wi-Fi.
+Choose **Choose another way** to see every available transport. Automation uses:
 
 | Flag | What happens |
 |---|---|
@@ -50,9 +55,10 @@ are:
 | `--tunnel` | Spawns `cloudflared` for a public `trycloudflare.com` URL. The URL is ephemeral; use a named tunnel for permanence. |
 | *(choose Tailscale Serve)* | Uses private HTTPS through `tailscale serve`; the relay stays on loopback. |
 | `--tailscale-direct` | Rollback path using the tailnet IP directly. |
-| *(choose Local network)* | LAN address. Phone must be on the same network. |
+| *(detected private network)* | Uses the address on an existing NetBird, WireGuard, ZeroTier, or similar interface. The phone must join that same private network. |
+| *(choose Same Wi-Fi)* | Local network address. Phone must be on the same trusted network. |
 
-Before recommending Serve, the wizard checks that it is available and not already owned. If Serve is disabled for the tailnet, muxr shows Tailscale's enablement link and offers direct Tailscale or LAN instead of waiting indefinitely.
+Before applying Serve, the wizard checks that it is available and not already owned. A timeout or invalid JSON response is inconclusive, so muxr keeps Serve recommended and lets the bounded Apply decide. Only proven disabled or occupied Serve changes the recommendation; muxr then preserves the existing state and offers direct Tailscale.
 
 muxr never enables Funnel. Restrict the Serve endpoint with a tailnet grant/ACL to intended devices even though muxr pairing and E2EE remain authoritative. `--web` requires a secure `wss://` route; insecure LAN HTTP is refused.
 

--- a/docs/npm-readme.md
+++ b/docs/npm-readme.md
@@ -18,7 +18,7 @@ The convenience installer at `https://raw.githubusercontent.com/umeranjum17/muxr
 First run:
 
 1. Install muxr on Android from Google Play testing or the [signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk), verified by [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS). On iOS, open the [public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) for 0.1.24 (build 45); Apple is not accepting new testers right now.
-2. Run `muxr`. It checks the computer, installs Herdr if needed, and asks how the phone should connect. Start with LAN when both devices use the same wifi.
+2. Run `muxr`. It checks the computer and proposes one ready route: the healthy current route, Tailscale, an existing private network such as NetBird or WireGuard, an installed temporary tunnel, or same Wi-Fi. **Choose another way** reveals every available alternative.
 3. Review the short plan, choose **Apply setup**, then scan the one-use QR from the phone app.
 
 Nothing changes before **Apply setup**. Setup then verifies the connection and managed services without printing credentials. Run `muxr pair` anytime for a fresh QR.
@@ -57,7 +57,7 @@ muxr self-host [--advertise <ws-url>] [--tunnel] [--tailscale-direct]
                [--port <n>] [--relay-only|--host-only] [--web] [--yes]
 ```
 
-The default uses Tailscale when available or the trusted local network otherwise. Session, terminal, attachment, and plugin-stream payloads use the strict v2 E2EE data plane; the relay routes ciphertext it cannot read.
+Interactive setup keeps the current healthy route, otherwise recommends Tailscale, a detected private overlay, an installed temporary tunnel, or the trusted local network in that order. An inconclusive Tailscale Serve preflight remains advisory; only proven disabled or occupied Serve changes the recommendation. Session, terminal, attachment, and plugin-stream payloads use the strict v2 E2EE data plane; the relay routes ciphertext it cannot read.
 
 For a shared VPS relay, prefer interactive `muxr`. Automation equivalents are:
 

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -237,6 +237,7 @@ function readMenuState() {
 const RELAY_KIND = {
     tailscale: 'Tailscale (private)',
     'tailscale-direct': 'Tailscale (direct IP)',
+    private: 'private network',
     cloudflare: 'Cloudflare tunnel (temporary public URL)',
     lan: 'LAN (same wifi)',
     external: 'your own server',

--- a/scripts/diagnostics/application/checkPackageSmoke.mjs
+++ b/scripts/diagnostics/application/checkPackageSmoke.mjs
@@ -453,13 +453,17 @@ try {
     const installedSkill = run(cli, ['--skill'], { cwd: installDir, env: cliEnv() }).stdout;
     assertCompactSkillOutput(installedSkill);
     assert.equal(run(cli, ['skill'], { cwd: installDir, env: cliEnv() }).stdout, installedSkill, 'packed skill alias diverged from --skill');
-    assert.match(run(cli, ['skill', 'onboarding'], { cwd: installDir, env: cliEnv() }).stdout, /## Diagnose and recover[\s\S]*muxr doctor[\s\S]*muxr diagnostics/);
+    const onboardingSkill = run(cli, ['skill', 'onboarding'], { cwd: installDir, env: cliEnv() }).stdout;
+    assert.match(onboardingSkill, /proposes one route[\s\S]*NetBird[\s\S]*WireGuard/);
+    assert.match(onboardingSkill, /## Diagnose and recover[\s\S]*muxr doctor[\s\S]*muxr diagnostics/);
     assert.match(run(cli, ['skill', 'collaboration'], { cwd: installDir, env: cliEnv() }).stdout, /muxr peers prompt/);
     assertUnifiedSkillOutput(run(cli, ['skill', 'all'], { cwd: installDir, env: cliEnv() }).stdout);
     const unavailablePeers = run(cli, ['peers', 'list'], { cwd: installDir, env: cliEnv(), allowFailure: true });
     assert.equal(unavailablePeers.status, 1);
     assert.match(unavailablePeers.stderr, /Peer access is not ready/);
     const wizardSource = readFileSync(join(installedPackage, 'setup/presentation/setupWizard.mjs'), 'utf8');
+    assert.match(wizardSource, /Recommended route[\s\S]*Use this route and continue[\s\S]*Choose another way/);
+    assert.match(wizardSource, /if \(recovered === undefined\) return stoppedAfterApply\(\)/, 'post-Apply stop falsely claimed nothing changed');
     const applyGuard = wizardSource.indexOf("if (apply !== true) return cancelSetup();");
     const tailscaleMutation = wizardSource.indexOf('await applyTailscaleConnect(found)', applyGuard);
     assert.ok(applyGuard >= 0 && tailscaleMutation > applyGuard, 'interactive setup may mutate Tailscale before Apply setup');

--- a/scripts/diagnostics/application/checkTailscaleIngress.mjs
+++ b/scripts/diagnostics/application/checkTailscaleIngress.mjs
@@ -3,11 +3,13 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileS
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
+    classifyNetworkRoutes,
     cleanupManagedIngress,
     continueWithDirectTailscale,
     inspectTailscaleServeRoot,
     persistOwnedServeIngress,
     readSelfhostState,
+    recommendedConnection,
     resolveAdvertise,
     selfhostArgsFromSetupPlan,
     tailscaleBin,
@@ -29,6 +31,29 @@ const commandsSince = (offset) => (existsSync(log) ? readFileSync(log, 'utf8') :
 process.env.PATH = `${scratch}:${originalPath}`;
 process.env.MUXR_HOME = join(scratch, 'muxr-home');
 try {
+    const routes = classifyNetworkRoutes({
+        docker0: [{ family: 'IPv4', internal: false, address: '172.17.0.1' }],
+        vboxnet0: [{ family: 'IPv4', internal: false, address: '192.168.56.1' }],
+        eno1: [{ family: 'IPv4', internal: false, address: '192.168.1.8' }],
+        wt0: [{ family: 'IPv4', internal: false, address: '100.90.0.4' }],
+        tailscale0: [{ family: 'IPv4', internal: false, address: '100.64.0.1' }],
+    });
+    assert.deepEqual(routes, {
+        private: { address: '100.90.0.4', interface: 'wt0', provider: 'NetBird' },
+        lan: '192.168.1.8',
+    });
+    const found = { tailscale: { connected: false }, private: routes.private, lan: routes.lan, cloudflared: { ok: false } };
+    assert.equal(recommendedConnection(found, undefined, false, { status: 'inconclusive' }).mode, 'private');
+    assert.equal(recommendedConnection({ ...found, private: undefined, cloudflared: { ok: true } }, undefined, false, { status: 'inconclusive' }).mode, 'cloudflare');
+    assert.equal(recommendedConnection({ ...found, private: undefined }, undefined, false, { status: 'inconclusive' }).mode, 'lan');
+    const privateArgs = selfhostArgsFromSetupPlan({ mode: 'private', port: 8792, web: false, pairing: 'phone', found });
+    assert.deepEqual(privateArgs.slice(-2), ['--advertise', 'ws://100.90.0.4:8792']);
+    assert.equal((await resolveAdvertise(privateArgs, 8792)).url, 'ws://100.90.0.4:8792');
+    assert.equal(recommendedConnection(found, { connectionMode: 'external', relayUrl: 'wss://relay.example', relayPort: 8792, relayHealthy: true, publicHealthy: true }, false, { status: 'free' }).mode, 'external');
+    assert.equal(recommendedConnection({ ...found, tailscale: { connected: true } }, undefined, false, { status: 'inconclusive' }).mode, 'tailscale');
+    assert.equal(recommendedConnection({ ...found, tailscale: { connected: true } }, undefined, false, { status: 'disabled' }).mode, 'tailscale-direct');
+    assert.equal(recommendedConnection({ ...found, tailscale: { connected: true } }, undefined, false, { status: 'occupied' }).mode, 'tailscale-direct');
+
     configure({ Self: { DNSName: 'dev.tailnet.ts.net.', TailscaleIPs: ['100.64.0.1'] } });
     const ingress = tailscaleIngress([]);
     assert.deepEqual(ingress, { dnsName: 'dev.tailnet.ts.net' });

--- a/scripts/diagnostics/application/checkTailscaleIngress.mjs
+++ b/scripts/diagnostics/application/checkTailscaleIngress.mjs
@@ -42,8 +42,13 @@ try {
         private: { address: '100.90.0.4', interface: 'wt0', provider: 'NetBird' },
         lan: '192.168.1.8',
     });
+    assert.deepEqual(classifyNetworkRoutes({
+        utun4: [{ family: 'IPv4', internal: false, address: '100.64.0.1' }],
+        utun5: [{ family: 'IPv4', internal: false, address: '10.20.0.2' }],
+    }, '100.64.0.1').private, { address: '10.20.0.2', interface: 'utun5', provider: 'private network' });
     const found = { tailscale: { connected: false }, private: routes.private, lan: routes.lan, cloudflared: { ok: false } };
     assert.equal(recommendedConnection(found, undefined, false, { status: 'inconclusive' }).mode, 'private');
+    assert.equal(recommendedConnection(found, undefined, true, { status: 'inconclusive' }).mode, 'private');
     assert.equal(recommendedConnection({ ...found, private: undefined, cloudflared: { ok: true } }, undefined, false, { status: 'inconclusive' }).mode, 'cloudflare');
     assert.equal(recommendedConnection({ ...found, private: undefined }, undefined, false, { status: 'inconclusive' }).mode, 'lan');
     const privateArgs = selfhostArgsFromSetupPlan({ mode: 'private', port: 8792, web: false, pairing: 'phone', found });

--- a/scripts/setup/domain/connection.ts
+++ b/scripts/setup/domain/connection.ts
@@ -99,7 +99,7 @@ export function parseConnection(state: unknown): Result<Connection> {
         reconfigureArgs() {
             const args: string[] = [];
             if (typeof mode === 'string') args.push('--connection-mode', mode);
-            if (mode === 'external' || mode === 'cloudflare') args.push('--advertise', String(record.relayUrl));
+            if (mode === 'external' || mode === 'private' || mode === 'cloudflare') args.push('--advertise', String(record.relayUrl));
             return args;
         },
         bindLoopback({ tailscale, tunnel, web, advertise }) {
@@ -114,7 +114,7 @@ export function parseConnection(state: unknown): Result<Connection> {
         },
         sameAs({ port, connectionMode, web, explicitAdvertise }) {
             if (record.relayPort !== port || record.connectionMode !== connectionMode || record.webEnabled !== web) return false;
-            if (connectionMode === 'external' || connectionMode === 'lan') return record.relayUrl === explicitAdvertise;
+            if (connectionMode === 'external' || connectionMode === 'private' || connectionMode === 'lan') return record.relayUrl === explicitAdvertise;
             return true;
         },
         credentialDaysRemaining(now = Date.now()) {
@@ -128,7 +128,7 @@ export function parseConnection(state: unknown): Result<Connection> {
 
 export type AdvertiseContext = {
     mode: string;
-    found: { lan?: string; tailscale: { ip?: string; dnsName?: string } };
+    found: { private?: { address: string }; lan?: string; tailscale: { ip?: string; dnsName?: string } };
     current?: { connectionMode?: string; relayUrl?: string; relayPort?: number; webEnabled?: boolean; ingressHealthy?: boolean };
     port: number;
     endpoint?: string;
@@ -139,6 +139,7 @@ export type AdvertiseContext = {
 export function advertisedUrlForMode(context: AdvertiseContext): string | undefined {
     const { mode, found, current, port, endpoint, web, tailscalePlanned } = context;
     if (mode === 'lan') return found.lan === undefined ? undefined : `ws://${found.lan}:${port}`;
+    if (mode === 'private') return endpoint ?? (found.private === undefined ? undefined : `ws://${found.private.address}:${port}`);
     if (mode === 'external') return endpoint;
     if (mode === 'tailscale-direct' && found.tailscale.ip) return `ws://${found.tailscale.ip}:${port}`;
     if (mode === 'tailscale-direct' && tailscalePlanned && current?.connectionMode === mode) return current.relayUrl;
@@ -171,6 +172,7 @@ export function ingressPlan(mode: string, tailscalePlanned: boolean, { shared = 
 export function connectionLabel(mode: string, endpoint: string | undefined, port: number): string {
     if (mode === 'tailscale') return `Tailscale Serve on local port ${port}`;
     if (mode === 'tailscale-direct') return `Direct Tailscale on port ${port}`;
+    if (mode === 'private') return `Private network on port ${port}`;
     if (mode === 'lan') return `Trusted LAN on port ${port}`;
     if (mode === 'cloudflare') return `Cloudflare quick tunnel to local port ${port}`;
     return `External ${endpoint ?? ''}`;

--- a/scripts/setup/index.mjs
+++ b/scripts/setup/index.mjs
@@ -52,10 +52,12 @@ export {
 
 export {
     applyMachineSetup,
+    classifyNetworkRoutes,
     connectRemoteRelay,
     continueWithDirectTailscale,
     hostSharedRelay,
     manageMachines,
+    recommendedConnection,
     selfhostArgsFromSetupPlan,
 } from './presentation/setupWizard.mjs';
 

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -57,13 +57,32 @@ function value(args, name) {
     return index >= 0 ? args[index + 1] : undefined;
 }
 
-function lanAddress() {
-    for (const list of Object.values(networkInterfaces())) {
+const privateIpv4 = (address) => /^10\./.test(address)
+    || /^192\.168\./.test(address)
+    || /^172\.(?:1[6-9]|2\d|3[01])\./.test(address);
+const overlayIpv4 = (address) => {
+    const match = address.match(/^100\.(\d+)\./);
+    return match !== null && Number(match[1]) >= 64 && Number(match[1]) <= 127;
+};
+const overlayProvider = (name) => {
+    if (/^(?:wt|netbird|nb)/i.test(name)) return 'NetBird';
+    if (/^wg/i.test(name)) return 'WireGuard';
+    if (/^zt/i.test(name)) return 'ZeroTier';
+    return 'private network';
+};
+
+export function classifyNetworkRoutes(interfaces = networkInterfaces()) {
+    const routes = { private: undefined, lan: undefined };
+    for (const [name, list] of Object.entries(interfaces)) {
         for (const entry of list ?? []) {
-            if (entry.family === 'IPv4' && !entry.internal) return entry.address;
+            if (entry.family !== 'IPv4' || entry.internal || /^tailscale/i.test(name)) continue;
+            const overlay = /^(?:wt|netbird|nb|wg|zt|tun|tap)/i.test(name) || overlayIpv4(entry.address);
+            if (overlay && routes.private === undefined) routes.private = { address: entry.address, interface: name, provider: overlayProvider(name) };
+            if (!overlay && routes.lan === undefined && privateIpv4(entry.address)
+                && !/^(?:docker|br-|veth|virbr|podman|lxc|vbox|vmnet|hyperv|wsl)/i.test(name)) routes.lan = entry.address;
         }
     }
-    return undefined;
+    return routes;
 }
 
 function integrationSummary(result) {
@@ -121,12 +140,15 @@ export function probeMachine() {
     const herdrVersion = command(binary, ['--version']);
     const integration = herdrVersion.ok ? command(binary, ['integration', 'status']) : { ok: false, output: '' };
     const agents = integrationSummary(integration);
+    const routes = classifyNetworkRoutes();
+    const tailscale = probeTailscale();
     return {
         herdr: { installed: !herdrVersion.missing, working: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrVersion.ok && herdrServerIsReady(binary) },
         agents,
-        tailscale: probeTailscale(),
+        tailscale,
         cloudflared: probeCloudflared(),
-        lan: lanAddress(),
+        private: routes.private?.address === tailscale.ip ? undefined : routes.private,
+        lan: routes.lan,
     };
 }
 
@@ -148,6 +170,7 @@ function renderInspection(found) {
     status('Herdr server', found.herdr.running ? 'running' : 'will be started', found.herdr.running ? 'ok' : 'warn');
     status('Agent integrations', agentIntegrationDetail(found), found.agents.checked && found.agents.current.length ? 'ok' : 'warn');
     status('Tailscale', found.tailscale.connected ? `connected — ${found.tailscale.ip}` : found.tailscale.detail, found.tailscale.connected ? 'ok' : 'off');
+    if (found.private) status('Private network', `${found.private.provider} on ${found.private.interface} — ${found.private.address}`, 'ok');
     status('Cloudflare Tunnel', found.cloudflared.ok ? 'available' : found.cloudflared.detail, found.cloudflared.ok ? 'ok' : 'off');
     process.stdout.write('\n');
 }
@@ -227,6 +250,7 @@ async function installPlugins(plugins) {
 const RELAY_KIND = {
     tailscale: 'Tailscale (private)',
     'tailscale-direct': 'Tailscale (direct IP)',
+    private: 'your private network',
     cloudflare: 'a temporary Cloudflare tunnel',
     lan: 'your LAN (same wifi only)',
     external: 'your own server',
@@ -234,53 +258,67 @@ const RELAY_KIND = {
 const relayKind = (mode) => RELAY_KIND[mode] ?? mode;
 
 function choices(found, tailscalePlanned = false, serveRoot = { status: 'inconclusive' }) {
-    // The relay is the one real choice in setup: it is how the phone reaches
-    // the host. Never delete an option silently — show it disabled with the
-    // reason and remedy attached, so the user sees what is standing in the way.
     const options = [];
     const serveOccupied = serveRoot.status === 'occupied';
-    const serveDisabled = serveRoot.status === 'disabled' && !tailscalePlanned;
+    const serveDisabled = serveRoot.status === 'disabled';
     if (found.tailscale.connected || tailscalePlanned) {
-        if (serveOccupied || serveDisabled) {
-            let directDescription = 'connect during Apply · reach this computer over the tailnet address';
-            if (!tailscalePlanned) directDescription = serveOccupied
-                ? 'private tailnet address · leaves the existing Serve service unchanged'
-                : 'private tailnet address · does not require Tailscale Serve';
-            options.push({
-                value: 'tailscale',
-                title: 'Tailscale Serve',
-                description: serveOccupied ? 'already used by another service · left unchanged' : serveRoot.reason,
-                disabled: true,
-            });
-            options.push({
-                value: 'tailscale-direct',
-                title: 'Tailscale · recommended',
-                description: directDescription,
-            });
-        } else {
-            options.push({
-                value: 'tailscale',
-                title: 'Tailscale · recommended',
-                description: serveRoot.status === 'inconclusive'
-                    ? 'private connection · availability will be verified during Apply'
-                    : tailscalePlanned ? 'connect during Apply · private access from anywhere' : 'private connection · works from anywhere · nothing exposed publicly',
-            });
-        }
+        let serveDescription = 'private HTTPS · works from anywhere';
+        if (serveOccupied) serveDescription = 'already used by another service · left unchanged';
+        else if (serveDisabled) serveDescription = serveRoot.reason;
+        options.push({
+            value: 'tailscale',
+            title: 'Tailscale Serve',
+            description: serveDescription,
+            disabled: serveOccupied || serveDisabled,
+        });
+        options.push({
+            value: 'tailscale-direct',
+            title: 'Direct Tailscale',
+            description: tailscalePlanned ? 'connect during Apply · use the private tailnet address' : 'use the private tailnet address · does not require Serve',
+        });
     } else {
         options.push({ value: 'tailscale', title: 'Tailscale', description: found.tailscale.detail, disabled: true });
     }
-    if (found.cloudflared.ok) {
-        options.push({ value: 'cloudflare', title: 'Cloudflare tunnel', description: 'temporary public HTTPS URL · nothing to run yourself' });
-    } else {
-        options.push({ value: 'cloudflare', title: 'Cloudflare tunnel', description: found.cloudflared.detail, disabled: true });
+    if (found.private) {
+        options.push({
+            value: 'private',
+            title: found.private.provider === 'private network' ? 'Private network' : `${found.private.provider} private network`,
+            description: `${found.private.interface} · phone must join the same private network`,
+        });
     }
     if (found.lan) {
-        options.push({ value: 'lan', title: found.tailscale.connected || tailscalePlanned ? 'LAN' : 'LAN · recommended', description: 'works now · phone and computer must use the same wifi' });
+        options.push({ value: 'lan', title: 'Same Wi-Fi', description: 'works now · phone and computer must use the same trusted network' });
     } else {
-        options.push({ value: 'lan', title: 'LAN', description: 'no usable LAN address found on this machine', disabled: true });
+        options.push({ value: 'lan', title: 'Same Wi-Fi', description: 'no usable local-network address found', disabled: true });
     }
-    options.push({ value: 'external', title: 'Your own server', description: 'an always-on relay you run · works from anywhere' });
+    if (found.cloudflared.ok) {
+        options.push({ value: 'cloudflare', title: 'Temporary Cloudflare tunnel', description: 'create a temporary public HTTPS URL during Apply' });
+    } else {
+        options.push({ value: 'cloudflare', title: 'Temporary Cloudflare tunnel', description: found.cloudflared.detail, disabled: true });
+    }
+    options.push({ value: 'external', title: 'Your own server', description: 'use an existing stable wss:// relay address' });
     return options;
+}
+
+export function recommendedConnection(found, current, tailscalePlanned, serveRoot) {
+    if (current?.relayHealthy && current?.publicHealthy
+        && ['tailscale', 'tailscale-direct', 'private', 'lan', 'external', 'cloudflare'].includes(current.connectionMode)) {
+        return { mode: current.connectionMode, title: connectionLabel(current.connectionMode, current.relayUrl, current.relayPort), description: 'already configured and reachable' };
+    }
+    if (found.tailscale.connected || tailscalePlanned) {
+        const direct = serveRoot.status === 'occupied' || serveRoot.status === 'disabled';
+        return direct
+            ? { mode: 'tailscale-direct', title: 'Direct Tailscale', description: 'private tailnet route · Tailscale Serve is not required' }
+            : { mode: 'tailscale', title: 'Tailscale Serve', description: tailscalePlanned ? 'connect Tailscale during Apply, then create private HTTPS access' : 'private access from anywhere · nothing exposed publicly' };
+    }
+    if (found.private) return {
+        mode: 'private',
+        title: `${found.private.provider} on ${found.private.interface}`,
+        description: 'use the private network already connected to this computer',
+    };
+    if (found.cloudflared.ok) return { mode: 'cloudflare', title: 'Temporary Cloudflare tunnel', description: 'create a temporary public HTTPS route during Apply' };
+    if (found.lan) return { mode: 'lan', title: 'Same Wi-Fi', description: 'works now while the phone and computer use this trusted network' };
+    return undefined;
 }
 
 const aborted = (value) => value === undefined || value === BACK;
@@ -299,6 +337,7 @@ export function continueWithDirectTailscale(plan) {
 export function selfhostArgsFromSetupPlan({ mode, port, web, pairing, found, endpoint }) {
     const selfhostArgs = ['--port', String(port), '--connection-mode', mode, '--reconfigure'];
     if (mode === 'lan') selfhostArgs.push('--advertise', `ws://${found.lan}:${port}`);
+    if (mode === 'private') selfhostArgs.push('--advertise', endpoint ?? `ws://${found.private.address}:${port}`);
     if (mode === 'external') selfhostArgs.push('--advertise', endpoint);
     if (mode === 'cloudflare') selfhostArgs.push('--tunnel');
     if (mode === 'tailscale-direct') selfhostArgs.push('--tailscale-direct');
@@ -315,26 +354,45 @@ function serveRootFor(found, port) {
 }
 
 async function chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args }) {
-    const plannedPort = Number(value(args, '--port')) || current?.relayPort || 8792;
+    const requestedPort = value(args, '--port');
+    const plannedPort = requestedPort === undefined ? current?.relayPort || 8792 : Number(requestedPort);
     const serveRoot = serveRootFor(found, plannedPort);
     let mode = requestedMode;
     if (mode === 'selfhost') mode = undefined;
     if (!mode) {
-        heading('muxr runs on this computer');
-        const connectionChoices = choices(found, tailscalePlanned, serveRoot).map((choice) => {
-            if (choice.value !== current?.connectionMode) return choice;
-            return { ...choice, title: `${choice.title} · current` };
-        });
-        const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
-        mode = await select('How should your phone connect?', connectionChoices, initial);
+        heading('Connect your phone to this computer');
+        const proposal = recommendedConnection(found, current, tailscalePlanned, serveRoot);
+        if (proposal) {
+            status('Recommended route', proposal.title, 'ok');
+            note(proposal.description);
+            const action = await select('Continue with this route?', [
+                { value: 'use', title: 'Use this route and continue', description: 'review every change before muxr applies it' },
+                { value: 'advanced', title: 'Choose another way', description: 'private networks, same Wi-Fi, tunnels, and your own server' },
+            ]);
+            if (aborted(action)) return undefined;
+            if (action === 'use') mode = proposal.mode;
+        } else {
+            note(['No ready route was detected.', 'Choose an existing network or server; muxr will not expose this computer automatically.']);
+        }
+        if (!mode) {
+            const connectionChoices = choices(found, tailscalePlanned, serveRoot).map((choice) => choice.value === current?.connectionMode
+                ? { ...choice, title: `${choice.title} · current` }
+                : choice);
+            const initial = Math.max(0, connectionChoices.findIndex((choice) => choice.value === current?.connectionMode));
+            mode = await select('Choose another way', connectionChoices, initial);
+        }
     }
     if (aborted(mode)) return undefined;
-    if (!['tailscale', 'tailscale-direct', 'lan', 'external', 'cloudflare'].includes(mode)) {
+    if (!['tailscale', 'tailscale-direct', 'private', 'lan', 'external', 'cloudflare'].includes(mode)) {
         process.stderr.write(`unknown setup mode: ${mode}\n`);
         return 1;
     }
     if ((mode === 'tailscale' || mode === 'tailscale-direct') && !found.tailscale.connected && !tailscalePlanned) {
         process.stderr.write(`Tailscale is unavailable: ${found.tailscale.detail}; or pick a different relay\n`);
+        return 1;
+    }
+    if (mode === 'private' && !found.private) {
+        process.stderr.write('no private-network address was found; connect NetBird, WireGuard, or another private network, then retry\n');
         return 1;
     }
     if (mode === 'lan' && !found.lan) {
@@ -346,16 +404,12 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
         return 1;
     }
 
-    let port = current === undefined && value(args, '--port') === undefined ? 8792 : undefined;
-    while (port === undefined) {
-        setupStep(2, 5, 'Choose connection port');
-        const portText = await prompt('Local connection port', value(args, '--port') ?? String(current.relayPort));
-        if (portText === undefined) return undefined;
-        const parsed = Number(portText);
-        if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
-        else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
+    const port = plannedPort;
+    if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+        process.stderr.write('setup port must be an integer from 1024 to 65535\n');
+        return 1;
     }
-    let endpoint;
+    let endpoint = mode === 'private' && current?.connectionMode === 'private' && current.publicHealthy ? current.relayUrl : undefined;
     if (mode === 'external') {
         while (endpoint === undefined) {
             setupStep(2, 5, 'Enter your server address');
@@ -407,7 +461,7 @@ async function chooseMachineConnection({ found, current, tailscalePlanned, reque
     return { mode, port, endpoint, web, pairing };
 }
 
-async function recoverTailscaleServe({ plan, found, current, tailscalePlanned, args }) {
+async function recoverTailscaleServe({ plan, found }) {
     if (plan.mode !== 'tailscale') return plan;
     const serveRoot = serveRootFor(found, plan.port);
     if (serveRoot.status === 'free' || serveRoot.status === 'ours' || serveRoot.status === 'inconclusive') return plan;
@@ -418,28 +472,21 @@ async function recoverTailscaleServe({ plan, found, current, tailscalePlanned, a
     note(occupied ? [
         'Another service already owns the Tailscale Serve root.',
         'muxr left that service unchanged.',
-        'You can use direct Tailscale networking, or go back and choose a different connection.',
+        'You can use direct Tailscale networking now, or stop and rerun setup with another route.',
     ] : [
         serveRoot.reason || 'muxr could not verify that Tailscale Serve is available.',
         'muxr made no Serve changes.',
-        'You can use direct Tailscale networking, or go back and choose LAN or another connection.',
+        'You can use direct Tailscale networking now, or stop and rerun setup with another route.',
     ]);
     const action = await select('How do you want to continue?', [
         { value: 'direct', title: 'Use direct Tailscale networking', description: 'reach this computer over its tailnet address · does not require Serve' },
-        { value: 'back', title: 'Change how your phone connects', description: 'go back and pick a different connection' },
+        { value: 'stop', title: 'Stop here', description: 'keep completed prerequisites and rerun setup to choose another route' },
     ]);
-    if (aborted(action)) return undefined;
-    if (action === 'direct') {
-        const next = continueWithDirectTailscale(plan);
-        if (plan.web) status('Browser client', 'needs Tailscale Serve or HTTPS; continuing with the native app only', 'warn');
-        status('Connection', connectionLabel(next.mode, next.endpoint, next.port), 'ok');
-        return next;
-    }
-    setupStep(2, 5, 'Choose how your phone connects');
-    const chosen = await chooseMachineConnection({ found, current, tailscalePlanned, requestedMode: undefined, args });
-    if (chosen === undefined) return undefined;
-    if (chosen === 1) return 1;
-    return chosen;
+    if (action !== 'direct') return undefined;
+    const next = continueWithDirectTailscale(plan);
+    if (plan.web) status('Browser client', 'needs Tailscale Serve or HTTPS; continuing with the native app only', 'warn');
+    status('Connection', connectionLabel(next.mode, next.endpoint, next.port), 'ok');
+    return next;
 }
 
 // Any abort before Apply must say so; a silent exit reads as "something ran".
@@ -447,6 +494,12 @@ function cancelled() {
     outro('Cancelled. Nothing changed.');
     completeFullscreen();
     return 0;
+}
+
+function stoppedAfterApply() {
+    outro('Stopped before the relay was configured. Completed prerequisites were kept; rerun muxr to finish setup.', 'warn');
+    completeFullscreen();
+    return 1;
 }
 
 // Choosing this only adds Tailscale to the reviewed plan. The command itself
@@ -508,13 +561,13 @@ export async function applyMachineSetup(args = []) {
     setupStep(1, 5, 'Check this machine');
     const found = await withSpinner('Inspecting Herdr, agents, and networking', async () => probeMachine());
     renderInspection(found);
-    const tailscaleResult = await offerTailscaleConnect(found);
-    if (aborted(tailscaleResult)) return cancelled();
-    const tailscalePlanned = tailscaleResult === true;
+    // A disconnected Tailscale installation is proposed as one reviewed route;
+    // connecting it remains behind Apply instead of becoming a preflight prompt.
+    const tailscalePlanned = found.tailscale.installed && !found.tailscale.connected && found.tailscale.backend !== undefined;
     const cancelSetup = () => cancelled();
     const current = await selfhostPublicSummary();
 
-    setupStep(2, 5, 'Choose how your phone connects');
+    setupStep(2, 5, 'Connect your phone');
     let plan = await chooseMachineConnection({ found, current, tailscalePlanned, requestedMode, args });
     if (plan === undefined) return cancelSetup();
     if (plan === 1) return 1;
@@ -569,9 +622,8 @@ export async function applyMachineSetup(args = []) {
     status('Network', 'checking Tailscale Serve ownership and local relay port', 'off');
     let result = 1;
     for (;;) {
-        const recovered = await recoverTailscaleServe({ plan, found, current, tailscalePlanned, args });
-        if (recovered === undefined) return cancelSetup();
-        if (recovered === 1) return 1;
+        const recovered = await recoverTailscaleServe({ plan, found });
+        if (recovered === undefined) return stoppedAfterApply();
         plan = recovered;
         result = await startSelfHost(selfhostArgsFromSetupPlan({ ...plan, found }));
         if (result === 0) break;
@@ -629,15 +681,9 @@ export async function hostSharedRelay() {
         process.stderr.write('This machine already runs an agent host. Use a dedicated VPS for a shared relay, or remove the existing setup first.\n');
         return 1;
     }
-    const options = choices(found, tailscalePlanned).filter((choice) => ['tailscale', 'external'].includes(choice.value)).map((choice) => choice.value === current?.connectionMode
-        ? { ...choice, title: `${choice.title} · current` }
-        : choice);
-    const initial = Math.max(0, options.findIndex((choice) => choice.value === current?.connectionMode));
     heading('This machine becomes the relay');
     status('relay', 'agent hosts dial out to it — the only choice is how they reach it', 'ok');
     process.stdout.write('\n');
-    let mode = await select('How should machines reach this shared relay?', options, initial);
-    if (aborted(mode)) return cancelRelaySetup();
     let port;
     while (port === undefined) {
         const entered = await prompt('Relay port', String(current?.relayPort ?? 8792));
@@ -646,6 +692,12 @@ export async function hostSharedRelay() {
         if (Number.isInteger(parsed) && parsed >= 1024 && parsed <= 65535) port = parsed;
         else status('Relay port', 'enter an integer from 1024 to 65535', 'warn');
     }
+    const options = choices(found, tailscalePlanned, serveRootFor(found, port)).filter((choice) => ['tailscale', 'external'].includes(choice.value)).map((choice) => choice.value === current?.connectionMode
+        ? { ...choice, title: `${choice.title} · current` }
+        : choice);
+    const initial = Math.max(0, options.findIndex((choice) => choice.value === current?.connectionMode));
+    const mode = await select('How should machines reach this shared relay?', options, initial);
+    if (aborted(mode)) return cancelRelaySetup();
     let endpoint;
     if (mode === 'external') {
         while (endpoint === undefined) {

--- a/scripts/setup/presentation/setupWizard.mjs
+++ b/scripts/setup/presentation/setupWizard.mjs
@@ -71,12 +71,13 @@ const overlayProvider = (name) => {
     return 'private network';
 };
 
-export function classifyNetworkRoutes(interfaces = networkInterfaces()) {
+export function classifyNetworkRoutes(interfaces = networkInterfaces(), ignoredAddress) {
     const routes = { private: undefined, lan: undefined };
     for (const [name, list] of Object.entries(interfaces)) {
         for (const entry of list ?? []) {
-            if (entry.family !== 'IPv4' || entry.internal || /^tailscale/i.test(name)) continue;
-            const overlay = /^(?:wt|netbird|nb|wg|zt|tun|tap)/i.test(name) || overlayIpv4(entry.address);
+            if (entry.family !== 'IPv4' || entry.internal || entry.address === ignoredAddress || /^tailscale/i.test(name)) continue;
+            // ponytail: CGNAT implies an overlay; add route-table evidence if WISP false positives become common.
+            const overlay = /^(?:wt|netbird|nb|wg|zt|utun|tun|tap)/i.test(name) || overlayIpv4(entry.address);
             if (overlay && routes.private === undefined) routes.private = { address: entry.address, interface: name, provider: overlayProvider(name) };
             if (!overlay && routes.lan === undefined && privateIpv4(entry.address)
                 && !/^(?:docker|br-|veth|virbr|podman|lxc|vbox|vmnet|hyperv|wsl)/i.test(name)) routes.lan = entry.address;
@@ -140,14 +141,14 @@ export function probeMachine() {
     const herdrVersion = command(binary, ['--version']);
     const integration = herdrVersion.ok ? command(binary, ['integration', 'status']) : { ok: false, output: '' };
     const agents = integrationSummary(integration);
-    const routes = classifyNetworkRoutes();
     const tailscale = probeTailscale();
+    const routes = classifyNetworkRoutes(networkInterfaces(), tailscale.ip);
     return {
         herdr: { installed: !herdrVersion.missing, working: herdrVersion.ok, version: herdrVersion.output.split('\n')[0], running: herdrVersion.ok && herdrServerIsReady(binary) },
         agents,
         tailscale,
         cloudflared: probeCloudflared(),
-        private: routes.private?.address === tailscale.ip ? undefined : routes.private,
+        private: routes.private,
         lan: routes.lan,
     };
 }
@@ -305,7 +306,7 @@ export function recommendedConnection(found, current, tailscalePlanned, serveRoo
         && ['tailscale', 'tailscale-direct', 'private', 'lan', 'external', 'cloudflare'].includes(current.connectionMode)) {
         return { mode: current.connectionMode, title: connectionLabel(current.connectionMode, current.relayUrl, current.relayPort), description: 'already configured and reachable' };
     }
-    if (found.tailscale.connected || tailscalePlanned) {
+    if (found.tailscale.connected || (tailscalePlanned && !found.private)) {
         const direct = serveRoot.status === 'occupied' || serveRoot.status === 'disabled';
         return direct
             ? { mode: 'tailscale-direct', title: 'Direct Tailscale', description: 'private tailnet route · Tailscale Serve is not required' }
@@ -627,7 +628,8 @@ export async function applyMachineSetup(args = []) {
         plan = recovered;
         result = await startSelfHost(selfhostArgsFromSetupPlan({ ...plan, found }));
         if (result === 0) break;
-        if (plan.mode !== 'tailscale' || serveRootFor(found, plan.port).status !== 'occupied') return result;
+        const failedServe = plan.mode === 'tailscale' ? serveRootFor(found, plan.port).status : undefined;
+        if (failedServe !== 'occupied' && failedServe !== 'disabled') return result;
     }
     const { mode, endpoint, port, pairing } = plan;
     const browserPairFailed = pairing === 'both' && (await pairDevice(['--browser'])) !== 0;

--- a/skills/muxr/references/onboarding.md
+++ b/skills/muxr/references/onboarding.md
@@ -33,9 +33,10 @@ Node itself.
 ## First run
 
 Run `muxr` with no arguments for the interactive setup and maintenance menu.
-The onboarding inspects the machine without changing it. You choose the
-connection method, local port or external URL, whether to host the
-control/view-only web client, agent integrations, optional plugins, and managed
+The onboarding inspects the machine without changing it. It keeps a healthy
+current route or proposes one detected private route and explains why. Accept
+that route or open **Choose another way** for alternative transports;
+then choose browser access, agent integrations, optional plugins, and managed
 services. Nothing changes before a final **Apply setup** confirmation. Setup
 then starts the selected relay and host, runs the pairing flow (scan the
 one-use QR from the phone app), and verifies the connection and managed
@@ -51,19 +52,25 @@ return after login or reboot. Preview managed-file changes anytime with
 
 ## Connection choices
 
-Interactive onboarding presents these; the automation equivalents are flags on
-`muxr self-host`:
+Interactive onboarding proposes one route instead of presenting infrastructure
+choices first. It prefers the healthy current route, Tailscale, a detected
+private overlay, an installed temporary tunnel, then same Wi-Fi. **Choose another way** reveals every available
+transport. Automation equivalents are flags on `muxr self-host`:
 
 | Choice / flag | What happens |
 |---|---|
 | `--advertise <url>` | Explicit relay URL wins. Use your own domain/reverse proxy. |
 | `--tunnel` | Spawns `cloudflared` for a public `trycloudflare.com` URL. Ephemeral; use a named tunnel for permanence. |
 | Tailscale Serve | Private HTTPS through `tailscale serve`; the relay stays on loopback. |
-| `--tailscale-direct` | Rollback path using the tailnet IP directly. |
-| Local network | LAN address. Phone must be on the same wifi. |
+| `--tailscale-direct` | Uses the tailnet IP directly when Serve is proven disabled or occupied. |
+| Detected private network | Existing NetBird, WireGuard, ZeroTier, or similar address. Phone must join the same private network. |
+| Same Wi-Fi | Local network address. Phone must be on the same trusted network. |
 
-muxr never enables Tailscale Funnel. Restrict a Serve endpoint with a tailnet
-grant/ACL even though pairing and E2EE remain authoritative. `--web` requires a
+An inconclusive read-only Serve probe does not demote Tailscale; the bounded
+Apply is authoritative. Proven disabled or occupied Serve is left unchanged and
+direct Tailscale is proposed instead. muxr never enables Tailscale Funnel.
+Restrict a Serve endpoint with a tailnet grant/ACL even though pairing and E2EE
+remain authoritative. `--web` requires a
 secure `wss://` route; insecure LAN HTTP is refused. Set `MUXR_TRUST_PROXY=1`
 when the relay sits behind cloudflared/nginx so rate limits key on real client
 IPs.
@@ -150,7 +157,7 @@ bounded deadline. Then follow the matching remedy:
 |---|---|
 | Herdr server or lifecycle integrations | accept doctor's offered repair, or run `muxr integrations sync`; rerun doctor |
 | muxr service, relay, or local peer access | `muxr daemon restart`, then `muxr doctor` |
-| Tailscale Serve | if Tailscale says Serve is not enabled, use its printed `login.tailscale.com` link or the Tailscale admin console to enable Serve, then rerun setup; otherwise choose LAN / `muxr self-host --tailscale-direct`. Restart `tailscaled` only when another connection can survive the interruption. |
+| Tailscale Serve | if Tailscale proves Serve is disabled, use its printed `login.tailscale.com` link or accept direct Tailscale. A timeout is inconclusive: let bounded Apply retry or choose another route. Restart `tailscaled` only when another connection can survive the interruption. |
 | Local relay port | `curl --max-time 3 http://127.0.0.1:8792/health`; inspect the owner with `ss -ltnp 'sport = :8792'` on Linux or `lsof -nP -iTCP:8792 -sTCP:LISTEN` on macOS; stop only a process you recognize or rerun `muxr setup --port <free-port>` |
 | Expired or interrupted pairing | `muxr pair` for a new single-use code |
 | Connection choice or tunnel | rerun interactive `muxr`; do not edit `~/.muxr` |


### PR DESCRIPTION
## Summary

- replace the infrastructure-first connection menu with one detected, explained route proposal
- keep a healthy current route first, then rank Tailscale, existing private overlays, an installed temporary tunnel, and same Wi-Fi
- detect NetBird, WireGuard, ZeroTier, and generic private interfaces without adding provider-specific integrations
- keep every alternative under **Choose another way** and preserve the final **Apply setup** trust gate
- keep inconclusive Tailscale Serve checks advisory; only proven disabled or occupied Serve selects direct Tailscale
- update the public README, npm README, self-hosting guide, and bundled onboarding skill to match the shipped flow

This is stacked on #199 because it consumes the bounded Serve states introduced there. Merge #199 first; this PR can then be retargeted to `main`.

## User flow

1. muxr inspects the machine without changing it.
2. Setup shows one **Recommended route** with **Use this route and continue**.
3. **Choose another way** reveals private networks, same Wi-Fi, temporary tunnels, and custom servers.
4. The user reviews all changes and chooses **Apply setup**.
5. Setup verifies the route and shows the existing one-use pairing QR.

If Tailscale Serve becomes unavailable after Apply, setup offers direct Tailscale or stops with an accurate receipt; it no longer restarts the wizard or claims that nothing changed after prerequisites ran.

## Safety

- no network, service, integration, or plugin mutation occurs before **Apply setup**
- occupied Serve state is never overwritten
- existing healthy routes and pairings stay preferred
- Docker, VM host-only, and Tailscale duplicate interfaces are excluded from misleading LAN/private recommendations
- the new private-overlay mode uses the selected private address for the QR; pairing and E2EE remain authoritative

## Verification

- `mise x node@22.23.2 -- yarn build`
- `node scripts/diagnostics/application/checkTailscaleIngress.mjs`
- `node scripts/diagnostics/application/checkArchitecture.mjs`
- `node scripts/diagnostics/application/checkPackageSmoke.mjs`
- temporary-state flow QA: private relay reached QR generation; invalid ports created no state or mutation commands
- read-only review approved after the post-Apply receipt, shared-relay preflight, macOS duplicate-route, VM adapter, and documentation findings were repaired

## Deliberate non-goals

- SSH-carried pairing is separate contract/mobile work and is not added here.
- Exact interface-only relay binding is not changed here; direct private/LAN modes retain the existing listener behavior, with muxr pairing and E2EE still required.
- No provider is installed or configured automatically.
