### PR TITLE
feat(mobile): improve file and diff navigation

### DIFF
--- a/apps/mobile/sources/app/(app)/_layout.tsx
+++ b/apps/mobile/sources/app/(app)/_layout.tsx
@@ -102,6 +102,14 @@ export default function RootLayout() {
                 }}
             />
             <Stack.Screen
+                name="session/[id]/file"
+                options={{
+                    headerShown: true,
+                    headerTitle: t('common.fileViewer'),
+                    headerBackTitle: t('common.back'),
+                }}
+            />
+            <Stack.Screen
                 name="session/[id]/takeover"
                 options={{
                     headerShown: true,

--- a/apps/mobile/sources/app/(app)/plugin/index.tsx
+++ b/apps/mobile/sources/app/(app)/plugin/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActivityIndicator, View, Text, Pressable } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { PluginSlot } from '@/plugins/ui';
-import { pluginCatalogLoaded, pluginSnapshot, pluginUnavailableReason } from '@/plugins';
+import { nearestContentMount, pluginCatalogLoaded, pluginSnapshot, pluginUnavailableReason } from '@/plugins';
 import { resolvePluginText } from '@/plugins';
 import { useSlotContributions } from '@/plugins';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
@@ -85,8 +85,7 @@ function mountTitle(pluginId: string, contentId: string): string {
     const entry = pluginSnapshot().find((item) => item.summary.pluginId === pluginId);
     if (entry === undefined) return '';
     const mounts = entry.manifest.contributions.filter((contribution) => 'contentContributionId' in contribution);
-    const mount = mounts.find((contribution) => contribution.contentContributionId === contentId)
-        ?? mounts.find((contribution) => contentId.startsWith(`${String(contribution.contentContributionId).split('.')[0]}.`));
+    const mount = nearestContentMount(mounts, contentId);
     if (mount !== undefined && 'label' in mount) return resolvePluginText(mount.label);
     if (mount !== undefined && 'title' in mount && mount.title !== undefined) return resolvePluginText(mount.title);
     return entry.summary.name;

--- a/apps/mobile/sources/app/(app)/plugin/index.tsx
+++ b/apps/mobile/sources/app/(app)/plugin/index.tsx
@@ -84,7 +84,10 @@ export default function PluginPage() {
 function mountTitle(pluginId: string, contentId: string): string {
     const entry = pluginSnapshot().find((item) => item.summary.pluginId === pluginId);
     if (entry === undefined) return '';
-    const nav = entry.manifest.contributions.find((contribution) =>
-        'type' in contribution && contribution.type === 'navigation-item' && contribution.contentContributionId === contentId);
-    return nav !== undefined && 'label' in nav ? resolvePluginText(nav.label) : entry.summary.name;
+    const mounts = entry.manifest.contributions.filter((contribution) => 'contentContributionId' in contribution);
+    const mount = mounts.find((contribution) => contribution.contentContributionId === contentId)
+        ?? mounts.find((contribution) => contentId.startsWith(`${String(contribution.contentContributionId).split('.')[0]}.`));
+    if (mount !== undefined && 'label' in mount) return resolvePluginText(mount.label);
+    if (mount !== undefined && 'title' in mount && mount.title !== undefined) return resolvePluginText(mount.title);
+    return entry.summary.name;
 }

--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -25,28 +25,33 @@ interface FileContent {
     isBinary: boolean;
 }
 
-function changeStatus(entry: FileNavigationEntry): { label: string; glyph: string; colorKey: 'added' | 'deleted' | 'modified' | 'renamed' } {
-    const group = entry.group?.toLowerCase() ?? '';
-    if (group.includes('delete')) return { label: 'Deleted', glyph: 'D', colorKey: 'deleted' };
-    if (group.includes('rename')) return { label: 'Renamed', glyph: 'R', colorKey: 'renamed' };
-    if (group.includes('new') || group.includes('add')) return { label: 'Added', glyph: 'A', colorKey: 'added' };
-    return { label: 'Modified', glyph: 'M', colorKey: 'modified' };
+function changeStatus(entry: FileNavigationEntry): { label: string; glyph: string; colorKey: 'added' | 'deleted' | 'modified' | 'renamed' } | undefined {
+    if (entry.icon === 'add-circle-outline') return { label: 'Added', glyph: 'A', colorKey: 'added' };
+    if (entry.icon === 'trash-outline') return { label: 'Deleted', glyph: 'D', colorKey: 'deleted' };
+    if (entry.icon === 'swap-horizontal-outline') return { label: 'Renamed', glyph: 'R', colorKey: 'renamed' };
+    if (entry.icon === 'git-compare-outline') return { label: 'Modified', glyph: 'M', colorKey: 'modified' };
+    return undefined;
+}
+
+function countMeta(entry: FileNavigationEntry, tone: 'positive' | 'danger', prefix: string): string | undefined {
+    return entry.metadata.find((item) => item.tone === tone && item.value.startsWith(prefix) && /^\d+$/.test(item.value.slice(prefix.length)))?.value;
 }
 
 function ChangeChip({ entry }: { entry?: FileNavigationEntry }) {
     const { theme } = useUnistyles();
     if (entry === undefined) return null;
     const status = changeStatus(entry);
-    const added = entry.metadata.find((item) => item.value.startsWith('+'))?.value;
-    const removed = entry.metadata.find((item) => item.value.startsWith('−'))?.value;
+    const added = countMeta(entry, 'positive', '+');
+    const removed = countMeta(entry, 'danger', '−');
     const binary = entry.metadata.some((item) => item.value === 'binary');
-    const statusColor = status.colorKey === 'added' ? theme.colors.gitAddedText
-        : status.colorKey === 'deleted' ? theme.colors.gitRemovedText
-            : status.colorKey === 'modified' ? theme.colors.accent : theme.colors.textSecondary;
-    const parts = [status.label, added, removed, binary ? 'binary' : undefined].filter(Boolean);
+    if (status === undefined && added === undefined && removed === undefined && !binary) return null;
+    const statusColor = status?.colorKey === 'added' ? theme.colors.gitAddedText
+        : status?.colorKey === 'deleted' ? theme.colors.gitRemovedText
+            : status?.colorKey === 'modified' ? theme.colors.accent : theme.colors.textSecondary;
+    const parts = [status?.label, added, removed, binary ? 'binary' : undefined].filter(Boolean);
     return (
         <View accessibilityRole="text" accessibilityLabel={`${entry.title}, ${parts.join(', ')}`} style={{ height: 22, borderRadius: 999, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.divider, backgroundColor: theme.colors.surfaceHigh, paddingHorizontal: 8, flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-            <Text style={{ color: statusColor, fontSize: 11, ...Typography.mono('semiBold') }}>{status.glyph}</Text>
+            {status !== undefined && <Text style={{ color: statusColor, fontSize: 11, ...Typography.mono('semiBold') }}>{status.glyph}</Text>}
             {added !== undefined && <Text style={{ color: theme.colors.gitAddedText, fontSize: 11.5, ...Typography.mono('semiBold') }}>{added}</Text>}
             {removed !== undefined && <Text style={{ color: theme.colors.gitRemovedText, fontSize: 11.5, ...Typography.mono('semiBold') }}>{removed}</Text>}
             {binary && <Text style={{ color: theme.colors.textSecondary, fontSize: 11.5, ...Typography.mono('semiBold') }}>binary</Text>}

--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { View, ScrollView, ActivityIndicator, Platform, Pressable, useWindowDimensions } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { Text } from '@/components/StyledText';
 import { SimpleSyntaxHighlighter } from '@/components/SimpleSyntaxHighlighter';
 import { Typography } from '@/constants/Typography';
@@ -12,15 +12,46 @@ import { useUnistyles, StyleSheet } from 'react-native-unistyles';
 import { layout } from '@/components/layout';
 import { t } from '@/text';
 import { Ionicons } from '@expo/vector-icons';
-import { FileIcon } from '@/components/FileIcon';
 import { PierreDiffView } from '@/components/diff/PierreDiffView';
 import { resolveSessionFilePath } from '@/terminal';
-import { MobileGlassSurface } from '@/components/MobileGlass';
 import { syntaxLanguage } from '@/components/code/syntaxHighlighting';
+import { PathBreadcrumb } from '@/components/PathBreadcrumb';
+import { fileIcon } from '@/plugins/domain/fileIcon';
+import { currentFileNavigation, type FileNavigationEntry } from '@/plugins/application/fileNavigationList';
+import { shellQuote } from '@/utils/shellQuote';
 
 interface FileContent {
     content: string;
     isBinary: boolean;
+}
+
+function changeStatus(entry: FileNavigationEntry): { label: string; glyph: string; colorKey: 'added' | 'deleted' | 'modified' | 'renamed' } {
+    const group = entry.group?.toLowerCase() ?? '';
+    if (group.includes('delete')) return { label: 'Deleted', glyph: 'D', colorKey: 'deleted' };
+    if (group.includes('rename')) return { label: 'Renamed', glyph: 'R', colorKey: 'renamed' };
+    if (group.includes('new') || group.includes('add')) return { label: 'Added', glyph: 'A', colorKey: 'added' };
+    return { label: 'Modified', glyph: 'M', colorKey: 'modified' };
+}
+
+function ChangeChip({ entry }: { entry?: FileNavigationEntry }) {
+    const { theme } = useUnistyles();
+    if (entry === undefined) return null;
+    const status = changeStatus(entry);
+    const added = entry.metadata.find((item) => item.value.startsWith('+'))?.value;
+    const removed = entry.metadata.find((item) => item.value.startsWith('−'))?.value;
+    const binary = entry.metadata.some((item) => item.value === 'binary');
+    const statusColor = status.colorKey === 'added' ? theme.colors.gitAddedText
+        : status.colorKey === 'deleted' ? theme.colors.gitRemovedText
+            : status.colorKey === 'modified' ? theme.colors.accent : theme.colors.textSecondary;
+    const parts = [status.label, added, removed, binary ? 'binary' : undefined].filter(Boolean);
+    return (
+        <View accessibilityRole="text" accessibilityLabel={`${entry.title}, ${parts.join(', ')}`} style={{ height: 22, borderRadius: 999, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.divider, backgroundColor: theme.colors.surfaceHigh, paddingHorizontal: 8, flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            <Text style={{ color: statusColor, fontSize: 11, ...Typography.mono('semiBold') }}>{status.glyph}</Text>
+            {added !== undefined && <Text style={{ color: theme.colors.gitAddedText, fontSize: 11.5, ...Typography.mono('semiBold') }}>{added}</Text>}
+            {removed !== undefined && <Text style={{ color: theme.colors.gitRemovedText, fontSize: 11.5, ...Typography.mono('semiBold') }}>{removed}</Text>}
+            {binary && <Text style={{ color: theme.colors.textSecondary, fontSize: 11.5, ...Typography.mono('semiBold') }}>binary</Text>}
+        </View>
+    );
 }
 
 /**
@@ -31,6 +62,8 @@ interface FileContent {
  */
 export default React.memo(function FileScreen() {
     const { theme } = useUnistyles();
+    const router = useRouter();
+    const navigation = useNavigation();
     const { id: sessionId } = useLocalSearchParams<{ id: string }>();
     const searchParams = useLocalSearchParams();
     const rawPath = typeof searchParams.path === 'string' ? searchParams.path : '';
@@ -43,17 +76,25 @@ export default React.memo(function FileScreen() {
     const resolvedPath = resolveSessionFilePath(rawPath, sessionPath);
     const filePath = resolvedPath?.absolutePath ?? rawPath;
     const fileName = filePath.split('/').pop() || filePath;
-    /** Run git from the file's own directory, so a repo is found wherever it lives. */
-    const fileDir = filePath.slice(0, filePath.lastIndexOf('/')) || '/';
+    const fileNavigation = sessionId === undefined ? null : (currentFileNavigation(sessionId, filePath) ?? currentFileNavigation(sessionId, rawPath));
+    const fileList = fileNavigation?.entries ?? [];
+    const fileIndex = fileNavigation?.index ?? -1;
+    const currentEntry = fileNavigation?.entries[fileNavigation.index];
+    /** The session cwd exists even when a deleted file's parent directory does not. */
+    const gitDirectory = sessionPath || filePath.slice(0, filePath.lastIndexOf('/')) || '/';
 
     const cached = useSessionFileCache(sessionId!, filePath);
+
+    React.useLayoutEffect(() => {
+        navigation.setOptions({ headerTitle: fileName, headerBackTitle: t('common.back') });
+    }, [fileName, navigation]);
 
     const [fileContent, setFileContent] = React.useState<FileContent | null>(() => {
         if (!cached) return null;
         return { content: cached.content ?? '', isBinary: cached.isBinary };
     });
     const [diffContent, setDiffContent] = React.useState<string | null>(() => cached?.diff ?? null);
-    const [displayMode, setDisplayMode] = React.useState<'file' | 'diff'>('diff');
+    const [displayMode, setDisplayMode] = React.useState<'file' | 'diff'>(() => requestedLine !== null && requestedLine > 0 ? 'file' : 'diff');
     const [isLoading, setIsLoading] = React.useState(!cached);
     const [error, setError] = React.useState<string | null>(null);
     const scrollViewRef = React.useRef<ScrollView | null>(null);
@@ -70,9 +111,9 @@ export default React.memo(function FileScreen() {
                     .onBegin(() => {
                         pinchStart.current = fontSize;
                     })
-                    .onUpdate((event) => {
+                    .onEnd((event) => {
                         const next = Math.round(Math.min(28, Math.max(8, pinchStart.current * event.scale)));
-                        setFontSize((current) => (current === next ? current : next));
+                        setFontSize(next);
                     })
                     .runOnJS(true),
                 Gesture.Native(),
@@ -97,24 +138,16 @@ export default React.memo(function FileScreen() {
 
     React.useEffect(() => {
         let isCancelled = false;
+        setError(null);
+        setFileContent(cached ? { content: cached.content ?? '', isBinary: cached.isBinary } : null);
+        setDiffContent(cached?.diff ?? null);
+        setIsLoading(cached === null);
 
         const loadFile = async () => {
             try {
-                if (!cached) {
-                    setIsLoading(true);
-                }
-                setError(null);
-
-                if (isBinaryFile(filePath)) {
-                    if (!isCancelled) {
-                        setFileContent({ content: '', isBinary: true });
-                        storage.getState().applyFileCache(sessionId!, filePath, '', null, true);
-                        setIsLoading(false);
-                    }
-                    return;
-                }
-
-                let fetchedDiff: string | null = null;
+                let fetchedDiff = cached?.diff ?? null;
+                let freshDiff: string | null = null;
+                let diffObserved = false;
 
                 // Live git diff. Changes come from the whole repo while a
                 // session's cwd is often one subdir of it, so anchoring this to
@@ -126,18 +159,18 @@ export default React.memo(function FileScreen() {
                 // that, what did the last commit touching this file change.
                 // Without the second, every file went blank the moment the work
                 // was committed -- which is most of them, most of the time.
-                if (!fetchedDiff && sessionId) {
-                    const git = `git -C "${fileDir}" -c diff.mnemonicPrefix=false`;
+                if (sessionId) {
+                    const git = `git -C ${shellQuote(gitDirectory)} -c diff.mnemonicPrefix=false`;
                     for (const command of [
-                        `${git} diff HEAD --no-ext-diff -- "${filePath}"`,
-                        `${git} log -1 -p --no-ext-diff --format= -- "${filePath}"`,
+                        `${git} diff HEAD --no-ext-diff -- ${shellQuote(filePath)}`,
+                        `${git} log -1 -p --no-ext-diff --format= -- ${shellQuote(filePath)}`,
                     ]) {
                         try {
                             const diffResponse = await sessionBash(sessionId, { command, timeout: 5000 });
                             if (isCancelled) return;
+                            if (diffResponse.success) diffObserved = true;
                             if (diffResponse.success && diffResponse.stdout.trim()) {
-                                fetchedDiff = diffResponse.stdout;
-                                setDiffContent(fetchedDiff);
+                                freshDiff = diffResponse.stdout;
                                 break;
                             }
                         } catch (diffError) {
@@ -145,7 +178,19 @@ export default React.memo(function FileScreen() {
                         }
                     }
                 }
+                if (diffObserved) {
+                    fetchedDiff = freshDiff;
+                    if (!isCancelled) setDiffContent(fetchedDiff);
+                }
 
+                if (isBinaryFile(filePath)) {
+                    if (!isCancelled) {
+                        const isBinary = fetchedDiff === null;
+                        setFileContent({ content: '', isBinary });
+                        storage.getState().applyFileCache(sessionId!, filePath, '', fetchedDiff, isBinary);
+                    }
+                    return;
+                }
 
                 const response = await sessionReadFile(sessionId, filePath);
 
@@ -163,28 +208,26 @@ export default React.memo(function FileScreen() {
                         const content = isBinary ? '' : text;
                         setFileContent({ content, isBinary });
                         storage.getState().applyFileCache(sessionId!, filePath, content, fetchedDiff, isBinary);
+                    } else if (fetchedDiff !== null) {
+                        // Deleted files have no working-tree contents, but their
+                        // diff is still the useful and truthful representation.
+                        setFileContent({ content: '', isBinary: false });
+                        storage.getState().applyFileCache(sessionId!, filePath, '', fetchedDiff, false);
                     } else {
                         setError(response.error || 'Failed to read file');
                     }
                 }
             } catch (loadError) {
                 console.error('Failed to load file:', loadError);
-                if (!isCancelled) {
-                    setError('Failed to load file');
-                }
+                if (!isCancelled) setError('Failed to load file');
             } finally {
-                if (!isCancelled) {
-                    setIsLoading(false);
-                }
+                if (!isCancelled) setIsLoading(false);
             }
         };
 
         loadFile();
-
-        return () => {
-            isCancelled = true;
-        };
-    }, [filePath, fileDir, isBinaryFile, sessionId, fileName]);
+        return () => { isCancelled = true; };
+    }, [filePath, gitDirectory, isBinaryFile, sessionId, fileName]);
 
     React.useEffect(() => {
         if (error) {
@@ -192,30 +235,23 @@ export default React.memo(function FileScreen() {
         }
     }, [error]);
 
-    React.useEffect(() => {
-        if (requestedLine !== null && requestedLine > 0) {
-            setDisplayMode('file');
-        } else if (diffContent) {
-            setDisplayMode('diff');
-        } else if (fileContent) {
-            setDisplayMode('file');
-        }
-    }, [diffContent, fileContent, requestedLine]);
+    const { width: windowWidth } = useWindowDimensions();
+    const isNarrow = windowWidth < 700;
 
     React.useEffect(() => {
-        if (!fileContent?.content || displayMode !== 'file' || requestedLine === null || requestedLine <= 0) {
-            return;
-        }
-        const offset = Math.max(0, ((requestedLine - 1) * 20) - 40);
+        if (!fileContent?.content || displayMode !== 'file' || requestedLine === null || requestedLine <= 0) return;
+        const lineHeight = Math.round((fontSize - (isNarrow ? 1 : 0)) * 10 / 7);
+        const offset = Math.max(0, ((requestedLine - 1) * lineHeight) - 40);
         requestAnimationFrame(() => {
             scrollViewRef.current?.scrollTo({ y: offset, animated: false });
         });
-    }, [displayMode, fileContent?.content, requestedLine]);
-
-    const { width: windowWidth } = useWindowDimensions();
-    const isNarrow = windowWidth < 700;
+    }, [displayMode, fileContent?.content, fontSize, isNarrow, requestedLine]);
     const [hunkOffsets, setHunkOffsets] = React.useState<number[]>([]);
     const hunkIndex = React.useRef(0);
+    React.useEffect(() => {
+        hunkIndex.current = 0;
+        setHunkOffsets([]);
+    }, [filePath]);
 
     // Offsets are measured inside the diff, so they need the scroller's own
     // padding added back before they mean anything to scrollTo.
@@ -225,11 +261,20 @@ export default React.memo(function FileScreen() {
         hunkIndex.current = next;
         scrollViewRef.current?.scrollTo({ y: Math.max(0, hunkOffsets[next] + 16 - 8), animated: true });
     }, [hunkOffsets]);
-    const directoryOfPath = (p: string): string => {
-        const slash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
-        return slash > 0 ? p.slice(0, slash) : '';
-    };
     const language = syntaxLanguage(undefined, filePath) ?? null;
+    const previousFile = fileIndex > 0 ? fileList[fileIndex - 1] : undefined;
+    const nextFile = fileIndex >= 0 && fileIndex < fileList.length - 1 ? fileList[fileIndex + 1] : undefined;
+    const navigateFile = React.useCallback((entry: FileNavigationEntry | undefined) => {
+        if (entry === undefined || sessionId === undefined) return;
+        router.replace(`/session/${encodeURIComponent(sessionId)}/file?path=${encodeURIComponent(entry.path)}` as never);
+    }, [router, sessionId]);
+    const lineSuffix = requestedLine !== null && requestedLine > 0
+        ? `:${requestedLine}${requestedColumn !== null && requestedColumn > 0 ? `:${requestedColumn}` : ''}`
+        : '';
+    const breadcrumbSegments = React.useMemo(() => filePath.split('/').filter(Boolean).map((label, index, segments) => ({
+        label: index === segments.length - 1 ? `${label}${lineSuffix}` : label,
+        ...(index === 0 ? { icon: fileIcon(fileName).name } : {}),
+    })), [fileName, filePath, lineSuffix]);
 
     if (isLoading) {
         return (
@@ -282,7 +327,7 @@ export default React.memo(function FileScreen() {
         );
     }
 
-    if (fileContent?.isBinary) {
+    if (fileContent?.isBinary && !diffContent) {
         return (
             <View style={{
                 flex: 1,
@@ -324,107 +369,52 @@ export default React.memo(function FileScreen() {
     return (
         <View style={styles.container}>
 
-            {/* File path header */}
-            <MobileGlassSurface enabled={Platform.OS !== 'web'} intensity={62} style={{
-                paddingHorizontal: 16,
-                paddingVertical: isNarrow ? 8 : 16,
-                borderBottomWidth: Platform.select({ web: 1, default: 0.5 }),
-                borderBottomColor: Platform.select({ web: theme.colors.divider, default: theme.colors.glass.border }),
-                backgroundColor: Platform.select({ web: theme.colors.surfaceHigh, android: theme.colors.glass.backgroundStrong, default: 'transparent' }),
-                flexDirection: 'row',
-                alignItems: 'center'
-            }}>
-                <FileIcon fileName={fileName} size={20} />
-                {/* On a phone the directory is worth less than the row it costs:
-                    name and path share one line, path shrinking to fit. */}
-                <View style={{ flex: 1, minWidth: 0, marginLeft: 10, flexDirection: isNarrow ? 'row' : 'column', alignItems: isNarrow ? 'baseline' : undefined }}>
-                    <Text numberOfLines={1} ellipsizeMode="middle" style={{
-                        fontSize: 14,
-                        color: theme.colors.text,
-                        flexShrink: 0,
-                        ...Typography.default('semiBold')
-                    }}>
-                        {fileName}
-                    </Text>
-                    <Text numberOfLines={1} ellipsizeMode="head" style={{
-                        fontSize: 12,
-                        color: theme.colors.textSecondary,
-                        ...(isNarrow ? { flexShrink: 1, marginLeft: 8 } : { marginTop: 1 }),
-                        ...Typography.mono()
-                    }}>
-                        {requestedLine !== null && requestedLine > 0
-                            ? `${directoryOfPath(filePath)}:${requestedLine}${requestedColumn !== null && requestedColumn > 0 ? `:${requestedColumn}` : ''}`
-                            : directoryOfPath(filePath)}
-                    </Text>
-                </View>
-            </MobileGlassSurface>
+            <PathBreadcrumb segments={breadcrumbSegments} fullPath={filePath}
+                {...(currentEntry === undefined ? {} : { trailing: <ChangeChip entry={currentEntry} /> })} />
 
-            {/* Always present: a view that appears and disappears reads as
-                arbitrary. Without a diff the tab is simply disabled. */}
-            {(
-                <View style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    paddingHorizontal: 16,
-                    paddingVertical: 4,
-                    borderBottomWidth: StyleSheet.hairlineWidth,
-                    borderBottomColor: theme.colors.divider,
-                    backgroundColor: Platform.select({ web: theme.colors.surface, default: 'transparent' })
-                }}>
-                    <View style={{
-                        flexDirection: 'row',
-                        gap: 2,
-                        padding: 2,
-                        borderRadius: 9,
-                        borderWidth: StyleSheet.hairlineWidth,
-                        borderColor: theme.colors.divider,
-                        backgroundColor: theme.colors.groupped.background,
-                    }}>
-                        {(['diff', 'file'] as const).map((mode) => {
-                            const active = displayMode === mode;
-                            const disabled = mode === 'diff' && !diffContent;
-                            return (
-                                <Pressable
-                                    key={mode}
-                                    disabled={disabled}
-                                    onPress={() => setDisplayMode(mode)}
-                                    style={{
-                                        paddingHorizontal: 12,
-                                        paddingVertical: 5,
-                                        borderRadius: 7,
-                                        opacity: disabled ? 0.4 : 1,
-                                        backgroundColor: active ? theme.colors.surface : 'transparent',
-                                    }}
-                                >
-                                    <Text style={{
-                                        fontSize: 13,
-                                        color: active ? theme.colors.text : theme.colors.textSecondary,
-                                        ...Typography.default(active ? 'semiBold' : undefined),
-                                    }}>
-                                        {mode === 'diff' ? t('files.diff') : t('files.file')}
-                                    </Text>
-                                </Pressable>
-                            );
-                        })}
+            <View style={styles.controls}>
+                <View style={styles.modeGroup}>
+                    {(['diff', 'file'] as const).map((mode) => {
+                        const active = displayMode === mode;
+                        const disabled = mode === 'diff' && !diffContent;
+                        return <Pressable key={mode} disabled={disabled} onPress={() => setDisplayMode(mode)} accessibilityRole="tab"
+                            accessibilityLabel={mode === 'diff' ? t('files.diff') : t('files.file')}
+                            accessibilityState={{ selected: active, disabled }}
+                            style={({ pressed }) => [styles.mode, { backgroundColor: active ? theme.colors.surfaceSelected : pressed ? theme.colors.surfacePressed : 'transparent', opacity: disabled ? 0.45 : 1 }]}>
+                            <Text style={{ color: active ? theme.colors.text : theme.colors.textSecondary, fontSize: 13, ...Typography.default(active ? 'semiBold' : undefined) }}>
+                                {mode === 'diff' ? t('files.diff') : t('files.file')}
+                            </Text>
+                        </Pressable>;
+                    })}
+                </View>
+
+                {displayMode === 'diff' && hunkOffsets.length > 1 && (
+                    <View style={styles.hunkControls}>
+                        {([['chevron-up', -1], ['chevron-down', 1]] as const).map(([icon, step]) => (
+                            <Pressable key={icon} onPress={() => jumpHunk(step)} accessibilityRole="button"
+                                accessibilityLabel={step < 0 ? 'Previous hunk' : 'Next hunk'} style={styles.hunkButton}>
+                                <Ionicons name={icon} size={18} color={theme.colors.text} />
+                            </Pressable>
+                        ))}
                     </View>
+                )}
 
-                    {/* Only earns its place once there is somewhere to jump to. */}
-                    {displayMode === 'diff' && hunkOffsets.length > 1 && (
-                        <View style={{ flexDirection: 'row', marginLeft: 'auto', alignItems: 'center', gap: 4 }}>
-                            {([['chevron-up', -1], ['chevron-down', 1]] as const).map(([icon, step]) => (
-                                <Pressable
-                                    key={icon}
-                                    hitSlop={8}
-                                    onPress={() => jumpHunk(step)}
-                                    style={{ padding: 6 }}
-                                >
-                                    <Ionicons name={icon} size={16} color={theme.colors.text} />
-                                </Pressable>
-                            ))}
-                        </View>
-                    )}
-                </View>
-            )}
+                {fileNavigation !== null && (
+                    <View style={styles.fileControls}>
+                        <Pressable disabled={previousFile === undefined} onPress={() => navigateFile(previousFile)} accessibilityRole="button"
+                            accessibilityLabel={`Previous changed file${previousFile === undefined ? '' : `, ${previousFile.title}`}, ${fileNavigation.index + 1} of ${fileNavigation.entries.length}`}
+                            accessibilityState={{ disabled: previousFile === undefined }} style={styles.fileButton}>
+                            <Ionicons name="chevron-back" size={18} color={previousFile === undefined ? theme.colors.textSecondary : theme.colors.text} />
+                        </Pressable>
+                        <Text accessibilityRole="text" style={styles.filePosition}>{fileNavigation.index + 1} / {fileNavigation.entries.length}</Text>
+                        <Pressable disabled={nextFile === undefined} onPress={() => navigateFile(nextFile)} accessibilityRole="button"
+                            accessibilityLabel={`Next changed file${nextFile === undefined ? '' : `, ${nextFile.title}`}, ${fileNavigation.index + 1} of ${fileNavigation.entries.length}`}
+                            accessibilityState={{ disabled: nextFile === undefined }} style={styles.fileButton}>
+                            <Ionicons name="chevron-forward" size={18} color={nextFile === undefined ? theme.colors.textSecondary : theme.colors.text} />
+                        </Pressable>
+                    </View>
+                )}
+            </View>
 
             {/* Content display */}
             <GestureDetector gesture={zoom}>
@@ -491,5 +481,60 @@ const styles = StyleSheet.create((theme) => ({
     container: {
         flex: 1,
         backgroundColor: Platform.select({ web: theme.colors.surface, default: 'transparent' }),
-    }
+    },
+    controls: {
+        minHeight: 44,
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 8,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: theme.colors.divider,
+        backgroundColor: Platform.select({ web: theme.colors.surface, default: 'transparent' }),
+    },
+    modeGroup: {
+        flexDirection: 'row',
+        gap: 2,
+        padding: 2,
+        borderRadius: 9,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: theme.colors.divider,
+        backgroundColor: theme.colors.groupped.background,
+    },
+    mode: {
+        minHeight: 36,
+        paddingHorizontal: 12,
+        borderRadius: 7,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    hunkControls: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 2,
+        marginLeft: 4,
+    },
+    hunkButton: {
+        width: 40,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    fileControls: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginLeft: 'auto',
+    },
+    fileButton: {
+        width: 44,
+        height: 44,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    filePosition: {
+        minWidth: 38,
+        textAlign: 'center',
+        color: theme.colors.textSecondary,
+        fontSize: 11.5,
+        ...Typography.mono('semiBold'),
+    },
 }));

--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -17,7 +17,7 @@ import { resolveSessionFilePath } from '@/terminal';
 import { syntaxLanguage } from '@/components/code/syntaxHighlighting';
 import { PathBreadcrumb } from '@/components/PathBreadcrumb';
 import { fileIcon } from '@/plugins/domain/fileIcon';
-import { currentFileNavigation, type FileNavigationEntry } from '@/plugins/application/fileNavigationList';
+import { currentFileNavigation, fileNavControlLabel, gitDirectoryProbeCommand, gitDirectorySearchPaths, type FileNavigationEntry } from '@/plugins/application/fileNavigationList';
 import { shellQuote } from '@/utils/shellQuote';
 
 interface FileContent {
@@ -80,8 +80,6 @@ export default React.memo(function FileScreen() {
     const fileList = fileNavigation?.entries ?? [];
     const fileIndex = fileNavigation?.index ?? -1;
     const currentEntry = fileNavigation?.entries[fileNavigation.index];
-    /** The session cwd exists even when a deleted file's parent directory does not. */
-    const gitDirectory = sessionPath || filePath.slice(0, filePath.lastIndexOf('/')) || '/';
 
     const cached = useSessionFileCache(sessionId!, filePath);
 
@@ -149,17 +147,22 @@ export default React.memo(function FileScreen() {
                 let freshDiff: string | null = null;
                 let diffObserved = false;
 
-                // Live git diff. Changes come from the whole repo while a
-                // session's cwd is often one subdir of it, so anchoring this to
-                // the session root meant every file outside that subdir showed
-                // no diff at all. The file's own directory always finds the
-                // right repo, and git takes the absolute path as a pathspec.
-                // Two questions, asked in order: what is uncommitted right now
-                // (diff HEAD covers staged and unstaged together), and failing
-                // that, what did the last commit touching this file change.
-                // Without the second, every file went blank the moment the work
-                // was committed -- which is most of them, most of the time.
+                // Discover git from the opened file's nearest existing directory
+                // so a third-party path outside the session cwd, or a nested
+                // repo, still diffs. Session cwd is only the last fallback when
+                // that directory is gone. Absolute pathspec stays quoted.
                 if (sessionId) {
+                    let gitDirectory = gitDirectorySearchPaths(filePath, sessionPath)[0] ?? '/';
+                    try {
+                        const probe = await sessionBash(sessionId, {
+                            command: gitDirectoryProbeCommand(filePath, sessionPath),
+                            timeout: 3000,
+                        });
+                        if (isCancelled) return;
+                        if (probe.success && probe.stdout.trim()) gitDirectory = probe.stdout.trim();
+                    } catch (probeError) {
+                        console.log('Could not resolve git directory:', probeError);
+                    }
                     const git = `git -C ${shellQuote(gitDirectory)} -c diff.mnemonicPrefix=false`;
                     for (const command of [
                         `${git} diff HEAD --no-ext-diff -- ${shellQuote(filePath)}`,
@@ -227,7 +230,7 @@ export default React.memo(function FileScreen() {
 
         loadFile();
         return () => { isCancelled = true; };
-    }, [filePath, gitDirectory, isBinaryFile, sessionId, fileName]);
+    }, [filePath, isBinaryFile, sessionId, sessionPath]);
 
     React.useEffect(() => {
         if (error) {
@@ -403,13 +406,13 @@ export default React.memo(function FileScreen() {
                 {fileNavigation !== null && (
                     <View style={styles.fileControls}>
                         <Pressable disabled={previousFile === undefined} onPress={() => navigateFile(previousFile)} accessibilityRole="button"
-                            accessibilityLabel={`Previous changed file${previousFile === undefined ? '' : `, ${previousFile.title}`}, ${fileNavigation.index + 1} of ${fileNavigation.entries.length}`}
+                            accessibilityLabel={fileNavControlLabel('previous', previousFile?.title, fileNavigation.index, fileNavigation.entries.length)}
                             accessibilityState={{ disabled: previousFile === undefined }} style={styles.fileButton}>
                             <Ionicons name="chevron-back" size={18} color={previousFile === undefined ? theme.colors.textSecondary : theme.colors.text} />
                         </Pressable>
                         <Text accessibilityRole="text" style={styles.filePosition}>{fileNavigation.index + 1} / {fileNavigation.entries.length}</Text>
                         <Pressable disabled={nextFile === undefined} onPress={() => navigateFile(nextFile)} accessibilityRole="button"
-                            accessibilityLabel={`Next changed file${nextFile === undefined ? '' : `, ${nextFile.title}`}, ${fileNavigation.index + 1} of ${fileNavigation.entries.length}`}
+                            accessibilityLabel={fileNavControlLabel('next', nextFile?.title, fileNavigation.index, fileNavigation.entries.length)}
                             accessibilityState={{ disabled: nextFile === undefined }} style={styles.fileButton}>
                             <Ionicons name="chevron-forward" size={18} color={nextFile === undefined ? theme.colors.textSecondary : theme.colors.text} />
                         </Pressable>

--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -17,7 +17,7 @@ import { resolveSessionFilePath } from '@/terminal';
 import { syntaxLanguage } from '@/components/code/syntaxHighlighting';
 import { PathBreadcrumb } from '@/components/PathBreadcrumb';
 import { fileIcon } from '@/plugins/domain/fileIcon';
-import { currentFileNavigation, fileNavControlLabel, gitDirectoryProbeCommand, gitDirectorySearchPaths, type FileNavigationEntry } from '@/plugins/application/fileNavigationList';
+import { bundledBinaryChip, currentFileNavigation, fileNavControlLabel, gitDirectoryProbeCommand, gitDirectorySearchPaths, type FileNavigationEntry } from '@/plugins/application/fileNavigationList';
 import { shellQuote } from '@/utils/shellQuote';
 
 interface FileContent {
@@ -43,7 +43,7 @@ function ChangeChip({ entry }: { entry?: FileNavigationEntry }) {
     const status = changeStatus(entry);
     const added = countMeta(entry, 'positive', '+');
     const removed = countMeta(entry, 'danger', '−');
-    const binary = entry.metadata.some((item) => item.value === 'binary');
+    const binary = bundledBinaryChip(entry.metadata);
     if (status === undefined && added === undefined && removed === undefined && !binary) return null;
     const statusColor = status?.colorKey === 'added' ? theme.colors.gitAddedText
         : status?.colorKey === 'deleted' ? theme.colors.gitRemovedText

--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -262,6 +262,7 @@ export default React.memo(function FileScreen() {
         scrollViewRef.current?.scrollTo({ y: Math.max(0, hunkOffsets[next] + 16 - 8), animated: true });
     }, [hunkOffsets]);
     const language = syntaxLanguage(undefined, filePath) ?? null;
+    const shownMode = displayMode === 'diff' && !diffContent ? 'file' : displayMode;
     const previousFile = fileIndex > 0 ? fileList[fileIndex - 1] : undefined;
     const nextFile = fileIndex >= 0 && fileIndex < fileList.length - 1 ? fileList[fileIndex + 1] : undefined;
     const navigateFile = React.useCallback((entry: FileNavigationEntry | undefined) => {
@@ -273,7 +274,7 @@ export default React.memo(function FileScreen() {
         : '';
     const breadcrumbSegments = React.useMemo(() => filePath.split('/').filter(Boolean).map((label, index, segments) => ({
         label: index === segments.length - 1 ? `${label}${lineSuffix}` : label,
-        ...(index === 0 ? { icon: fileIcon(fileName).name } : {}),
+        ...(index === segments.length - 1 ? { icon: fileIcon(fileName).name } : {}),
     })), [fileName, filePath, lineSuffix]);
 
     if (isLoading) {
@@ -375,7 +376,7 @@ export default React.memo(function FileScreen() {
             <View style={styles.controls}>
                 <View style={styles.modeGroup}>
                     {(['diff', 'file'] as const).map((mode) => {
-                        const active = displayMode === mode;
+                        const active = shownMode === mode;
                         const disabled = mode === 'diff' && !diffContent;
                         return <Pressable key={mode} disabled={disabled} onPress={() => setDisplayMode(mode)} accessibilityRole="tab"
                             accessibilityLabel={mode === 'diff' ? t('files.diff') : t('files.file')}
@@ -388,7 +389,7 @@ export default React.memo(function FileScreen() {
                     })}
                 </View>
 
-                {displayMode === 'diff' && hunkOffsets.length > 1 && (
+                {shownMode === 'diff' && hunkOffsets.length > 1 && (
                     <View style={styles.hunkControls}>
                         {([['chevron-up', -1], ['chevron-down', 1]] as const).map(([icon, step]) => (
                             <Pressable key={icon} onPress={() => jumpHunk(step)} accessibilityRole="button"
@@ -424,7 +425,7 @@ export default React.memo(function FileScreen() {
                 contentContainerStyle={{ padding: 16, maxWidth: layout.maxWidth, alignSelf: 'center', width: '100%' }}
                 showsVerticalScrollIndicator={true}
             >
-                {displayMode === 'diff' && diffContent ? (
+                {shownMode === 'diff' && diffContent ? (
                     <PierreDiffView
                         patch={diffContent}
                         fontSize={fontSize}
@@ -435,7 +436,7 @@ export default React.memo(function FileScreen() {
                         onHunkOffsets={setHunkOffsets}
                         disableFileHeader
                     />
-                ) : displayMode === 'file' && fileContent?.content ? (
+                ) : shownMode === 'file' && fileContent?.content ? (
                     isNarrow ? (
                         <SimpleSyntaxHighlighter
                             code={fileContent.content}
@@ -452,7 +453,7 @@ export default React.memo(function FileScreen() {
                             fontSize={fontSize}
                         />
                     )
-                ) : displayMode === 'file' && fileContent && !fileContent.content ? (
+                ) : shownMode === 'file' && fileContent && !fileContent.content ? (
                     <Text style={{
                         fontSize: 16,
                         color: theme.colors.textSecondary,

--- a/apps/mobile/sources/components/PathBreadcrumb.tsx
+++ b/apps/mobile/sources/components/PathBreadcrumb.tsx
@@ -34,7 +34,7 @@ export function PathBreadcrumb({
     const path = fullPath ?? segments.map((segment) => segment.label).join('/');
     const visibleSegments = React.useMemo<PathBreadcrumbSegment[]>(() => {
         if (segments.length <= 4) return segments;
-        return [segments[0]!, { label: '…' }, ...segments.slice(-3)];
+        return [segments[0]!, { label: '…' }, ...segments.slice(-2)];
     }, [segments]);
     const openFullPath = React.useCallback(() => setShowFullPath(true), []);
     const copyPath = React.useCallback(async () => {
@@ -61,8 +61,8 @@ export function PathBreadcrumb({
                                 {index > 0 && <Text accessible={false} style={{ color: withAlpha(theme.colors.textSecondary, 0.45), fontSize: 12, paddingHorizontal: 6, ...Typography.mono() }}>/</Text>}
                                 <Pressable onPress={onPress} onLongPress={openFullPath} accessibilityRole="button"
                                     accessibilityLabel={isEllipsis ? 'Show full path' : segment.onPress === undefined ? `Path ${segment.label}, show full path` : `Go to ${segment.label}`}
-                                    style={({ pressed }) => ({ minHeight: 44, justifyContent: 'center', flexDirection: 'row', alignItems: 'center', gap: index === 0 && segment.icon !== undefined ? 5 : 0, paddingHorizontal: 8, backgroundColor: pressed ? theme.colors.surfaceHighest : 'transparent' })}>
-                                    {index === 0 && segment.icon !== undefined && <MaterialCommunityIcons name={segment.icon} size={16} color={theme.colors.textSecondary} />}
+                                    style={({ pressed }) => ({ minHeight: 44, justifyContent: 'center', flexDirection: 'row', alignItems: 'center', gap: segment.icon !== undefined ? 5 : 0, paddingHorizontal: 8, backgroundColor: pressed ? theme.colors.surfaceHighest : 'transparent' })}>
+                                    {segment.icon !== undefined && <MaterialCommunityIcons name={segment.icon} size={16} color={theme.colors.textSecondary} />}
                                     <Text numberOfLines={1} style={{ maxWidth: 220, color: isLast ? theme.colors.text : theme.colors.textSecondary, fontSize: 12, lineHeight: 16, ...Typography.mono(isLast ? 'semiBold' : 'regular') }}>{segment.label}</Text>
                                 </Pressable>
                             </React.Fragment>

--- a/apps/mobile/sources/components/PathBreadcrumb.tsx
+++ b/apps/mobile/sources/components/PathBreadcrumb.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { StyleSheet, useUnistyles } from 'react-native-unistyles';
+import { Typography } from '@/constants/Typography';
+import { Modal } from '@/modal';
+import { OptionSheet } from '@/components/OptionSheet';
+import { t } from '@/text';
+import { withAlpha } from '@/components/ui';
+
+type IconName = React.ComponentProps<typeof MaterialCommunityIcons>['name'];
+
+export interface PathBreadcrumbSegment {
+    label: string;
+    onPress?: () => void;
+    icon?: IconName;
+}
+
+export function PathBreadcrumb({
+    segments,
+    fullPath,
+    inline = false,
+    trailing,
+}: {
+    segments: PathBreadcrumbSegment[];
+    fullPath?: string;
+    inline?: boolean;
+    trailing?: React.ReactNode;
+}) {
+    const { theme } = useUnistyles();
+    const trail = React.useRef<ScrollView>(null);
+    const [showFullPath, setShowFullPath] = React.useState(false);
+    const path = fullPath ?? segments.map((segment) => segment.label).join('/');
+    const visibleSegments = React.useMemo<PathBreadcrumbSegment[]>(() => {
+        if (segments.length <= 4) return segments;
+        return [segments[0]!, { label: '…' }, ...segments.slice(-3)];
+    }, [segments]);
+    const openFullPath = React.useCallback(() => setShowFullPath(true), []);
+    const copyPath = React.useCallback(async () => {
+        try {
+            await Clipboard.setStringAsync(path);
+            setShowFullPath(false);
+            Modal.alert(t('common.copied'), path);
+        } catch (error) {
+            Modal.alert(t('common.error'), error instanceof Error ? error.message : String(error));
+        }
+    }, [path]);
+
+    return (
+        <>
+            <View accessible={false} style={{ height: 44, minHeight: 44, flexDirection: 'row', backgroundColor: inline ? 'transparent' : theme.colors.surface, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: theme.colors.divider }}>
+                <ScrollView ref={trail} horizontal showsHorizontalScrollIndicator={false} style={{ flex: 1 }} contentContainerStyle={{ alignItems: 'center' }}
+                    onContentSizeChange={() => trail.current?.scrollToEnd({ animated: true })}>
+                    {visibleSegments.map((segment, index) => {
+                        const isLast = index === visibleSegments.length - 1;
+                        const isEllipsis = segment.label === '…';
+                        const onPress = isEllipsis ? openFullPath : segment.onPress ?? openFullPath;
+                        return (
+                            <React.Fragment key={`${segment.label}:${index}`}>
+                                {index > 0 && <Text accessible={false} style={{ color: withAlpha(theme.colors.textSecondary, 0.45), fontSize: 12, paddingHorizontal: 6, ...Typography.mono() }}>/</Text>}
+                                <Pressable onPress={onPress} onLongPress={openFullPath} accessibilityRole="button"
+                                    accessibilityLabel={isEllipsis ? 'Show full path' : segment.onPress === undefined ? `Path ${segment.label}, show full path` : `Go to ${segment.label}`}
+                                    style={({ pressed }) => ({ minHeight: 44, justifyContent: 'center', flexDirection: 'row', alignItems: 'center', gap: index === 0 && segment.icon !== undefined ? 5 : 0, paddingHorizontal: 8, backgroundColor: pressed ? theme.colors.surfaceHighest : 'transparent' })}>
+                                    {index === 0 && segment.icon !== undefined && <MaterialCommunityIcons name={segment.icon} size={16} color={theme.colors.textSecondary} />}
+                                    <Text numberOfLines={1} style={{ maxWidth: 220, color: isLast ? theme.colors.text : theme.colors.textSecondary, fontSize: 12, lineHeight: 16, ...Typography.mono(isLast ? 'semiBold' : 'regular') }}>{segment.label}</Text>
+                                </Pressable>
+                            </React.Fragment>
+                        );
+                    })}
+                </ScrollView>
+                {trailing !== undefined && <View style={{ minHeight: 44, justifyContent: 'center', paddingHorizontal: 8 }}>{trailing}</View>}
+            </View>
+            <OptionSheet visible={showFullPath} title="Full path" options={[]} onSelect={() => {}} onClose={() => setShowFullPath(false)}
+                body={<View style={{ paddingHorizontal: 16, paddingBottom: 12, gap: 12 }}>
+                    <Text selectable style={{ color: theme.colors.text, fontSize: 13, lineHeight: 20, ...Typography.mono() }}>{path}</Text>
+                    <Pressable onPress={() => void copyPath()} accessibilityRole="button" accessibilityLabel={t('common.copy')}
+                        style={({ pressed }) => ({ minHeight: 44, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.divider, backgroundColor: pressed ? theme.colors.surfacePressed : theme.colors.surfaceHigh, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 })}>
+                        <MaterialCommunityIcons name="content-copy" size={16} color={theme.colors.textSecondary} />
+                        <Text style={{ color: theme.colors.text, fontSize: 14, ...Typography.default('semiBold') }}>{t('common.copy')}</Text>
+                    </Pressable>
+                </View>} />
+        </>
+    );
+}

--- a/apps/mobile/sources/components/code/SyntaxHighlightedCode.tsx
+++ b/apps/mobile/sources/components/code/SyntaxHighlightedCode.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ScrollView, Text, View } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { boundText } from '@/utils/boundedText';
 import { SyntaxSpans } from '@/components/SimpleSyntaxHighlighter';
 import { highlightCodeLines, syntaxLanguage } from '@/components/code/syntaxHighlighting';
 import { ui } from '@/components/ui';
+import { PathBreadcrumb } from '@/components/PathBreadcrumb';
+import { fileIcon } from '@/plugins/domain/fileIcon';
 
 export const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode(props: { code: string; language?: string; fileName?: string }) {
     const { theme } = useUnistyles();
@@ -18,13 +19,14 @@ export const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode(p
     const fontSize = 12;
     const lineHeight = 19;
     const gutterWidth = 16 + digits * 7;
+    const pathSegments = (props.fileName ?? 'Source').split('/').filter(Boolean).map((label, index) => ({
+        label,
+        ...(index === 0 ? { icon: fileIcon(props.fileName ?? label).name } : {}),
+    }));
     return (
         <View style={{ borderRadius: ui.radius.card, overflow: 'hidden', backgroundColor: theme.colors.surfaceHigh, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.divider, marginBottom: 10 }}>
-            <View style={{ minHeight: 40, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center', gap: 8, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: theme.colors.divider }}>
-                <Ionicons name="code-slash-outline" size={15} color={theme.colors.textSecondary} />
-                <Text numberOfLines={1} ellipsizeMode="middle" style={{ color: theme.colors.text, fontSize: 11.5, flex: 1, ...Typography.mono('semiBold') }}>{props.fileName ?? 'Source'}</Text>
-                <Text style={{ color: theme.colors.textSecondary, fontSize: 10.5, ...Typography.mono() }}>{language ?? 'plain text'}</Text>
-            </View>
+            <PathBreadcrumb segments={pathSegments} fullPath={props.fileName ?? 'Source'} inline
+                trailing={<Text style={{ color: theme.colors.textSecondary, fontSize: 10.5, ...Typography.mono() }}>{language ?? 'plain text'}</Text>} />
             <View style={{ flexDirection: 'row', paddingVertical: 8 }}>
                 {/* The gutter stays put while long code moves underneath it. A
                     scrolling line number is no longer a line number. */}

--- a/apps/mobile/sources/components/code/SyntaxHighlightedCode.tsx
+++ b/apps/mobile/sources/components/code/SyntaxHighlightedCode.tsx
@@ -19,9 +19,9 @@ export const SyntaxHighlightedCode = React.memo(function SyntaxHighlightedCode(p
     const fontSize = 12;
     const lineHeight = 19;
     const gutterWidth = 16 + digits * 7;
-    const pathSegments = (props.fileName ?? 'Source').split('/').filter(Boolean).map((label, index) => ({
+    const pathSegments = (props.fileName ?? 'Source').split('/').filter(Boolean).map((label, index, segments) => ({
         label,
-        ...(index === 0 ? { icon: fileIcon(props.fileName ?? label).name } : {}),
+        ...(index === segments.length - 1 ? { icon: fileIcon(props.fileName ?? label).name } : {}),
     }));
     return (
         <View style={{ borderRadius: ui.radius.card, overflow: 'hidden', backgroundColor: theme.colors.surfaceHigh, borderWidth: StyleSheet.hairlineWidth, borderColor: theme.colors.divider, marginBottom: 10 }}>

--- a/apps/mobile/sources/components/diff/NavigableDiff.tsx
+++ b/apps/mobile/sources/components/diff/NavigableDiff.tsx
@@ -3,45 +3,7 @@ import { Pressable, ScrollView, Text, View, useWindowDimensions } from 'react-na
 import { StyleSheet, useUnistyles } from 'react-native-unistyles';
 import { Typography } from '@/constants/Typography';
 import { PierreDiffView } from '@/components/diff/PierreDiffView';
-
-interface PatchFile {
-    key: string;
-    label: string;
-    patch: string;
-    added: number;
-    removed: number;
-    binary: boolean;
-    status: 'added' | 'deleted' | 'modified' | 'renamed';
-}
-
-function patchFiles(patch: string): PatchFile[] {
-    const starts = [...patch.matchAll(/^diff --git .+$/gm)];
-    if (starts.length < 2) return [];
-    return starts.map((match, index) => {
-        const start = match.index ?? 0;
-        const end = starts[index + 1]?.index ?? patch.length;
-        const filePatch = patch.slice(start, end).trimEnd();
-        const path = /^\+\+\+\s+(?:b\/)?([^\t\n]+)/m.exec(filePatch)?.[1]
-            ?? / b\/(.+)$/.exec(match[0])?.[1]
-            ?? `File ${index + 1}`;
-        const clean = path.replace(/^"|"$/g, '');
-        let added = 0;
-        let removed = 0;
-        for (const line of filePatch.split('\n')) {
-            if (line.startsWith('+') && !line.startsWith('+++')) added += 1;
-            if (line.startsWith('-') && !line.startsWith('---')) removed += 1;
-        }
-        const binary = /^(?:Binary files|GIT binary patch)/m.test(filePatch);
-        const status = /^(?:deleted file mode|--- .*\n\+\+\+ \/dev\/null)/m.test(filePatch)
-            ? 'deleted'
-            : /^(?:new file mode|--- \/dev\/null)/m.test(filePatch)
-                ? 'added'
-                : /^(?:similarity index|rename from|rename to)/m.test(filePatch)
-                    ? 'renamed'
-                    : 'modified';
-        return { key: `${index}:${clean}`, label: clean, patch: filePatch, added, removed, binary, status };
-    });
-}
+import { patchFiles, uniqueDiffLabels, type PatchFile } from '@/components/diff/patchFiles';
 
 /** A commit stays scrollable as one patch, but every changed file is one tap away. */
 export function NavigableDiff({ patch }: { patch: string }) {
@@ -51,25 +13,15 @@ export function NavigableDiff({ patch }: { patch: string }) {
     const [selected, setSelected] = React.useState<number>();
     React.useEffect(() => setSelected(undefined), [patch]);
     const shown = selected === undefined ? patch : files[selected]?.patch ?? patch;
-    const basenameCounts = React.useMemo(() => {
-        const counts = new Map<string, number>();
-        for (const file of files) {
-            const basename = file.label.split('/').pop() ?? file.label;
-            counts.set(basename, (counts.get(basename) ?? 0) + 1);
-        }
-        return counts;
-    }, [files]);
+    const chipLabels = React.useMemo(() => uniqueDiffLabels(files.map((file) => file.label)), [files]);
 
     return <View>
         {files.length > 1 && <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.rail}
             contentContainerStyle={styles.railContent} accessibilityRole="tablist">
             <DiffTab label="All" active={selected === undefined} onPress={() => setSelected(undefined)} />
-            {files.map((file, index) => {
-                const basename = file.label.split('/').pop() ?? file.label;
-                const parent = file.label.slice(0, Math.max(0, file.label.length - basename.length - 1)).split('/').pop();
-                const label = (basenameCounts.get(basename) ?? 0) > 1 && parent ? `${parent}/${basename}` : basename;
-                return <DiffTab key={file.key} file={file} label={label} active={selected === index} onPress={() => setSelected(index)} />;
-            })}
+            {files.map((file, index) => (
+                <DiffTab key={file.key} file={file} label={chipLabels[index] ?? file.label} active={selected === index} onPress={() => setSelected(index)} />
+            ))}
         </ScrollView>}
         <PierreDiffView patch={shown} diffStyle="unified" overflow={width < 700 ? 'wrap' : 'scroll'} fontSize={12} />
     </View>;

--- a/apps/mobile/sources/components/diff/NavigableDiff.tsx
+++ b/apps/mobile/sources/components/diff/NavigableDiff.tsx
@@ -82,14 +82,19 @@ export function NavigableDiff({ patch }: { patch: string }) {
                 : file.status === 'deleted' ? theme.colors.gitRemovedText
                     : file.status === 'modified' ? theme.colors.accent : theme.colors.textSecondary;
         return <Pressable onPress={onPress} accessibilityRole="tab"
-            accessibilityLabel={file === undefined ? label : `Show changes in ${file.label}, ${status}, ${stats}`}
+            accessibilityLabel={file === undefined ? label : `Show changes in ${file.label}, ${status}, ${stats ?? ''}`}
             accessibilityState={{ selected: active }}
             style={({ pressed }) => [styles.tab, { borderColor: active ? theme.colors.accent : theme.colors.divider, backgroundColor: active ? theme.colors.surfaceSelected : pressed ? theme.colors.surfacePressed : theme.colors.surfaceHigh }] }>
             <View style={styles.tabTitle}>
                 {status !== undefined && <Text style={{ color: statusColor, fontSize: 11, ...Typography.mono('semiBold') }}>{status}</Text>}
                 <Text numberOfLines={1} style={{ color: active ? theme.colors.text : theme.colors.textSecondary, fontSize: 11.5, ...Typography.mono(active ? 'semiBold' : 'regular') }}>{label}</Text>
             </View>
-            {stats !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 10.5, ...Typography.mono() }}>{stats}</Text>}
+            {file?.binary === true
+                ? <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 10.5, ...Typography.mono() }}>binary</Text>
+                : file !== undefined && <View style={{ flexDirection: 'row', gap: 6 }}>
+                    <Text style={{ color: theme.colors.gitAddedText, fontSize: 10.5, ...Typography.mono('semiBold') }}>+{file.added}</Text>
+                    <Text style={{ color: theme.colors.gitRemovedText, fontSize: 10.5, ...Typography.mono('semiBold') }}>−{file.removed}</Text>
+                </View>}
         </Pressable>;
     }
 }

--- a/apps/mobile/sources/components/diff/NavigableDiff.tsx
+++ b/apps/mobile/sources/components/diff/NavigableDiff.tsx
@@ -8,6 +8,10 @@ interface PatchFile {
     key: string;
     label: string;
     patch: string;
+    added: number;
+    removed: number;
+    binary: boolean;
+    status: 'added' | 'deleted' | 'modified' | 'renamed';
 }
 
 function patchFiles(patch: string): PatchFile[] {
@@ -21,7 +25,21 @@ function patchFiles(patch: string): PatchFile[] {
             ?? / b\/(.+)$/.exec(match[0])?.[1]
             ?? `File ${index + 1}`;
         const clean = path.replace(/^"|"$/g, '');
-        return { key: `${index}:${clean}`, label: clean, patch: filePatch };
+        let added = 0;
+        let removed = 0;
+        for (const line of filePatch.split('\n')) {
+            if (line.startsWith('+') && !line.startsWith('+++')) added += 1;
+            if (line.startsWith('-') && !line.startsWith('---')) removed += 1;
+        }
+        const binary = /^(?:Binary files|GIT binary patch)/m.test(filePatch);
+        const status = /^(?:deleted file mode|--- .*\n\+\+\+ \/dev\/null)/m.test(filePatch)
+            ? 'deleted'
+            : /^(?:new file mode|--- \/dev\/null)/m.test(filePatch)
+                ? 'added'
+                : /^(?:similarity index|rename from|rename to)/m.test(filePatch)
+                    ? 'renamed'
+                    : 'modified';
+        return { key: `${index}:${clean}`, label: clean, patch: filePatch, added, removed, binary, status };
     });
 }
 
@@ -33,21 +51,45 @@ export function NavigableDiff({ patch }: { patch: string }) {
     const [selected, setSelected] = React.useState<number>();
     React.useEffect(() => setSelected(undefined), [patch]);
     const shown = selected === undefined ? patch : files[selected]?.patch ?? patch;
+    const basenameCounts = React.useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const file of files) {
+            const basename = file.label.split('/').pop() ?? file.label;
+            counts.set(basename, (counts.get(basename) ?? 0) + 1);
+        }
+        return counts;
+    }, [files]);
 
     return <View>
         {files.length > 1 && <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.rail}
             contentContainerStyle={styles.railContent} accessibilityRole="tablist">
             <DiffTab label="All" active={selected === undefined} onPress={() => setSelected(undefined)} />
-            {files.map((file, index) => <DiffTab key={file.key} label={file.label.split('/').pop() ?? file.label}
-                accessibilityLabel={`Show changes in ${file.label}`} active={selected === index} onPress={() => setSelected(index)} />)}
+            {files.map((file, index) => {
+                const basename = file.label.split('/').pop() ?? file.label;
+                const parent = file.label.slice(0, Math.max(0, file.label.length - basename.length - 1)).split('/').pop();
+                const label = (basenameCounts.get(basename) ?? 0) > 1 && parent ? `${parent}/${basename}` : basename;
+                return <DiffTab key={file.key} file={file} label={label} active={selected === index} onPress={() => setSelected(index)} />;
+            })}
         </ScrollView>}
         <PierreDiffView patch={shown} diffStyle="unified" overflow={width < 700 ? 'wrap' : 'scroll'} fontSize={12} />
     </View>;
 
-    function DiffTab({ label, active, onPress, accessibilityLabel }: { label: string; active: boolean; onPress: () => void; accessibilityLabel?: string }) {
-        return <Pressable onPress={onPress} accessibilityRole="tab" accessibilityLabel={accessibilityLabel ?? label} accessibilityState={{ selected: active }}
-            style={({ pressed }) => [styles.tab, { borderColor: theme.colors.divider, backgroundColor: active ? theme.colors.surfaceHighest : pressed ? theme.colors.surfacePressed : theme.colors.surfaceHigh }]}>
-            <Text numberOfLines={1} style={{ color: active ? theme.colors.text : theme.colors.textSecondary, fontSize: 11.5, ...Typography.mono(active ? 'semiBold' : 'regular') }}>{label}</Text>
+    function DiffTab({ file, label, active, onPress }: { file?: PatchFile; label: string; active: boolean; onPress: () => void }) {
+        const stats = file === undefined ? undefined : file.binary ? 'binary' : `+${file.added} −${file.removed}`;
+        const status = file === undefined ? undefined : file.status === 'added' ? 'A' : file.status === 'deleted' ? 'D' : file.status === 'renamed' ? 'R' : 'M';
+        const statusColor = file === undefined ? theme.colors.textSecondary
+            : file.status === 'added' ? theme.colors.gitAddedText
+                : file.status === 'deleted' ? theme.colors.gitRemovedText
+                    : file.status === 'modified' ? theme.colors.accent : theme.colors.textSecondary;
+        return <Pressable onPress={onPress} accessibilityRole="tab"
+            accessibilityLabel={file === undefined ? label : `Show changes in ${file.label}, ${status}, ${stats}`}
+            accessibilityState={{ selected: active }}
+            style={({ pressed }) => [styles.tab, { borderColor: active ? theme.colors.accent : theme.colors.divider, backgroundColor: active ? theme.colors.surfaceSelected : pressed ? theme.colors.surfacePressed : theme.colors.surfaceHigh }] }>
+            <View style={styles.tabTitle}>
+                {status !== undefined && <Text style={{ color: statusColor, fontSize: 11, ...Typography.mono('semiBold') }}>{status}</Text>}
+                <Text numberOfLines={1} style={{ color: active ? theme.colors.text : theme.colors.textSecondary, fontSize: 11.5, ...Typography.mono(active ? 'semiBold' : 'regular') }}>{label}</Text>
+            </View>
+            {stats !== undefined && <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 10.5, ...Typography.mono() }}>{stats}</Text>}
         </Pressable>;
     }
 }
@@ -55,5 +97,6 @@ export function NavigableDiff({ patch }: { patch: string }) {
 const styles = StyleSheet.create({
     rail: { marginBottom: 8 },
     railContent: { gap: 6, paddingRight: 16 },
-    tab: { minHeight: 44, maxWidth: 180, justifyContent: 'center', borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 11 },
+    tab: { minHeight: 44, maxWidth: 190, justifyContent: 'center', gap: 2, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, paddingHorizontal: 11 },
+    tabTitle: { flexDirection: 'row', alignItems: 'center', gap: 5 },
 });

--- a/apps/mobile/sources/components/diff/patchFiles.ts
+++ b/apps/mobile/sources/components/diff/patchFiles.ts
@@ -1,3 +1,5 @@
+import { decodeGitPath } from '@/catalog/infrastructure/git-parsers/gitPath';
+
 export interface PatchFile {
     key: string;
     label: string;
@@ -8,44 +10,9 @@ export interface PatchFile {
     status: 'added' | 'deleted' | 'modified' | 'renamed';
 }
 
-const GIT_C_ESCAPES: Record<string, number> = {
-    a: 0x07, b: 0x08, t: 0x09, n: 0x0a, v: 0x0b, f: 0x0c, r: 0x0d, '"': 0x22, '\\': 0x5c,
-};
-
-function unquoteGitPath(raw: string): string {
-    if (!raw.startsWith('"')) return raw;
-    const bytes: number[] = [];
-    for (let i = 1; i < raw.length; i += 1) {
-        const ch = raw[i];
-        if (ch === undefined || ch === '"') break;
-        if (ch !== '\\') {
-            bytes.push(ch.charCodeAt(0));
-            continue;
-        }
-        const next = raw[i + 1];
-        if (next === undefined) break;
-        if (next >= '0' && next <= '7') {
-            let value = 0;
-            let count = 0;
-            while (count < 3) {
-                const digit = raw[i + 1];
-                if (digit === undefined || digit < '0' || digit > '7') break;
-                value = (value << 3) + (digit.charCodeAt(0) - 48);
-                i += 1;
-                count += 1;
-            }
-            bytes.push(value & 0xff);
-            continue;
-        }
-        bytes.push(GIT_C_ESCAPES[next] ?? next.charCodeAt(0));
-        i += 1;
-    }
-    return new TextDecoder().decode(Uint8Array.from(bytes));
-}
-
 function headerPath(raw: string | undefined): string | undefined {
     if (raw === undefined) return undefined;
-    const path = unquoteGitPath(raw);
+    const path = decodeGitPath(raw);
     if (path === '/dev/null') return undefined;
     return path.replace(/^[ab]\//, '');
 }

--- a/apps/mobile/sources/components/diff/patchFiles.ts
+++ b/apps/mobile/sources/components/diff/patchFiles.ts
@@ -1,0 +1,78 @@
+export interface PatchFile {
+    key: string;
+    label: string;
+    patch: string;
+    added: number;
+    removed: number;
+    binary: boolean;
+    status: 'added' | 'deleted' | 'modified' | 'renamed';
+}
+
+function headerPath(line: string | undefined): string | undefined {
+    if (line === undefined || line === '/dev/null') return undefined;
+    return line.replace(/^"|"$/g, '');
+}
+
+export function patchFiles(patch: string): PatchFile[] {
+    const starts = [...patch.matchAll(/^diff --git .+$/gm)];
+    if (starts.length < 2) return [];
+    return starts.map((match, index) => {
+        const start = match.index ?? 0;
+        const end = starts[index + 1]?.index ?? patch.length;
+        const filePatch = patch.slice(start, end).trimEnd();
+        const plus = headerPath(/^\+\+\+\s+(?:b\/)?([^\t\n]+)/m.exec(filePatch)?.[1]);
+        const minus = headerPath(/^---\s+(?:a\/)?([^\t\n]+)/m.exec(filePatch)?.[1]);
+        const gitNew = headerPath(/ b\/(.+)$/.exec(match[0])?.[1]);
+        const gitOld = headerPath(/ a\/(.+) b\//.exec(match[0])?.[1]);
+        const clean = plus ?? minus ?? gitNew ?? gitOld ?? `File ${index + 1}`;
+        let added = 0;
+        let removed = 0;
+        let inHunk = false;
+        for (const line of filePatch.split('\n')) {
+            if (line.startsWith('@@')) {
+                inHunk = true;
+                continue;
+            }
+            if (line.startsWith('diff --git')) {
+                inHunk = false;
+                continue;
+            }
+            if (!inHunk) continue;
+            if (line.startsWith('+')) added += 1;
+            if (line.startsWith('-')) removed += 1;
+        }
+        const binary = /^(?:Binary files|GIT binary patch)/m.test(filePatch);
+        const status = /^(?:deleted file mode|--- .*\n\+\+\+ \/dev\/null)/m.test(filePatch)
+            ? 'deleted'
+            : /^(?:new file mode|--- \/dev\/null)/m.test(filePatch)
+                ? 'added'
+                : /^(?:similarity index|rename from|rename to)/m.test(filePatch)
+                    ? 'renamed'
+                    : 'modified';
+        return { key: `${index}:${clean}`, label: clean, patch: filePatch, added, removed, binary, status };
+    });
+}
+
+/** Expand parent segments of colliding basenames until each chip label is unique. */
+export function uniqueDiffLabels(paths: string[]): string[] {
+    const segments = paths.map((path) => path.replace(/^\/+/, '').split('/').filter(Boolean));
+    const take = segments.map((parts) => Math.min(1, parts.length));
+    for (;;) {
+        const labels = segments.map((parts, index) => {
+            if (parts.length === 0) return paths[index] ?? '';
+            return parts.slice(-Math.max(1, take[index] ?? 1)).join('/');
+        });
+        const counts = new Map<string, number>();
+        for (const label of labels) counts.set(label, (counts.get(label) ?? 0) + 1);
+        let grew = false;
+        for (let index = 0; index < labels.length; index += 1) {
+            const label = labels[index] ?? '';
+            const parts = segments[index] ?? [];
+            if ((counts.get(label) ?? 0) > 1 && (take[index] ?? 0) < parts.length) {
+                take[index] = (take[index] ?? 1) + 1;
+                grew = true;
+            }
+        }
+        if (!grew) return labels;
+    }
+}

--- a/apps/mobile/sources/components/diff/patchFiles.ts
+++ b/apps/mobile/sources/components/diff/patchFiles.ts
@@ -8,9 +8,75 @@ export interface PatchFile {
     status: 'added' | 'deleted' | 'modified' | 'renamed';
 }
 
-function headerPath(line: string | undefined): string | undefined {
-    if (line === undefined || line === '/dev/null') return undefined;
-    return line.replace(/^"|"$/g, '');
+const GIT_C_ESCAPES: Record<string, number> = {
+    a: 0x07, b: 0x08, t: 0x09, n: 0x0a, v: 0x0b, f: 0x0c, r: 0x0d, '"': 0x22, '\\': 0x5c,
+};
+
+function unquoteGitPath(raw: string): string {
+    if (!raw.startsWith('"')) return raw;
+    const bytes: number[] = [];
+    for (let i = 1; i < raw.length; i += 1) {
+        const ch = raw[i];
+        if (ch === undefined || ch === '"') break;
+        if (ch !== '\\') {
+            bytes.push(ch.charCodeAt(0));
+            continue;
+        }
+        const next = raw[i + 1];
+        if (next === undefined) break;
+        if (next >= '0' && next <= '7') {
+            let value = 0;
+            let count = 0;
+            while (count < 3) {
+                const digit = raw[i + 1];
+                if (digit === undefined || digit < '0' || digit > '7') break;
+                value = (value << 3) + (digit.charCodeAt(0) - 48);
+                i += 1;
+                count += 1;
+            }
+            bytes.push(value & 0xff);
+            continue;
+        }
+        bytes.push(GIT_C_ESCAPES[next] ?? next.charCodeAt(0));
+        i += 1;
+    }
+    return new TextDecoder().decode(Uint8Array.from(bytes));
+}
+
+function headerPath(raw: string | undefined): string | undefined {
+    if (raw === undefined) return undefined;
+    const path = unquoteGitPath(raw);
+    if (path === '/dev/null') return undefined;
+    return path.replace(/^[ab]\//, '');
+}
+
+function gitPathToken(input: string): { token: string; rest: string } | undefined {
+    const text = input.trimStart();
+    if (text === '') return undefined;
+    if (!text.startsWith('"')) {
+        const end = text.search(/\s/);
+        const token = end < 0 ? text : text.slice(0, end);
+        return { token, rest: end < 0 ? '' : text.slice(end) };
+    }
+    let i = 1;
+    while (i < text.length) {
+        if (text[i] === '\\') {
+            i += 2;
+            continue;
+        }
+        if (text[i] === '"') return { token: text.slice(0, i + 1), rest: text.slice(i + 1) };
+        i += 1;
+    }
+    return { token: text, rest: '' };
+}
+
+function diffGitPaths(line: string): { old?: string; neu?: string } {
+    const first = gitPathToken(line.replace(/^diff --git\s+/, ''));
+    if (first === undefined) return {};
+    const second = gitPathToken(first.rest);
+    const old = headerPath(first.token);
+    const neu = second === undefined ? undefined : headerPath(second.token);
+    return { ...(old === undefined ? {} : { old }), ...(neu === undefined ? {} : { neu }) };
 }
 
 export function patchFiles(patch: string): PatchFile[] {
@@ -20,11 +86,10 @@ export function patchFiles(patch: string): PatchFile[] {
         const start = match.index ?? 0;
         const end = starts[index + 1]?.index ?? patch.length;
         const filePatch = patch.slice(start, end).trimEnd();
-        const plus = headerPath(/^\+\+\+\s+(?:b\/)?([^\t\n]+)/m.exec(filePatch)?.[1]);
-        const minus = headerPath(/^---\s+(?:a\/)?([^\t\n]+)/m.exec(filePatch)?.[1]);
-        const gitNew = headerPath(/ b\/(.+)$/.exec(match[0])?.[1]);
-        const gitOld = headerPath(/ a\/(.+) b\//.exec(match[0])?.[1]);
-        const clean = plus ?? minus ?? gitNew ?? gitOld ?? `File ${index + 1}`;
+        const names = diffGitPaths(match[0] ?? '');
+        const plus = headerPath(/^\+\+\+\s+([^\t\n]+)/m.exec(filePatch)?.[1]);
+        const minus = headerPath(/^---\s+([^\t\n]+)/m.exec(filePatch)?.[1]);
+        const clean = plus ?? minus ?? names.neu ?? names.old ?? `File ${index + 1}`;
         let added = 0;
         let removed = 0;
         let inHunk = false;

--- a/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
@@ -1,0 +1,97 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { patchFiles, uniqueDiffLabels } from '@/components/diff/patchFiles';
+import { nearestContentMount } from '@/plugins/domain/screenModel';
+import {
+    fileNavControlLabel,
+    gitDirectoryProbeCommand,
+    gitDirectorySearchPaths,
+} from './fileNavigationList';
+
+const commit = `diff --git a/src/old.ts b/src/old.ts
+deleted file mode 100644
+index 1111111..0000000
+--- a/src/old.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-export const gone = 1;
+-export const also = 2;
+diff --git a/a/shared/index.ts b/a/shared/index.ts
+index 2222222..3333333 100644
+--- a/a/shared/index.ts
++++ b/a/shared/index.ts
+@@ -1,3 +1,4 @@
+ keep
++++added plusplus
+----removed minusminus
++ok
+diff --git a/b/shared/index.ts b/b/shared/index.ts
+index 4444444..5555555 100644
+--- a/b/shared/index.ts
++++ b/b/shared/index.ts
+@@ -1 +1,2 @@
+-old
++new
++readme
+diff --git a/notes.md b/notes.md
+index 6666666..7777777 100644
+--- a/notes.md
++++ b/notes.md
+@@ -1 +1 @@
+-before
++after
+`;
+
+describe('file and diff navigation', () => {
+    it('opens a third-party file, reads a mixed commit, and titles the nested screen', () => {
+        const root = mkdtempSync(join(tmpdir(), 'muxr-file-nav-'));
+        try {
+            const otherFile = join(root, 'other', 'repo', 'src', 'app.ts');
+            const session = join(root, 'main');
+            mkdirSync(join(root, 'other', 'repo', 'src'), { recursive: true });
+            mkdirSync(session, { recursive: true });
+            writeFileSync(otherFile, 'export {}\n');
+
+            expect(gitDirectorySearchPaths(otherFile, session)[0]).toBe(join(root, 'other', 'repo', 'src'));
+            expect(gitDirectorySearchPaths(otherFile, session).at(-1)).toBe(session);
+            expect(probe(otherFile, session)).toBe(join(root, 'other', 'repo', 'src'));
+            expect(probe(join(root, 'other', 'repo', 'gone', 'file.ts'), session)).toBe(join(root, 'other', 'repo'));
+            expect(gitDirectorySearchPaths('orphan.ts', session)).toEqual([session]);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+
+        const files = patchFiles(commit);
+        expect(files.map((file) => ({ label: file.label, status: file.status, added: file.added, removed: file.removed }))).toEqual([
+            { label: 'src/old.ts', status: 'deleted', added: 0, removed: 2 },
+            { label: 'a/shared/index.ts', status: 'modified', added: 2, removed: 1 },
+            { label: 'b/shared/index.ts', status: 'modified', added: 2, removed: 1 },
+            { label: 'notes.md', status: 'modified', added: 1, removed: 1 },
+        ]);
+        expect(uniqueDiffLabels(files.map((file) => file.label))).toEqual([
+            'old.ts',
+            'a/shared/index.ts',
+            'b/shared/index.ts',
+            'notes.md',
+        ]);
+
+        const mounts = [
+            { contentContributionId: 'foo.files', label: 'Files' },
+            { contentContributionId: 'foo.settings', label: 'Settings' },
+        ];
+        expect(nearestContentMount(mounts, 'foo.settings.detail')?.label).toBe('Settings');
+        expect(nearestContentMount(mounts, 'foo.files')?.label).toBe('Files');
+        expect(nearestContentMount(mounts, 'foo.other.x')).toBeUndefined();
+
+        expect(fileNavControlLabel('next', 'b.ts', 0, 3)).toBe('Next changed file, b.ts, 2 of 3');
+        expect(fileNavControlLabel('previous', 'a.ts', 1, 3)).toBe('Previous changed file, a.ts, 1 of 3');
+        expect(fileNavControlLabel('previous', undefined, 0, 3)).toBe('Previous changed file');
+    });
+});
+
+function probe(filePath: string, sessionPath: string): string {
+    return execFileSync('/bin/bash', ['-lc', gitDirectoryProbeCommand(filePath, sessionPath)], { encoding: 'utf8' });
+}

--- a/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
@@ -1,17 +1,21 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { patchFiles, uniqueDiffLabels } from '@/components/diff/patchFiles';
 import { nearestContentMount } from '@/plugins/domain/screenModel';
 import {
+    bundledBinaryChip,
     currentFileNavigation,
     fileNavControlLabel,
     gitDirectoryProbeCommand,
     gitDirectorySearchPaths,
     recordFileNavigation,
 } from './fileNavigationList';
+
+const changesScript = join(dirname(fileURLToPath(import.meta.url)), '../../../../../plugins/code/changes.mjs');
 
 const commit = `diff --git a/src/old.ts b/src/old.ts
 deleted file mode 100644
@@ -52,6 +56,13 @@ index 8888888..9999999 100644
 @@ -1 +1 @@
 -old
 +new
+diff --git "a/é file.ts" "b/é file.ts"
+index aaaaaaa..bbbbbbb 100644
+--- "a/é file.ts"
++++ "b/é file.ts"
+@@ -1 +1 @@
+-plain
++quoted
 `;
 
 describe('file and diff navigation', () => {
@@ -80,6 +91,7 @@ describe('file and diff navigation', () => {
             { label: 'b/shared/index.ts', status: 'modified', added: 2, removed: 1 },
             { label: 'notes.md', status: 'modified', added: 1, removed: 1 },
             { label: 'é.ts', status: 'modified', added: 1, removed: 1 },
+            { label: 'é file.ts', status: 'modified', added: 1, removed: 1 },
         ]);
         expect(uniqueDiffLabels(files.map((file) => file.label))).toEqual([
             'old.ts',
@@ -87,18 +99,43 @@ describe('file and diff navigation', () => {
             'b/shared/index.ts',
             'notes.md',
             'é.ts',
+            'é file.ts',
         ]);
+
+        const bin = mkdtempSync(join(tmpdir(), 'muxr-git-'));
+        try {
+            writeFileSync(join(bin, 'git'), `#!/bin/sh
+case " $* " in
+  *" rev-parse "*) printf '%s\\n' "$2" ;;
+  *" --porcelain=v1 "*) printf 'C  copied.ts\\0kept.ts\\0' ;;
+esac
+`, { mode: 0o755 });
+            const items = JSON.parse(execFileSync(process.execPath, [changesScript], {
+                encoding: 'utf8',
+                env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+                input: JSON.stringify({ cwd: '/repo' }),
+            })).items as Array<{ title: string; group: string; icon: string }>;
+            expect(items.map(({ title, group, icon }) => ({ title, group, icon }))).toEqual([
+                { title: 'copied.ts', group: 'Renamed', icon: 'swap-horizontal-outline' },
+            ]);
+        } finally {
+            rmSync(bin, { recursive: true, force: true });
+        }
 
         recordFileNavigation('session-1', [
             { id: 'row-a', title: 'first', metadata: [], action: { type: 'kernel.navigate', target: 'file', path: '/repo/a.ts' } },
             { id: 'row-a-again', title: 'dup', group: 'Addressed', metadata: [{ value: '+VIP' }], action: { type: 'kernel.navigate', target: 'file', path: '/repo/a.ts' } },
+            { id: 'row-bin', title: 'photo', metadata: [{ value: 'binary', tone: 'secondary' }], action: { type: 'kernel.navigate', target: 'file', path: '/repo/photo.png' } },
+            { id: 'row-fake-bin', title: 'notes', metadata: [{ value: 'binary' }], action: { type: 'kernel.navigate', target: 'file', path: '/repo/notes.md' } },
             { id: 'row-b', title: 'second', metadata: [], action: { type: 'kernel.navigate', target: 'file', path: '/repo/b.ts' } },
         ], '/repo/a.ts');
         const current = currentFileNavigation('session-1', '/repo/a.ts');
-        expect(current?.entries.map((entry) => entry.path)).toEqual(['/repo/a.ts', '/repo/b.ts']);
+        expect(current?.entries.map((entry) => entry.path)).toEqual(['/repo/a.ts', '/repo/photo.png', '/repo/notes.md', '/repo/b.ts']);
         expect(current?.index).toBe(0);
-        expect(current!.entries[current!.index + 1]?.path).toBe('/repo/b.ts');
-        expect(currentFileNavigation('session-1', '/repo/b.ts')?.index).toBe(1);
+        expect(current!.entries[current!.index + 1]?.path).toBe('/repo/photo.png');
+        expect(bundledBinaryChip(currentFileNavigation('session-1', '/repo/photo.png')!.entries[1]!.metadata)).toBe(true);
+        expect(bundledBinaryChip(currentFileNavigation('session-1', '/repo/notes.md')!.entries[2]!.metadata)).toBe(false);
+        expect(currentFileNavigation('session-1', '/repo/b.ts')?.index).toBe(3);
 
         const mounts = [
             { contentContributionId: 'foo.files', label: 'Files' },

--- a/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.spec.ts
@@ -6,9 +6,11 @@ import { describe, expect, it } from 'vitest';
 import { patchFiles, uniqueDiffLabels } from '@/components/diff/patchFiles';
 import { nearestContentMount } from '@/plugins/domain/screenModel';
 import {
+    currentFileNavigation,
     fileNavControlLabel,
     gitDirectoryProbeCommand,
     gitDirectorySearchPaths,
+    recordFileNavigation,
 } from './fileNavigationList';
 
 const commit = `diff --git a/src/old.ts b/src/old.ts
@@ -43,6 +45,13 @@ index 6666666..7777777 100644
 @@ -1 +1 @@
 -before
 +after
+diff --git "a/\\303\\251.ts" "b/\\303\\251.ts"
+index 8888888..9999999 100644
+--- "a/\\303\\251.ts"
++++ "b/\\303\\251.ts"
+@@ -1 +1 @@
+-old
++new
 `;
 
 describe('file and diff navigation', () => {
@@ -70,13 +79,26 @@ describe('file and diff navigation', () => {
             { label: 'a/shared/index.ts', status: 'modified', added: 2, removed: 1 },
             { label: 'b/shared/index.ts', status: 'modified', added: 2, removed: 1 },
             { label: 'notes.md', status: 'modified', added: 1, removed: 1 },
+            { label: 'é.ts', status: 'modified', added: 1, removed: 1 },
         ]);
         expect(uniqueDiffLabels(files.map((file) => file.label))).toEqual([
             'old.ts',
             'a/shared/index.ts',
             'b/shared/index.ts',
             'notes.md',
+            'é.ts',
         ]);
+
+        recordFileNavigation('session-1', [
+            { id: 'row-a', title: 'first', metadata: [], action: { type: 'kernel.navigate', target: 'file', path: '/repo/a.ts' } },
+            { id: 'row-a-again', title: 'dup', group: 'Addressed', metadata: [{ value: '+VIP' }], action: { type: 'kernel.navigate', target: 'file', path: '/repo/a.ts' } },
+            { id: 'row-b', title: 'second', metadata: [], action: { type: 'kernel.navigate', target: 'file', path: '/repo/b.ts' } },
+        ], '/repo/a.ts');
+        const current = currentFileNavigation('session-1', '/repo/a.ts');
+        expect(current?.entries.map((entry) => entry.path)).toEqual(['/repo/a.ts', '/repo/b.ts']);
+        expect(current?.index).toBe(0);
+        expect(current!.entries[current!.index + 1]?.path).toBe('/repo/b.ts');
+        expect(currentFileNavigation('session-1', '/repo/b.ts')?.index).toBe(1);
 
         const mounts = [
             { contentContributionId: 'foo.files', label: 'Files' },

--- a/apps/mobile/sources/plugins/application/fileNavigationList.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.ts
@@ -73,6 +73,11 @@ export function gitDirectoryProbeCommand(filePath: string, sessionPath: string |
     return `for d in ${listed}; do [ -d "$d" ] && { printf '%s' "$d"; exit 0; }; done; printf '%s' ${shellQuote(paths[paths.length - 1] ?? '/')}`;
 }
 
+/** Bundled changes rows mark binaries with value+secondary; a bare "binary" string is not Git status. */
+export function bundledBinaryChip(metadata: FileNavigationEntry['metadata']): boolean {
+    return metadata.some((item) => item.value === 'binary' && item.tone === 'secondary');
+}
+
 export function fileNavControlLabel(direction: 'previous' | 'next', title: string | undefined, index: number, total: number): string {
     const verb = direction === 'previous' ? 'Previous' : 'Next';
     if (title === undefined) return `${verb} changed file`;

--- a/apps/mobile/sources/plugins/application/fileNavigationList.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.ts
@@ -6,6 +6,7 @@ export interface FileNavigationEntry {
     title: string;
     subtitle?: string;
     group?: string;
+    icon?: string;
     metadata: PluginItemListItem['metadata'];
 }
 
@@ -18,18 +19,23 @@ export function recordFileNavigation(sessionId: string, items: PluginItemListIte
         activeSessionId = sessionId;
         entries = [];
     }
-    entries = items.flatMap((item) => {
+    const next: FileNavigationEntry[] = [];
+    const seen = new Set<string>();
+    for (const item of items) {
         const action = item.action;
-        if (action?.type !== 'kernel.navigate' || action.target !== 'file') return [];
-        return [{
+        if (action?.type !== 'kernel.navigate' || action.target !== 'file') continue;
+        if (seen.has(action.path)) continue;
+        seen.add(action.path);
+        next.push({
             path: action.path,
             title: item.title,
             ...(item.subtitle === undefined ? {} : { subtitle: item.subtitle }),
             ...(item.group === undefined ? {} : { group: item.group }),
+            ...(item.icon === undefined ? {} : { icon: item.icon }),
             metadata: item.metadata,
-        }];
-    });
-    if (!entries.some((entry) => entry.path === selectedPath)) entries = [];
+        });
+    }
+    entries = next.some((entry) => entry.path === selectedPath) ? next : [];
 }
 
 export function currentFileNavigation(sessionId: string, path: string): { entries: FileNavigationEntry[]; index: number } | null {

--- a/apps/mobile/sources/plugins/application/fileNavigationList.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.ts
@@ -1,4 +1,5 @@
 import type { PluginItemListItem } from '../domain/itemListModel';
+import { shellQuote } from '@/utils/shellQuote';
 
 export interface FileNavigationEntry {
     path: string;
@@ -35,4 +36,40 @@ export function currentFileNavigation(sessionId: string, path: string): { entrie
     if (activeSessionId !== sessionId) return null;
     const index = entries.findIndex((entry) => entry.path === path);
     return index < 0 ? null : { entries, index };
+}
+
+export function parentDirectory(path: string): string | null {
+    if (path === '/' || path === '') return null;
+    const slash = path.lastIndexOf('/');
+    if (slash < 0) return null;
+    return slash === 0 ? '/' : path.slice(0, slash);
+}
+
+/** File directory first, then ancestors, then session cwd only if it is not already an ancestor. */
+export function gitDirectorySearchPaths(filePath: string, sessionPath: string | null): string[] {
+    let dir = parentDirectory(filePath);
+    if (dir === null) return sessionPath ? [sessionPath] : ['/'];
+    const paths: string[] = [];
+    for (;;) {
+        paths.push(dir);
+        if (dir === '/') break;
+        const next = parentDirectory(dir);
+        if (next === null) break;
+        dir = next;
+    }
+    if (sessionPath && !paths.includes(sessionPath)) paths.push(sessionPath);
+    return paths;
+}
+
+export function gitDirectoryProbeCommand(filePath: string, sessionPath: string | null): string {
+    const paths = gitDirectorySearchPaths(filePath, sessionPath);
+    const listed = paths.map(shellQuote).join(' ');
+    return `for d in ${listed}; do [ -d "$d" ] && { printf '%s' "$d"; exit 0; }; done; printf '%s' ${shellQuote(paths[paths.length - 1] ?? '/')}`;
+}
+
+export function fileNavControlLabel(direction: 'previous' | 'next', title: string | undefined, index: number, total: number): string {
+    const verb = direction === 'previous' ? 'Previous' : 'Next';
+    if (title === undefined) return `${verb} changed file`;
+    const ordinal = direction === 'previous' ? index : index + 2;
+    return `${verb} changed file, ${title}, ${ordinal} of ${total}`;
 }

--- a/apps/mobile/sources/plugins/application/fileNavigationList.ts
+++ b/apps/mobile/sources/plugins/application/fileNavigationList.ts
@@ -1,0 +1,38 @@
+import type { PluginItemListItem } from '../domain/itemListModel';
+
+export interface FileNavigationEntry {
+    path: string;
+    title: string;
+    subtitle?: string;
+    group?: string;
+    metadata: PluginItemListItem['metadata'];
+}
+
+let activeSessionId: string | undefined;
+let entries: FileNavigationEntry[] = [];
+
+/** Keep the last generic file list so a file viewer can continue the review. */
+export function recordFileNavigation(sessionId: string, items: PluginItemListItem[], selectedPath: string): void {
+    if (activeSessionId !== sessionId) {
+        activeSessionId = sessionId;
+        entries = [];
+    }
+    entries = items.flatMap((item) => {
+        const action = item.action;
+        if (action?.type !== 'kernel.navigate' || action.target !== 'file') return [];
+        return [{
+            path: action.path,
+            title: item.title,
+            ...(item.subtitle === undefined ? {} : { subtitle: item.subtitle }),
+            ...(item.group === undefined ? {} : { group: item.group }),
+            metadata: item.metadata,
+        }];
+    });
+    if (!entries.some((entry) => entry.path === selectedPath)) entries = [];
+}
+
+export function currentFileNavigation(sessionId: string, path: string): { entries: FileNavigationEntry[]; index: number } | null {
+    if (activeSessionId !== sessionId) return null;
+    const index = entries.findIndex((entry) => entry.path === path);
+    return index < 0 ? null : { entries, index };
+}

--- a/apps/mobile/sources/plugins/domain/screenModel.ts
+++ b/apps/mobile/sources/plugins/domain/screenModel.ts
@@ -234,3 +234,21 @@ export async function runScreenButton(
         return { ok: false, text: displayText(error instanceof Error ? error.message : String(error)) };
     }
 }
+
+/** Longest `contentContributionId` prefix at a dot boundary; exact id wins. */
+export function nearestContentMount<T extends { contentContributionId: string }>(
+    mounts: readonly T[],
+    contentId: string,
+): T | undefined {
+    let best: T | undefined;
+    let bestLen = -1;
+    for (const mount of mounts) {
+        const id = mount.contentContributionId;
+        if (id === contentId) return mount;
+        if (contentId.startsWith(`${id}.`) && id.length > bestLen) {
+            best = mount;
+            bestLen = id.length;
+        }
+    }
+    return best;
+}

--- a/apps/mobile/sources/plugins/presentation/DeclarativeScreen.tsx
+++ b/apps/mobile/sources/plugins/presentation/DeclarativeScreen.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, Pressable, RefreshControl, ScrollView, StyleSheet, T
 import { randomUUID } from 'expo-crypto';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-import Animated, { Easing, FadeInDown, cancelAnimation, useAnimatedStyle, useReducedMotion, useSharedValue, withRepeat, withSpring, withTiming } from 'react-native-reanimated';
+import Animated, { Easing, cancelAnimation, useAnimatedStyle, useReducedMotion, useSharedValue, withRepeat, withSpring, withTiming } from 'react-native-reanimated';
 import { useUnistyles } from 'react-native-unistyles';
 import type { PluginManifestV1, PluginScreenButtonNode, PluginScreenContribution, PluginScreenNode, PluginScreenRowAction, PluginScreenRowNode, PluginScreenTreeNode, PluginSource, PluginText, RequestParams } from '@muxr/contract';
 import { MAX_SCREEN_LIST_ROWS, PLUGIN_CALL_CLIENT_TIMEOUT_MS, capUtf8Bytes, defaultPluginText, sanitizeDisplayText } from '@muxr/contract';
@@ -198,8 +198,10 @@ function ScreenNode(props: {
     const { node, data, fields } = props;
     const bind = (value: PluginText) => bindText(resolvePluginText(value), data);
     switch (node.type) {
-        case 'text':
-            return <Text style={{ color: node.tone === undefined ? theme.colors.text : toneColor(theme, node.tone), fontSize: 15, lineHeight: 21, marginBottom: 8 }}>{bind(node.text)}</Text>;
+        case 'text': {
+            const text = bind(node.text);
+            return text === '' ? null : <Text style={{ color: node.tone === undefined ? theme.colors.text : toneColor(theme, node.tone), fontSize: 15, lineHeight: 21, marginBottom: 8 }}>{text}</Text>;
+        }
         case 'row':
             return <ScreenRow row={node} data={data} onRowAction={props.onRowAction} insideCard={props.nested === true} style={{ paddingVertical: 10 }} />;
         case 'diff': {
@@ -522,7 +524,6 @@ function ScreenBody(props: {
     }, [props.manifest, props.manifestHash, callParams, props.pluginId, request]);
 
     const { theme } = useUnistyles();
-    const reduceMotion = useReducedMotion();
     // A reload keeps the last payload on screen: blanking to a spinner costs the
     // reader their place and re-runs the entrance on every tab tap.
     const hasContent = dataContributionId === undefined || data !== undefined || dataError !== undefined;
@@ -554,12 +555,10 @@ function ScreenBody(props: {
                     {hasContent
                         ? <View style={{ opacity: loading ? 0.55 : 1 }}>
                             {screen.children.map((node, index) => (
-                                <Animated.View key={index} entering={reduceMotion ? undefined : FadeInDown.duration(280).delay(Math.min(index, 8) * 40).easing(Easing.bezier(0.23, 1, 0.32, 1))}>
-                                    <ScreenNode node={node} data={data} fields={fields} setField={setField} running={running} onButton={onButton} onRowAction={onRowAction} onTreeLoad={onTreeLoad}
-                                        tabOverrides={tabParams}
-                                        onSelectTab={(param, value) => setTabParams((current) => ({ ...current, [param]: value }))}
-                                        onTreeError={(error) => setStatus({ ok: false, text: error instanceof Error ? error.message : String(error) })} />
-                                </Animated.View>
+                                <ScreenNode key={index} node={node} data={data} fields={fields} setField={setField} running={running} onButton={onButton} onRowAction={onRowAction} onTreeLoad={onTreeLoad}
+                                    tabOverrides={tabParams}
+                                    onSelectTab={(param, value) => setTabParams((current) => ({ ...current, [param]: value }))}
+                                    onTreeError={(error) => setStatus({ ok: false, text: error instanceof Error ? error.message : String(error) })} />
                             ))}
                         </View>
                         : <ScreenSkeleton />}

--- a/apps/mobile/sources/plugins/presentation/primitives/ItemList.tsx
+++ b/apps/mobile/sources/plugins/presentation/primitives/ItemList.tsx
@@ -14,6 +14,7 @@ import { PLUGIN_CALL_CLIENT_TIMEOUT_MS } from '@muxr/contract';
 import type { PrimitiveProps } from '../../domain/primitiveTypes'
 import { asPluginItemList, type PluginItemListAction, type PluginItemListItem, type PluginItemListModel } from '../../domain/itemListModel';
 import { dispatchPluginAction, validatePluginAction } from '../../application/pluginActions';
+import { recordFileNavigation } from '../../application/fileNavigationList';
 import { pluginSnapshot } from '../../application/pluginStore';
 import { clearPluginCache, registerPluginDataCacheInvalidator, subscribePluginDataInvalidation } from '../../application/pluginDataInvalidation';
 import { toneColor } from '../../domain/pluginTone';
@@ -201,6 +202,9 @@ export function ItemList({ context, pluginId, manifestHash, contribution, presen
         if (manifest === undefined || action === undefined) return;
         setBusyId(busyKey);
         try {
+            if (sessionId !== undefined && action.type === 'kernel.navigate' && action.target === 'file') {
+                recordFileNavigation(sessionId, items, action.path);
+            }
             await dispatchPluginAction(action, {
                 router, pluginId, manifestHash, manifest,
                 ...(sessionId === undefined ? {} : { sessionId }),
@@ -214,7 +218,7 @@ export function ItemList({ context, pluginId, manifestHash, contribution, presen
         } finally {
             setBusyId(null);
         }
-    }, [manifest, manifestHash, pluginId, router, sessionId]);
+    }, [items, manifest, manifestHash, pluginId, router, sessionId]);
 
     const title = contribution.title === undefined ? t('plugins.items') : resolvePluginText(contribution.title);
     const icon = contribution.icon ?? 'document-outline';

--- a/apps/mobile/sources/plugins/presentation/screenTree.tsx
+++ b/apps/mobile/sources/plugins/presentation/screenTree.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { Easing, FadeIn, SlideInLeft, SlideInRight, runOnJS, useReducedMotion } from 'react-native-reanimated';
@@ -11,7 +11,8 @@ import { asScreenTree, type RuntimeTreeItem } from '../domain/screenTreeModel';
 import { fileIcon, folderIcon, type FileIcon } from '../domain/fileIcon';
 import { t } from '@/text';
 import { Typography } from '@/constants/Typography';
-import { cardStyle, SectionLabel, ui, withAlpha } from '@/components/ui';
+import { cardStyle, ui, withAlpha } from '@/components/ui';
+import { PathBreadcrumb } from '@/components/PathBreadcrumb';
 import type { ScreenFieldValues } from '../domain/screenModel';
 
 function treeIcon(item: RuntimeTreeItem, expanded: boolean): FileIcon {
@@ -43,7 +44,6 @@ export function ScreenTree(props: {
     const [opening, setOpening] = React.useState<string | undefined>(undefined);
     const [descending, setDescending] = React.useState(true);
     const stackDepth = React.useRef(0);
-    const trail = React.useRef<ScrollView>(null);
     const up = React.useCallback((depth: number) => {
         setDescending(false);
         setStack((current) => current.slice(0, depth));
@@ -99,43 +99,22 @@ export function ScreenTree(props: {
     };
 
     const trailTitle = title ?? 'root';
+    const rootPath = resolvePath(props.data, 'root');
+    const breadcrumbSegments = React.useMemo(() => [
+        { label: trailTitle, ...(stack.length > 0 ? { onPress: () => up(0) } : {}), icon: folderIcon(false).name },
+        ...stack.map((crumb, index) => ({
+            label: crumb.name,
+            ...(index < stack.length - 1 ? { onPress: () => up(index + 1) } : {}),
+        })),
+    ], [stack, trailTitle, up]);
+    const currentPath = stack[stack.length - 1]?.path;
+    const fullPath = typeof rootPath === 'string' && rootPath !== ''
+        ? `${rootPath}${currentPath === undefined ? '' : `/${currentPath}`}`
+        : [trailTitle, currentPath].filter(Boolean).join('/');
 
     return (
         <View style={{ marginBottom: 14 }}>
-            <View style={{ flexDirection: 'row', alignItems: 'center', minHeight: 32, marginBottom: 8 }}>
-                {stack.length > 0 && (
-                    <Pressable onPress={() => up(stack.length - 1)}
-                        accessibilityRole="button" accessibilityLabel="Back to parent folder" hitSlop={12}
-                        style={({ pressed }) => ({ paddingRight: 6, opacity: pressed ? 0.6 : 1 })}>
-                        <Ionicons name="chevron-back" size={16} color={theme.colors.textSecondary} />
-                    </Pressable>
-                )}
-                {stack.length === 0
-                    ? title !== undefined && <SectionLabel style={{ flex: 1 }}>{title}</SectionLabel>
-                    : (
-                        <ScrollView ref={trail} horizontal showsHorizontalScrollIndicator={false} style={{ flex: 1 }} contentContainerStyle={{ alignItems: 'center' }}
-                            onContentSizeChange={() => trail.current?.scrollToEnd({ animated: true })}>
-                            {/* The root keeps its name in the trail: three folders deep,
-                                "which repo is this" is the question you cannot answer
-                                from a list of leaf names. */}
-                            <Pressable onPress={() => up(0)} hitSlop={10}
-                                accessibilityRole="button" accessibilityLabel={`Go to ${trailTitle}`}>
-                                <Text numberOfLines={1} style={{ color: theme.colors.textSecondary, fontSize: 12, ...Typography.mono('regular') }}>{trailTitle}</Text>
-                            </Pressable>
-                            {stack.map((crumb, index) => (
-                                // The separator is its own element: a slash padded with
-                                // spaces inside the label collapses on web and leaves
-                                // "apps/ mobile", which reads as a typo.
-                                <React.Fragment key={crumb.path}>
-                                    <Text style={{ color: withAlpha(theme.colors.textSecondary, 0.45), fontSize: 12, paddingHorizontal: 6, ...Typography.mono('regular') }}>/</Text>
-                                    <Pressable onPress={() => up(index + 1)} hitSlop={10} accessibilityRole="button" accessibilityLabel={`Go to ${crumb.name}`}>
-                                        <Text numberOfLines={1} style={{ color: index === stack.length - 1 ? theme.colors.text : theme.colors.textSecondary, fontSize: 12, ...Typography.mono('regular') }}>{crumb.name}</Text>
-                                    </Pressable>
-                                </React.Fragment>
-                            ))}
-                        </ScrollView>
-                    )}
-            </View>
+            <PathBreadcrumb segments={breadcrumbSegments} fullPath={fullPath} />
             <GestureDetector gesture={swipeBack}>
                 <View style={{ ...cardStyle(theme), paddingVertical: 4, overflow: 'hidden' }}>
                     <Animated.View key={here?.path ?? '/'} entering={enter}>

--- a/apps/mobile/sources/utils/shellQuote.spec.ts
+++ b/apps/mobile/sources/utils/shellQuote.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { shellQuote } from './shellQuote';
+
+describe('shellQuote', () => {
+    it('keeps hostile filenames inside one shell argument', () => {
+        expect(shellQuote(`it's \"$(touch /tmp/should-not-run)\"`)).toBe(`'it'\\''s "$(touch /tmp/should-not-run)"'`);
+    });
+});

--- a/apps/mobile/sources/utils/shellQuote.ts
+++ b/apps/mobile/sources/utils/shellQuote.ts
@@ -1,0 +1,4 @@
+/** Quote one value for the POSIX shell used by the connected host. */
+export function shellQuote(value: string): string {
+    return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/plugins/code/changes.mjs
+++ b/plugins/code/changes.mjs
@@ -67,7 +67,7 @@ function untrackedStat(path) {
 function iconFor(status) {
     if (status.includes('?') || status.includes('A')) return 'add-circle-outline';
     if (status.includes('D')) return 'trash-outline';
-    if (status.includes('R')) return 'swap-horizontal-outline';
+    if (status.includes('R') || status.includes('C')) return 'swap-horizontal-outline';
     return 'git-compare-outline';
 }
 

--- a/plugins/code/changes.mjs
+++ b/plugins/code/changes.mjs
@@ -11,8 +11,21 @@ if (cwd === '' || cwd.includes('\0')) {
     process.exit(0);
 }
 
-function git(args) {
-    return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8', timeout: 15000, maxBuffer: 4 * 1024 * 1024 });
+function git(args, directory = cwd) {
+    return execFileSync('git', ['-C', directory, ...args], { encoding: 'utf8', timeout: 15000, maxBuffer: 4 * 1024 * 1024 });
+}
+
+let root = '';
+try {
+    root = git(['rev-parse', '--show-toplevel']).trim();
+    if (root === '') throw new Error('not a repository');
+} catch {
+    process.stdout.write(JSON.stringify({ items: [] }));
+    process.exit(0);
+}
+
+function repoGit(args) {
+    return git(args, root);
 }
 
 function addNumstat(target, output) {
@@ -40,9 +53,9 @@ function addNumstat(target, output) {
 
 function untrackedStat(path) {
     try {
-        const info = statSync(join(cwd, path));
+        const info = statSync(join(root, path));
         if (!info.isFile() || info.size > 1024 * 1024) return undefined;
-        const content = readFileSync(join(cwd, path));
+        const content = readFileSync(join(root, path));
         if (content.includes(0)) return { binary: true };
         if (content.length === 0) return { lines: 0, binary: false };
         return { lines: content.toString('utf8').split('\n').length - (content.at(-1) === 10 ? 1 : 0), binary: false };
@@ -61,23 +74,33 @@ function iconFor(status) {
 let porcelain = '';
 const stats = new Map();
 try {
-    porcelain = git(['status', '--porcelain=v1', '-z', '-uall']);
-    addNumstat(stats, git(['diff', '--numstat', '-z']));
-    addNumstat(stats, git(['diff', '--cached', '--numstat', '-z']));
+    porcelain = repoGit(['status', '--porcelain=v1', '-z', '-uall']);
+    addNumstat(stats, repoGit(['diff', '--numstat', '-z']));
+    addNumstat(stats, repoGit(['diff', '--cached', '--numstat', '-z']));
 } catch {
     process.stdout.write(JSON.stringify({ items: [] }));
     process.exit(0);
 }
 
+function groupFor(status) {
+    if (status.includes('R') || status.includes('C')) return 'Renamed';
+    if (status.includes('D')) return 'Deleted';
+    if (status.includes('A') || status.includes('?')) return 'New';
+    return 'Modified';
+}
+
 const records = porcelain.split('\0');
-const items = [];
-for (let index = 0; index < records.length && items.length < 50; index += 1) {
+const changed = [];
+for (let index = 0; index < records.length; index += 1) {
     const record = records[index];
     if (!record || record.length < 4) continue;
     const status = record.slice(0, 2);
     const path = record.slice(3);
     // Porcelain -z appends the source path after a rename/copy destination.
     if (status.includes('R') || status.includes('C')) index += 1;
+    changed.push({ status, path });
+}
+const items = changed.slice(0, 50).map(({ status, path }) => {
     const name = path.split('/').pop() ?? path;
     const stat = stats.get(path);
     const untracked = status === '??' ? untrackedStat(path) : undefined;
@@ -88,13 +111,14 @@ for (let index = 0; index < records.length && items.length < 50; index += 1) {
             ...(stat !== undefined && stat.deleted > 0 ? [{ value: `−${stat.deleted}`, tone: 'danger' }] : []),
             ...(untracked?.lines !== undefined ? [{ value: `+${untracked.lines}`, tone: 'positive' }] : []),
         ];
-    items.push({
+    return {
         id: path,
         title: name,
         subtitle: path,
+        group: groupFor(status),
         icon: iconFor(status),
         metadata,
-        action: { type: 'kernel.navigate', target: 'file', path },
-    });
-}
-process.stdout.write(JSON.stringify({ items, total: items.length }));
+        action: { type: 'kernel.navigate', target: 'file', path: join(root, path) },
+    };
+});
+process.stdout.write(JSON.stringify({ items, ...(changed.length > 50 ? { badge: { value: '50+', tone: 'warning' } } : {}) }));

--- a/plugins/code/files.mjs
+++ b/plugins/code/files.mjs
@@ -59,9 +59,9 @@ function fileTree(paths, folder = '') {
             ...(directory ? { hasChildren: true } : {}),
         });
     }
-    return [...nodes.values()]
-        .sort((a, b) => Number(b.kind === 'folder') - Number(a.kind === 'folder') || a.name.localeCompare(b.name))
-        .slice(0, 256);
+    const sorted = [...nodes.values()]
+        .sort((a, b) => Number(b.kind === 'folder') - Number(a.kind === 'folder') || a.name.localeCompare(b.name));
+    return { tree: sorted.slice(0, 256), total: sorted.length };
 }
 
 const method = process.argv[2];
@@ -73,12 +73,13 @@ if (method === 'repos') {
     const all = exec('git', ['-C', root, 'ls-files', '--cached', '--others', '--exclude-standard', '-z']).split('\0').filter(Boolean);
     const folder = String(input.path ?? '').replace(/^\/+|\/+$/g, '');
     if (folder.split('/').some((segment) => segment === '..')) throw new Error('invalid folder');
-    const tree = fileTree(all, folder);
+    const listed = fileTree(all, folder);
     process.stdout.write(JSON.stringify({
         root,
         title: root.split('/').pop(),
         count: `${all.length} files`,
-        tree,
+        tree: listed.tree,
+        treeNote: listed.total > listed.tree.length ? `Showing first 256 of ${listed.total}` : '',
     }));
 } else {
     const root = repoRoot(input.root);
@@ -99,7 +100,8 @@ if (method === 'repos') {
     const lines = allLines.slice(0, 240);
     const truncated = stat.size > limit || allLines.length > lines.length;
     process.stdout.write(JSON.stringify({
-        name: relative,
+        name: relative.split('/').pop() ?? relative,
+        path: relative,
         body: binary ? 'Binary file — preview unavailable.' : lines.join('\n'),
         note: truncated ? `Preview capped at ${lines.length} lines / 24 KiB.` : '',
     }));

--- a/plugins/code/muxr-ui.json
+++ b/plugins/code/muxr-ui.json
@@ -95,13 +95,13 @@
       },
       "children": [
         {
-          "type": "text",
-          "text": "{{data.count}}",
+          "type": "badge",
+          "label": "{{data.count}}",
           "tone": "secondary"
         },
         {
           "type": "tree",
-          "title": "Explorer",
+          "title": "{{data.title}}",
           "emptyText": "No files",
           "path": "data.tree",
           "source": {
@@ -116,6 +116,11 @@
               "path": "{{item.path}}"
             }
           }
+        },
+        {
+          "type": "text",
+          "text": "{{data.treeNote}}",
+          "tone": "secondary"
         }
       ]
     },
@@ -132,7 +137,7 @@
         {
           "type": "code",
           "path": "data.body",
-          "fileNamePath": "data.name"
+          "fileNamePath": "data.path"
         },
         {
           "type": "text",

--- a/scripts/diagnostics/application/checkBundledPlugins.mjs
+++ b/scripts/diagnostics/application/checkBundledPlugins.mjs
@@ -179,7 +179,7 @@ if (preview.status !== 0) {
     process.exit(1);
 }
 const body = JSON.parse(preview.stdout);
-if (body.name !== leaf || typeof body.body !== 'string' || body.body === '') {
+if (body.name !== 'README.md' || body.path !== leaf || typeof body.body !== 'string' || body.body === '') {
     process.stderr.write('FAIL files.read did not return the selected leaf\n');
     process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Shared 44dp path chrome, status/+− chips, and prev/next file review on the native viewer without merging the two file mounts.
- Changes resolve from the repository root so a session cwd below the repo still opens the right file; hostile paths are single-quoted for `sessionBash`.
- Stacked on `feat/plugin-herdr-actions` (`c23216a5`). Does not restore Runbook, Ports, or Browser Preview.

## Test plan
- [ ] Changes from a subdirectory cwd opens the correct absolute path
- [ ] Prev/next walks the recorded file list; one Back leaves the review
- [ ] Deep breadcrumbs collapse to first / … / parent / leaf and copy the full path
- [ ] Deleted and hostile filenames show a diff without shell interpolation
- [ ] Commit rail disambiguates duplicate basenames and shows +/− counts


Made with [Cursor](https://cursor.com)