### PR TITLE
test(perf): add provenance-checked emulator PR feature and performance smoke

### DIFF
--- a/.github/workflows/emulator-pr-smoke.yml
+++ b/.github/workflows/emulator-pr-smoke.yml
@@ -1,0 +1,79 @@
+name: emulator PR smoke (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: Full 40-character commit SHA to build and test
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: emulator-pr-smoke-${{ inputs.revision }}
+  cancel-in-progress: false
+
+jobs:
+  emulator:
+    # Disposable hosted runner. Never attach an automatic PR trigger to a personal runner.
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      ANDROID_SERIAL: emulator-5554
+      CI: true
+    steps:
+      - name: Validate revision input
+        env:
+          REVISION: ${{ inputs.revision }}
+        run: '[[ "$REVISION" =~ ^[a-f0-9]{40}$ ]]'
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.revision }}
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Verify checkout
+        env:
+          REVISION: ${{ inputs.revision }}
+        run: 'test "$(git rev-parse HEAD)" = "$REVISION"'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.23.2
+          cache: yarn
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+      - name: Dependencies and release APK with provenance
+        run: |
+          yarn install --frozen-lockfile --non-interactive
+          node perf/buildPrApk.mjs "$RUNNER_TEMP/pr-apk"
+      - name: Install Maestro 2.7.0
+        run: |
+          curl --fail --location --retry 3 https://github.com/mobile-dev-inc/maestro/releases/download/cli-2.7.0/maestro.zip -o "$RUNNER_TEMP/maestro.zip"
+          echo "a4ccab6b604617e7aef6db4f885666056eabe5cfa32befaa3bc994041b8fcbb5  $RUNNER_TEMP/maestro.zip" | sha256sum --check
+          unzip -q "$RUNNER_TEMP/maestro.zip" -d "$RUNNER_TEMP/maestro"
+          echo "MAESTRO_BIN=$RUNNER_TEMP/maestro/maestro/bin/maestro" >> "$GITHUB_ENV"
+      - name: Start disposable emulator
+        run: |
+          sudo chmod a+rw /dev/kvm
+          sdkmanager 'platform-tools' 'emulator' 'system-images;android-35;google_apis;x86_64'
+          echo no | avdmanager create avd --force --name muxr_pr --package 'system-images;android-35;google_apis;x86_64'
+          "$ANDROID_HOME/emulator/emulator" -avd muxr_pr -port 5554 -no-window -no-audio -no-boot-anim -no-snapshot -gpu swiftshader_indirect > "$RUNNER_TEMP/emulator.log" 2>&1 &
+          timeout 180 adb wait-for-device
+          timeout 180 bash -c 'until [ "$(adb shell getprop sys.boot_completed | tr -d "\r")" = 1 ]; do sleep 2; done'
+      - name: Mounted feature smoke and measured pathology gate
+        run: node perf/prGate.mjs --apk "$RUNNER_TEMP/pr-apk/app-release.apk" --out "$RUNNER_TEMP/pr-evidence"
+      - name: Preserve diagnostics, including failures
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: emulator-pr-${{ inputs.revision }}
+          path: |
+            ${{ runner.temp }}/pr-evidence
+            ${{ runner.temp }}/pr-apk/app-release.apk
+            ${{ runner.temp }}/pr-apk/app-release.apk.json
+            ${{ runner.temp }}/emulator.log
+          retention-days: 14

--- a/perf/PR_GATE.md
+++ b/perf/PR_GATE.md
@@ -1,0 +1,100 @@
+# Emulator PR smoke
+
+This is a bounded feature and performance-pathology gate for review, alongside
+`releaseGate.mjs`. It reuses the real relay/host/fake-Herdr stack, real E2EE
+pairing, existing Maestro navigation, and OS samplers. It does not replace the
+release gesture/latency gate or a physical-device run.
+
+Run long builds and gates in a dedicated herdr shell pane. Use an otherwise idle,
+dedicated emulator: the gate intentionally uninstalls `com.trymuxr.app` and
+installs its own test-signed release APK. No personal app state is retained.
+The gate pins all adb/Maestro commands to `--serial`, accepts emulator serials
+only, and takes an atomic per-emulator lock. Check other panes/processes before
+using it; the lock cannot detect tools which do not cooperate. A stale lock at
+`/tmp/muxr-pr-gate-<serial>.lock/owner.json` must be inspected before removal.
+
+```bash
+# Node 22.13+, Java 21, Android SDK/NDK, Python 3, yarn dependencies, and
+# Maestro 2.7.0 (via mise, or MAESTRO_BIN=/absolute/path/to/maestro).
+node perf/buildPrApk.mjs /tmp/pr-apk
+PERF_PARENT_PANE=w1FE:pG node perf/prGate.mjs \
+  --apk /tmp/pr-apk/app-release.apk \
+  --serial emulator-5554 --out /tmp/pr-evidence
+```
+
+The build requires a private dependency directory, runs a frozen forced install
+(including postinstall/patch-package), and verifies the native patch guard.
+Copying another branch's already-patched node_modules is insufficient: it once
+produced a working text terminal with no Kitty support or cell metrics. The build
+uses package.json's version and an explicit ANDROID_VERSION_CODE or Git revision
+count, generates a test keystore, and builds a release x86_64 APK.
+The manifest beside it binds the APK SHA256 to the source revision and content
+fingerprints and hashes of every actual patched dependency file. The gate checks
+native parity, pulls back the installed APK and checks identical bytes;
+it records package metadata, device model/API/renderer/size, host revision and
+content digest, and a separate harness/workflow digest. Dirty source fingerprints
+are recorded honestly. This is local build provenance, not signed attestation.
+Never create a manifest for an unrelated prebuilt APK to make a check pass.
+
+`--host-root` supports a separately built integration checkout. Its mobile/shared
+source digest must match the APK manifest. Host/plugin-only differences can be
+reported separately; a mobile change requires rebuilding the APK. The gate builds
+the host checkout itself and verifies its source fingerprint stayed fixed during
+the run. Do not edit measured source or run competing builds while measuring.
+
+The small flow requires:
+
+- Fresh pairing and a mounted herd under 30-pane/6-agent, 2 Hz title churn.
+- A real file list and the seeded 250-line document in the real viewer.
+- Mounted text terminal plus a recorded real host attach, while graphics are off.
+- Mounted terminal with an opaque magenta/teal Kitty checkerboard verified in
+  the terminal framebuffer region, positive cell dimensions and positive delivered
+  graphics frames during that window. Chrome or scroll-notch events cannot pass.
+- Mounted Usage, OMP before OpenCode by timestamp (11:00 vs 10:00), and provider
+  switching with token totals 150 → 300 → 150. Local activity does not imply quota.
+
+Only Herdr and upstream usage fixture inputs are controlled. The fake Herdr
+advertises the real code/status/terminal-keys plugin manifests. Its cwd is a real
+scratch git repository. OMP/OpenCode databases contain synthetic aggregate rows.
+A scratch Usage entry wrapper sets test-only clock/backend environment variables
+then imports the original plugin: the production host intentionally sanitizes
+plugin environment variables, and the harness does not weaken that boundary.
+The ccusage CLI is an explicit fixture boundary; this flow does not test ccusage's
+own database parser or call real provider credentials/quota services.
+
+Every performance window is 35 seconds by default (`--seconds 30..120`) and must
+contain at least 25 seconds of actual timestamped CPU and PSS samples. Raw tick
+samples, timestamped PSS observations and gfxinfo dumps accompany derived numbers.
+Missing samples, dead/restarted
+runtime, JS busy above 60%, PSS drift above 100 MiB, a 30-second frame stall, no
+rendered frames, fatal crashes and React update-depth errors fail. These broad
+limits come from the existing emulator pathology profile. Jank percent/percentiles
+are measured diagnostics here, not gesture-feel acceptance. Use the full release
+gate for targeted jank, movement, input latency, graphics budget and memory soak.
+
+Every feature must prove mount; a failed assertion stays a failure. An earlier
+failure does not silently skip later features. The overall run has a 12-minute
+deadline. All flows and adb commands have individual timeouts. A shared command
+scope owns setup/build/adb/Maestro children; it aborts new work, kills process
+groups, and awaits termination before releasing the emulator lock. Failed
+termination retains the lock for inspection. Diagnostic export uses its own
+bounded scope after the measurement scope closes. Evidence includes
+report.json, UI XML, before/after screenshots, Maestro diagnostics, logcat, host
+and relay logs, host journal and attach/input records, collected before stack
+cleanup. A failed setup is not a performance pass. In a herdr pane, final bundles,
+report and screenshot are copied to both PocketHerdr and muxr attachment watchers;
+PERF_PARENT_PANE additionally exports to the coordinating pane. CI retains the
+APK/provenance and evidence on success and failure.
+
+The `emulator-pr-smoke.yml` workflow is workflow_dispatch-only and builds the
+explicit full SHA on a disposable GitHub-hosted runner. It has no deployment,
+provider credentials, personal runner access, push, or pull_request trigger.
+Dispatch it against the integrated revision you intend to review. Making it a
+required status check is a separate repository policy decision; this change does
+not pretend a manual workflow automatically blocks every PR.
+
+Integration target: release/0.1.26. The PR209 surface harness starts from
+origin/pr-review-209. Usage fixtures require the separate usage fix (OMP adapter,
+OpenCode quota/status reporting, provider recency and mobile provider cap); its
+main-based worktree cannot be substituted for the release APK. Integrate that
+fix onto the release branch and rebuild a matching APK before claiming Usage PASS.

--- a/perf/PR_GATE.md
+++ b/perf/PR_GATE.md
@@ -46,6 +46,10 @@ The small flow requires:
 
 - Fresh pairing and a mounted herd under 30-pane/6-agent, 2 Hz title churn.
 - A real file list and the seeded 250-line document in the real viewer.
+- The session's real Changes list opens a git-backed native diff showing both
+  removed/added markers. In that same viewer, zoom increases measured line height,
+  unwrapped horizontal pan changes code-region pixels without leaving the file,
+  and Wrap retains its enabled state. Screenshots retain the word-diff example.
 - Mounted text terminal plus a recorded real host attach, while graphics are off.
 - Mounted terminal with an opaque magenta/teal Kitty checkerboard verified in
   the terminal framebuffer region, positive cell dimensions and positive delivered

--- a/perf/PR_GATE.md
+++ b/perf/PR_GATE.md
@@ -49,7 +49,13 @@ The small flow requires:
 - The session's real Changes list opens a git-backed native diff showing both
   removed/added markers. In that same viewer, zoom increases measured line height,
   unwrapped horizontal pan changes code-region pixels without leaving the file,
-  and Wrap retains its enabled state. Screenshots retain the word-diff example.
+  and Wrap retains its enabled state. Two changed files and two separated hunks
+  mount the combined navigator; all exposed navigator buttons, including overflow,
+  must fit the measured emulator viewport without overlap. An 80-character CJK
+  line must retain both end markers in one rendered Text node with the same
+  row height as ASCII and wrap off. Missing full-text evidence fails this check. Screenshots retain
+  the word-diff/CJK examples. CJK full horizontal extent and scrub source-line
+  labels remain device-unverified; this does not cover every phone width.
 - Mounted text terminal plus a recorded real host attach, while graphics are off.
 - Mounted terminal with an opaque magenta/teal Kitty checkerboard verified in
   the terminal framebuffer region, positive cell dimensions and positive delivered

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,5 +1,9 @@
 # Release performance gate
 
+For bounded PR review, use [the manual emulator smoke gate](PR_GATE.md). It
+requires matching APK/native-patch provenance and mounted document, terminal,
+graphics and Usage flows. The longer gate below remains the gesture/soak check.
+
 `yarn perf` drives the release APK on a real device against a real relay and a
 real host, and fails on the signals that shipped broken software: a saturated JS
 thread, a dead React runtime, a frozen screen, runaway memory.

--- a/perf/buildPrApk.mjs
+++ b/perf/buildPrApk.mjs
@@ -1,0 +1,33 @@
+// Run in a dedicated shell pane. This builds a release variant with a test signer.
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { patchedDependencies, sha256, sourceIdentity } from './lib/provenance.mjs';
+
+const out = resolve(process.argv[2] ?? '/tmp/muxr-pr-build');
+mkdirSync(out, { recursive: true });
+const source = sourceIdentity();
+const version = JSON.parse(readFileSync('package.json', 'utf8')).version;
+const versionCode = process.env.ANDROID_VERSION_CODE ?? execFileSync('git', ['rev-list', '--count', 'HEAD'], { encoding: 'utf8' }).trim();
+if (!/^\d+\.\d+\.\d+$/.test(version) || !/^[1-9]\d*$/.test(versionCode)) throw new Error('Invalid app version/version code');
+const run = (bin, args, options = {}) => execFileSync(bin, args, { stdio: 'inherit', timeout: 45 * 60_000, ...options });
+if (existsSync('node_modules') && realpathSync('node_modules') !== resolve('node_modules')) throw new Error('Build needs private node_modules; refusing to modify a shared symlink');
+// --force restores package files before postinstall reapplies this revision's
+// patches. A copied dependency tree may contain another branch's native patch.
+run('yarn', ['install', '--frozen-lockfile', '--non-interactive', '--force']);
+run(process.execPath, ['scripts/diagnostics/application/verifyNativePatches.mjs']);
+const nativeDependencies = patchedDependencies();
+run('yarn', ['build']);
+const keystore = resolve(out, 'test.keystore');
+if (!existsSync(keystore)) run('keytool', ['-genkeypair', '-keystore', keystore, '-storepass', 'android', '-keypass', 'android', '-alias', 'androiddebugkey', '-dname', 'CN=Emulator PR Gate', '-keyalg', 'RSA', '-validity', '3650']);
+run('./gradlew', ['app:assembleRelease', '--no-daemon', '--max-workers=4', '-PreactNativeArchitectures=x86_64',
+    `-PappVersion=${version}`, `-PandroidVersionCode=${versionCode}`,
+    `-PreleaseStoreFile=${keystore}`,
+    '-PreleaseStorePassword=android', '-PreleaseKeyAlias=androiddebugkey', '-PreleaseKeyPassword=android'],
+{ cwd: 'apps/mobile/android', env: { ...process.env, NODE_ENV: 'production', APP_ENV: 'production', MUXR_PUBLIC_BASE_URL: 'https://trymuxr.com', MUXR_DISTRIBUTION: 'store' } });
+if (sourceIdentity().sourceSha256 !== source.sourceSha256) throw new Error('Sources changed during build; rebuild before claiming provenance');
+const apk = resolve(out, 'app-release.apk');
+copyFileSync('apps/mobile/android/app/build/outputs/apk/release/app-release.apk', apk);
+if (JSON.stringify(patchedDependencies()) !== JSON.stringify(nativeDependencies)) throw new Error('Patched dependencies changed during build');
+writeFileSync(`${apk}.json`, JSON.stringify({ ...source, nativeDependencies, apkSha256: sha256(apk), variant: 'release', signer: 'Android test key (not store signing)', builtAt: new Date().toISOString() }, null, 2));
+console.log(`APK and provenance: ${apk}`);

--- a/perf/fake-herdr/bin.mjs
+++ b/perf/fake-herdr/bin.mjs
@@ -204,10 +204,13 @@ function runTerminal(args) {
     const paneId = args[1] ?? 'p1';
     // A one-line marker beside the socket: the gate needs to tell "the phone
     // never asked for graphics" apart from "graphics were asked for and lost".
-    const noteCellMetrics = () => {
+    const noteCellMetrics = (message) => {
         const socketPath = process.env.FAKE_HERDR_SOCKET;
         if (socketPath === undefined) return;
-        try { writeFileSync(`${socketPath}.cell-metrics`, 'seen\n', { encoding: 'utf8' }); } catch { /* best effort */ }
+        try {
+            writeFileSync(`${socketPath}.cell-metrics`, 'seen\n', { encoding: 'utf8' });
+            appendFileSync(`${socketPath}.cell-metrics.jsonl`, `${JSON.stringify({ at: new Date().toISOString(), pane_id: paneId, source: 'terminal.resize', cols, rows, cellWidthPx: message.cellWidthPx, cellHeightPx: message.cellHeightPx })}\n`);
+        } catch { /* best effort */ }
     };
     let cols = Number(flag(args, '--cols') ?? 80) || 80;
     let rows = Number(flag(args, '--rows') ?? 24) || 24;
@@ -268,7 +271,7 @@ function runTerminal(args) {
                     // A phone that declares cell pixels is a phone the graphics
                     // bridge can serve; without them the host never opens one,
                     // and a run with no graphics account has to say which it was.
-                    if (Number(message.cellWidthPx) > 0 && Number(message.cellHeightPx) > 0) noteCellMetrics();
+                    if (Number(message.cellWidthPx) > 0 && Number(message.cellHeightPx) > 0) noteCellMetrics(message);
                     emit(true);
                 }
                 else if (message.type === 'terminal.scroll') emit(true);

--- a/perf/fake-herdr/graphics.mjs
+++ b/perf/fake-herdr/graphics.mjs
@@ -301,7 +301,9 @@ function serveClient(socket, options) {
             const wanted = targetPaneId === undefined
                 ? undefined
                 : cursors.find((cursor) => cursor.paneId === targetPaneId);
-            const cursor = wanted ?? cursors[imageId % cursors.length] ?? cursors[0];
+            // The PR flow opens the first live pane. Pin its proof producer;
+            // round-robin across offscreen panes makes framebuffer proof flaky.
+            const cursor = options.enableFile !== undefined ? cursors[0] : wanted ?? cursors[imageId % cursors.length] ?? cursors[0];
             const bytes = kittyChunk({
                 ...cursor,
                 imageId,

--- a/perf/fake-herdr/graphics.mjs
+++ b/perf/fake-herdr/graphics.mjs
@@ -176,6 +176,27 @@ function kittyChunk({ row, col, imageId, width, height, rgba, cols, rows, proof 
     );
 }
 
+// ClientHello transports the native cell metrics even if a stable grid never
+// sends a later terminal.resize. Retain both decoded fields and exact wire bytes.
+function clientHelloMetrics(payload) {
+    let at = 0;
+    const next = () => {
+        const tag = payload.readUInt8(at++);
+        if (tag < 251) return tag;
+        const bytes = tag === 251 ? 2 : tag === 252 ? 4 : tag === 253 ? 8 : 0;
+        if (!bytes) throw new Error('Invalid ClientHello integer');
+        const value = bytes === 8 ? Number(payload.readBigUInt64LE(at)) : payload.readUIntLE(at, bytes);
+        at += bytes;
+        if (!Number.isSafeInteger(value)) throw new Error('Unsafe ClientHello integer');
+        return value;
+    };
+    try {
+        const [type, version, cols, rows, cellWidthPx, cellHeightPx] = Array.from({ length: 6 }, next);
+        if (type !== 0 || version !== PROTOCOL_VERSION) return undefined;
+        return { source: 'graphics.ClientHello', version, cols, rows, cellWidthPx, cellHeightPx, payloadBase64: payload.toString('base64') };
+    } catch { return undefined; }
+}
+
 function readType(payload) {
     const prefix = payload[0];
     if (prefix === undefined) return -1;
@@ -385,11 +406,12 @@ function serveClient(socket, options) {
             const payload = buffered.subarray(4, length + 4);
             buffered = buffered.subarray(length + 4);
             const type = readType(payload);
-            if (type !== 0 && inputLogPath !== undefined) {
+            if (inputLogPath !== undefined) {
                 try {
                     appendFileSync(inputLogPath, `${JSON.stringify({
                         at: new Date().toISOString(),
                         type,
+                        ...(type === 0 ? clientHelloMetrics(payload) : {}),
                         sgr: decodeSgr(payload),
                         bytes: payload.length,
                     })}\n`);

--- a/perf/fake-herdr/graphics.mjs
+++ b/perf/fake-herdr/graphics.mjs
@@ -7,7 +7,7 @@
  * capped at the ~3 MB/s the real Herdr app-client socket sustains, so a burst
  * of paints queues instead of flushing instantly.
  */
-import { appendFileSync, unlinkSync } from 'node:fs';
+import { appendFileSync, existsSync, unlinkSync } from 'node:fs';
 import { createServer } from 'node:net';
 
 const PROTOCOL_VERSION = 20;
@@ -146,10 +146,17 @@ export function imageSizeFromWorld(world, overrides = {}) {
     };
 }
 
-function kittyChunk({ row, col, imageId, width, height, rgba, cols, rows }) {
+function kittyChunk({ row, col, imageId, width, height, rgba, cols, rows, proof = false }) {
     // Cheap unique fill: one byte for the field, then a 32-bit stamp so two
     // consecutive payloads cannot be byte-identical even if the fill wrapped.
     rgba.fill((imageId * 37) & 255);
+    // PR-only opaque checkerboard: identifiable in the phone framebuffer,
+    // unlike terminal text/chrome or a pipeline event with zero deliveries.
+    if (proof) for (let y = 0; y < height; y++) for (let x = 0; x < width; x++) {
+        const at = (y * width + x) * 4;
+        const color = ((x >> 5) + (y >> 5)) % 2 === 0 ? [235, 35, 170] : [20, 215, 185];
+        rgba[at] = color[0]; rgba[at + 1] = color[1]; rgba[at + 2] = color[2]; rgba[at + 3] = 255;
+    }
     rgba[0] = imageId & 255;
     rgba[1] = (imageId >>> 8) & 255;
     rgba[2] = (imageId >>> 16) & 255;
@@ -301,6 +308,7 @@ function serveClient(socket, options) {
                 width: imageWidth,
                 height: imageHeight,
                 rgba,
+                proof: options.enableFile !== undefined,
                 cols: Math.max(1, cursor?.rect?.width ?? 1),
                 rows: Math.max(1, cursor?.rect?.height ?? 1),
             });
@@ -308,6 +316,9 @@ function serveClient(socket, options) {
             return frame(outputPayload(bytes));
         },
     });
+    const paint = () => {
+        if (options.enableFile === undefined || existsSync(options.enableFile)) pacer.admit();
+    };
 
     const stopRequestTick = () => {
         if (requestTimer === undefined) return;
@@ -339,7 +350,7 @@ function serveClient(socket, options) {
             return;
         }
         requested -= 1;
-        pacer.admit();
+        paint();
         if (requested <= 0) stopRequestTick();
     };
 
@@ -387,8 +398,8 @@ function serveClient(socket, options) {
                 socket.write(frame(welcomePayload()));
                 onReady?.(requestFramesForClient);
                 if (frameHz > 0) {
-                    pacer.admit();
-                    periodicTimer = setInterval(() => pacer.admit(), Math.max(1, Math.round(1000 / frameHz)));
+                    paint();
+                    periodicTimer = setInterval(paint, Math.max(1, Math.round(1000 / frameHz)));
                     timers.add(periodicTimer);
                 }
             } else if (type === 4) {
@@ -409,6 +420,7 @@ export async function startGraphics({
     imageHeight,
     bytesPerSecond = DEFAULT_BYTES_PER_SECOND,
     inputLogPath,
+    enableFile,
 } = {}) {
     try { unlinkSync(socketPath); } catch { /* leftover from a killed run */ }
     const sockets = new Set();
@@ -448,6 +460,7 @@ export async function startGraphics({
             timers,
             isClosed: () => closed,
             inputLogPath,
+            enableFile,
             onReady: (emit) => {
                 emitters.add(emit);
                 socket.once('close', () => emitters.delete(emit));

--- a/perf/fake-herdr/server.mjs
+++ b/perf/fake-herdr/server.mjs
@@ -2,7 +2,7 @@
  * Fake Herdr control plane: NDJSON JSON-RPC on a unix socket, plus title/status
  * churn. Graphics and the HERDR_BIN shim are sibling modules.
  */
-import { appendFileSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -20,6 +20,11 @@ export async function startFakeHerdr(options) {
     const titleChurnHz = Number(options.titleChurnHz ?? 2);
     const terminalBytesPerSecond = options.terminalBytesPerSecond ?? 4096;
     const graphicsFrameHz = options.graphicsFrameHz ?? 0;
+    const plugins = options.pluginsRoot === undefined ? [] : ['code', 'status', 'terminal-keys'].map((name) => {
+        const root = resolve(options.pluginsRoot, name);
+        const manifest = JSON.parse(readFileSync(join(root, 'muxr-ui.json'), 'utf8'));
+        return { plugin_id: manifest.pluginId, name, version: '0.1.0', plugin_root: root, enabled: true, actions: [], source: { kind: 'local' } };
+    });
     const cwd = join(dir, 'project');
     const attachJsonl = join(dir, 'attach.jsonl');
     const graphicsInputJsonl = join(dir, 'graphics-input.jsonl');
@@ -87,6 +92,7 @@ export async function startFakeHerdr(options) {
             socketPath: clientSocketPath,
             world,
             frameHz: graphicsFrameHz,
+            enableFile: options.graphicsEnableFile,
             inputLogPath: graphicsInputJsonl,
         });
         binPath = writeBinShim({ dir, socketPath, terminalBytesPerSecond });
@@ -230,7 +236,7 @@ export async function startFakeHerdr(options) {
 
     const methods = {
         'session.snapshot': () => ({ snapshot: snapshotOf(live) }),
-        'plugin.list': () => ({ plugins: [] }),
+        'plugin.list': () => ({ plugins }),
         'plugin.action.invoke': (params) => {
             const logId = `log-${live.nextLog++}`;
             live.pluginLogs.unshift({
@@ -728,6 +734,8 @@ function parseArgs(argv) {
         else if (flag === '--title-churn-hz') { out.titleChurnHz = Number(value); index += 1; }
         else if (flag === '--terminal-bytes-per-second') { out.terminalBytesPerSecond = Number(value); index += 1; }
         else if (flag === '--graphics-frame-hz') { out.graphicsFrameHz = Number(value); index += 1; }
+        else if (flag === '--graphics-enable-file') { out.graphicsEnableFile = value; index += 1; }
+        else if (flag === '--plugins-root') { out.pluginsRoot = value; index += 1; }
     }
     if (out.dir === undefined) throw new Error('fake-herdr: --dir is required');
     return out;

--- a/perf/fixtures/usageHome.mjs
+++ b/perf/fixtures/usageHome.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -9,7 +9,9 @@ export const usagePlugins = (sourceRoot) => ({ root, env }) => {
     for (const name of ['code', 'terminal-keys']) symlinkSync(join(sourceRoot, 'plugins', name), join(dir, name));
     const original = join(sourceRoot, 'plugins/status');
     for (const file of readdirSync(original)) {
-        if (file !== 'usage.mjs') symlinkSync(join(original, file), join(dir, 'status', file));
+        // The real catalog opens manifests with O_NOFOLLOW. Preserve that guard.
+        if (file === 'muxr-ui.json') copyFileSync(join(original, file), join(dir, 'status', file));
+        else if (file !== 'usage.mjs') symlinkSync(join(original, file), join(dir, 'status', file));
     }
     // Host sanitization is retained: only this scratch fixture entry restores
     // test env. All parsing, collection and rendering use real product modules.

--- a/perf/fixtures/usageHome.mjs
+++ b/perf/fixtures/usageHome.mjs
@@ -1,0 +1,47 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const usagePlugins = (sourceRoot) => ({ root, env }) => {
+    const dir = join(root, 'fixture-plugins');
+    mkdirSync(join(dir, 'status'), { recursive: true });
+    for (const name of ['code', 'terminal-keys']) symlinkSync(join(sourceRoot, 'plugins', name), join(dir, name));
+    const original = join(sourceRoot, 'plugins/status');
+    for (const file of readdirSync(original)) {
+        if (file !== 'usage.mjs') symlinkSync(join(original, file), join(dir, 'status', file));
+    }
+    // Host sanitization is retained: only this scratch fixture entry restores
+    // test env. All parsing, collection and rendering use real product modules.
+    writeFileSync(join(dir, 'status/usage.mjs'), `Object.assign(process.env, ${JSON.stringify(env)});\nawait import(${JSON.stringify(pathToFileURL(join(original, 'usage.mjs')).href)});\n`);
+    return dir;
+};
+
+// Real provider databases, consumed by the real plugin. Only the external
+// ccusage CLI is stubbed; there is deliberately no mocked plugin response.
+export function usageHome(home) {
+    execFileSync('python3', ['-c', `
+import sqlite3,json,pathlib,sys,datetime
+h=pathlib.Path(sys.argv[1])
+def stamp(hour): return int(datetime.datetime(2026,9,5,hour,tzinfo=datetime.timezone.utc).timestamp()*1000)
+p=h/'.omp/stats.db'; p.parent.mkdir(parents=True,exist_ok=True)
+with sqlite3.connect(p) as db:
+ db.execute('CREATE TABLE messages(timestamp INTEGER, model TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER, total_tokens INTEGER, cost_total REAL)')
+ db.execute('INSERT INTO messages VALUES(?,?,?,?,?,?,?,?)',(stamp(11),'fixture-omp',100,20,30,0,150,.01))
+p=h/'.local/share/opencode/opencode.db'; p.parent.mkdir(parents=True,exist_ok=True)
+with sqlite3.connect(p) as db:
+ db.execute('CREATE TABLE message(time_created INTEGER,data TEXT)')
+ db.execute('INSERT INTO message VALUES(?,?)',(stamp(10),json.dumps({'role':'assistant','modelID':'fixture-go','providerID':'opencode-go','time':{'created':stamp(10)},'tokens':{'input':200,'output':40,'reasoning':0,'cache':{'read':60,'write':0}},'cost':0})))
+`, home], { timeout: 10_000 });
+    const bin = join(home, 'fixture-bin');
+    mkdirSync(bin);
+    writeFileSync(join(bin, 'ccusage'), '#!/bin/sh\nprintf \'{"daily":[{"period":"2026-09-05","agents":[{"agent":"opencode","totalTokens":300,"totalCost":0}]}],"session":[]}\\n\'\n', { mode: 0o755 });
+    // Exclude the user's CLIs/credentials while retaining node and sqlite tools.
+    return {
+        PATH: `${bin}:/usr/bin:/bin:${join(process.execPath, '..')}`,
+        XDG_DATA_HOME: join(home, '.local/share'), PI_CONFIG_DIR: '.omp',
+        CLAUDE_CONFIG_DIR: join(home, '.claude'), CODEX_HOME: join(home, '.codex'),
+        OMP_PROFILE: '', PI_PROFILE: '', MUXR_USAGE_NOW: '2026-09-05T12:00:00Z', TZ: 'UTC',
+        MUXR_CCUSAGE_BIN: join(bin, 'ccusage'),
+    };
+}

--- a/perf/lib/androidSignals.mjs
+++ b/perf/lib/androidSignals.mjs
@@ -19,13 +19,11 @@
  * app gets a new process and a new JS thread, so pid and tid are resolved every
  * interval and a restart is counted instead of ending the run.
  */
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { assertCommandActive, runCommand as run } from './commands.mjs';
 
 import { writeFileSync } from 'node:fs';
 import { parseFrameStatsDump, parseJankDump, parseUptime } from './gestureMetrics.mjs';
 
-const run = promisify(execFile);
 /** Linux clock ticks per second; /proc jiffies are in these units. */
 const HZ = 100;
 const JS_THREAD = 'mqt_v_js';
@@ -36,9 +34,11 @@ async function adb(args, timeout = 10_000) {
 }
 
 async function quiet(args, timeout = 10_000) {
+    assertCommandActive();
     try {
         return await adb(args, timeout);
     } catch {
+        assertCommandActive();
         return '';
     }
 }
@@ -172,8 +172,7 @@ export async function deviceMonotonicSeconds() {
  * little-endian u32) then RGBA8888. No PNG, no decoder.
  */
 export async function screencapRaw(path) {
-    const { execFileSync } = await import('node:child_process');
-    const bytes = execFileSync('adb', ['exec-out', 'screencap'], { maxBuffer: 64 * 1024 * 1024 });
+    const { stdout: bytes } = await run('adb', ['exec-out', 'screencap'], { encoding: null, maxBuffer: 64 * 1024 * 1024, timeout: 20_000 });
     if (path !== undefined) writeFileSync(path, bytes);
     if (bytes.length < 16) return { width: 0, height: 0, format: 0, colorspace: 0, bytes };
     return {
@@ -246,9 +245,8 @@ export async function updateDepthErrors() {
 }
 
 export async function screenshot(path) {
-    const { execFileSync } = await import('node:child_process');
-    const { writeFileSync } = await import('node:fs');
-    writeFileSync(path, execFileSync('adb', ['exec-out', 'screencap', '-p'], { maxBuffer: 64 * 1024 * 1024 }));
+    const { stdout } = await run('adb', ['exec-out', 'screencap', '-p'], { encoding: null, maxBuffer: 64 * 1024 * 1024, timeout: 20_000 });
+    writeFileSync(path, stdout);
 }
 
 /**
@@ -266,6 +264,12 @@ export async function samplePhase(options) {
     let pid;
     let tid;
     let previousTicks;
+    let previousTickAt;
+    const samples = [];
+    const pssSamples = [];
+    let missingPss = 0;
+    const frameSamples = [];
+    let missingFrames = 0;
     let busyTicks = 0;
     let busySeconds = 0;
     let restarts = 0;
@@ -276,7 +280,9 @@ export async function samplePhase(options) {
     let lastPss;
     let maxPss = 0;
     const framesStart = await framesRendered(pkg);
+    if (framesStart === undefined) missingFrames += 1;
     let previousFrames = framesStart;
+    let previousFramesAt = performance.now();
 
     while (Date.now() < deadline) {
         const tickStarted = Date.now();
@@ -306,28 +312,36 @@ export async function samplePhase(options) {
                     tid = undefined;
                     previousTicks = undefined;
                 } else {
+                    const sampledAt = performance.now();
                     if (previousTicks !== undefined) {
                         busyTicks += ticks - previousTicks;
-                        busySeconds += (Date.now() - tickStarted + intervalMs) / 1000;
+                        busySeconds += (sampledAt - previousTickAt) / 1000;
                     }
                     previousTicks = ticks;
+                    previousTickAt = sampledAt;
+                    samples.push({ atMs: sampledAt, pid, tid, ticks });
                 }
             }
             const pss = await totalPssKb(pid);
             if (pss !== undefined) {
+                pssSamples.push({ atMs: performance.now(), pid, pssKb: pss });
                 if (firstPss === undefined) firstPss = pss;
                 lastPss = pss;
                 if (pss > maxPss) maxPss = pss;
-            }
+            } else missingPss += 1;
         }
 
         const frames = await framesRendered(pkg);
+        const framesAt = performance.now();
+        frameSamples.push({ atMs: framesAt, frames: frames ?? null });
+        if (frames === undefined) missingFrames += 1;
         if (frames !== undefined && previousFrames !== undefined) {
             const drawn = frames - previousFrames;
-            frameStall = drawn > 0 ? 0 : frameStall + intervalMs / 1000;
+            frameStall = drawn > 0 ? 0 : frameStall + (framesAt - previousFramesAt) / 1000;
             if (frameStall > worstFrameStall) worstFrameStall = frameStall;
         }
         if (frames !== undefined) previousFrames = frames;
+        previousFramesAt = framesAt;
 
         if (onTick !== undefined) await onTick();
         const elapsed = Date.now() - tickStarted;
@@ -335,10 +349,17 @@ export async function samplePhase(options) {
     }
 
     const framesEnd = await framesRendered(pkg);
+    if (framesEnd === undefined) missingFrames += 1;
     const wall = (Date.now() - started) / 1000;
     return {
         seconds: Number(wall.toFixed(1)),
         sampledSeconds: Number(busySeconds.toFixed(1)),
+        samples,
+        pssSamples,
+        frameSamples,
+        missingFrames,
+        missingPss,
+        pssSampledSeconds: pssSamples.length < 2 ? 0 : (pssSamples.at(-1).atMs - pssSamples[0].atMs) / 1000,
         jsBusyPercent: busySeconds > 0 ? Number((busyTicks / HZ / busySeconds * 100).toFixed(1)) : undefined,
         // A restart resets gfxinfo's counter, so an end below the start means
         // "not comparable", never a negative frame rate.

--- a/perf/lib/commands.mjs
+++ b/perf/lib/commands.mjs
@@ -1,0 +1,69 @@
+import { spawn as nodeSpawn, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+let active;
+const defaultRun = promisify(execFile);
+export const useCommandScope = (scope) => { active = scope; };
+export const runCommand = (...args) => active ? active.run(...args) : defaultRun(...args);
+export const spawnCommand = (...args) => active ? active.spawn(...args) : nodeSpawn(...args);
+export const onCommandCleanup = (cleanup) => active?.cleanups.push(cleanup);
+export const commandSignal = () => active?.signal;
+export const assertCommandActive = () => active?.signal.throwIfAborted();
+
+/** All gate subprocesses share cancellation, including helpers during setup. */
+export class CommandScope {
+    controller = new AbortController();
+    children = new Map();
+    cleanups = [];
+    get signal() { return this.controller.signal; }
+    spawn(bin, args, options = {}) {
+        this.signal.throwIfAborted();
+        const child = nodeSpawn(bin, args, { ...options, detached: true });
+        const closed = new Promise((done) => child.once('close', done));
+        this.children.set(child, closed);
+        // Always handle spawn errors, including callers waiting for readiness.
+        child.on('error', () => {});
+        child.once('close', () => this.children.delete(child));
+        return child;
+    }
+    kill(child) {
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { /* exited */ }
+    }
+    async run(bin, args, options = {}) {
+        this.signal.throwIfAborted();
+        const { timeout = 30_000, maxBuffer = 64 * 1024 * 1024, encoding = 'utf8', ...rest } = options;
+        const child = this.spawn(bin, args, { ...rest, stdio: ['ignore', 'pipe', 'pipe'] });
+        return new Promise((resolve, reject) => {
+            const stdout = [], stderr = [];
+            let bytes = 0, error;
+            const timer = setTimeout(() => { error = new Error(`${bin}: exceeded ${timeout}ms`); this.kill(child); }, timeout);
+            const collect = (target) => (chunk) => {
+                bytes += chunk.length;
+                if (bytes > maxBuffer) { error = new Error(`${bin}: output exceeds ${maxBuffer} bytes`); this.kill(child); }
+                else target.push(chunk);
+            };
+            child.stdout.on('data', collect(stdout)); child.stderr.on('data', collect(stderr));
+            child.once('error', (cause) => { error = cause; });
+            child.once('close', (code) => {
+                clearTimeout(timer);
+                const decode = (chunks) => encoding === null || encoding === 'buffer' ? Buffer.concat(chunks) : Buffer.concat(chunks).toString(encoding);
+                const result = { stdout: decode(stdout), stderr: decode(stderr) };
+                if (this.signal.aborted || error || code !== 0) reject(Object.assign(error ?? new Error(`${bin}: ${this.signal.aborted ? 'cancelled' : `exit ${code}`}`), result));
+                else resolve(result);
+            });
+        });
+    }
+    async close() {
+        this.controller.abort();
+        const pending = [...this.children.entries()];
+        for (const [child] of pending) this.kill(child);
+        let timer;
+        try {
+            await Promise.race([
+                Promise.all(pending.map(([, closed]) => closed)),
+                new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('Owned commands did not terminate within 10s; retaining emulator lock')), 10_000); }),
+            ]);
+        } finally { clearTimeout(timer); }
+    }
+    cleanup() { for (const cleanup of this.cleanups.splice(0).reverse()) cleanup(); }
+}

--- a/perf/lib/fakeStack.mjs
+++ b/perf/lib/fakeStack.mjs
@@ -11,14 +11,12 @@
  * service unit, herdr socket or `~/.muxr` on this machine is touched. Ports are
  * picked free, so a running muxr install keeps working while the gate runs.
  */
-import { execFile, spawn, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { createServer } from 'node:net';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { promisify } from 'node:util';
-
-const run = promisify(execFile);
+import { join, resolve } from 'node:path';
+import { runCommand as run, spawnCommand as spawn, onCommandCleanup, commandSignal, assertCommandActive } from './commands.mjs';
 
 const RELAY_ENTRY = 'apps/relay/dist/main.js';
 const HOST_ENTRY = 'apps/host/dist/main.js';
@@ -46,6 +44,8 @@ async function spawnFakeHerdr(dir, options) {
         ['--title-churn-hz', options.titleChurnHz],
         ['--terminal-bytes-per-second', options.terminalBytesPerSecond],
         ['--graphics-frame-hz', options.graphicsFrameHz],
+        ['--graphics-enable-file', options.graphicsEnableFile],
+        ['--plugins-root', options.pluginsRoot],
     ]) {
         if (value !== undefined) args.push(flag, String(value));
     }
@@ -77,7 +77,8 @@ async function spawnFakeHerdr(dir, options) {
 
 async function relayHealthy(port) {
     for (let attempt = 0; attempt < 60; attempt += 1) {
-        const ok = await fetch(`http://127.0.0.1:${port}/health`)
+        assertCommandActive();
+        const ok = await fetch(`http://127.0.0.1:${port}/health`, { signal: commandSignal() })
             .then((response) => response.ok)
             .catch(() => false);
         if (ok) return true;
@@ -111,15 +112,18 @@ function childEnv(home, muxrHome, extra) {
  *   terminalBytesPerSecond?: number, graphicsFrameHz?: number }} [options]
  */
 export async function startFakeStack(options = {}) {
+    const sourceRoot = resolve(options.sourceRoot ?? '.');
     for (const entry of [RELAY_ENTRY, HOST_ENTRY]) {
-        if (!existsSync(entry)) throw new Error(`${entry} is missing; run \`yarn build\` first`);
+        if (!existsSync(join(sourceRoot, entry))) throw new Error(`${entry} is missing; run \`yarn build\` first`);
     }
 
     const root = mkdtempSync(join(tmpdir(), 'muxr-perf-'));
+    onCommandCleanup(() => rmSync(root, { recursive: true, force: true }));
     const home = join(root, 'home');
     const muxrHome = join(root, 'muxr');
     mkdirSync(join(home, '.config'), { recursive: true });
     mkdirSync(muxrHome, { recursive: true });
+    const fixtureEnv = options.setupHome?.(home) ?? {};
     // Seed an owner-only journal before the host starts. HostDiagnosticsJournal
     // refuses a world-readable diagnostics.json and then logs nothing; the gate
     // would pair against a live herd and later read an empty file.
@@ -150,7 +154,8 @@ export async function startFakeStack(options = {}) {
     // event loop with the harness, and one blocking call here - a Maestro run,
     // an adb dump - freezes every Herdr answer, which the phone sees as a
     // 15-second stall and reports as "reconnecting".
-    const fake = await spawnFakeHerdr(join(root, 'herdr'), options);
+    const pluginsRoot = options.setupPlugins?.({ root, home, env: fixtureEnv }) ?? options.pluginsRoot;
+    const fake = await spawnFakeHerdr(join(root, 'herdr'), { ...options, pluginsRoot });
 
     const stop = () => {
         for (const child of children.splice(0)) {
@@ -159,9 +164,10 @@ export async function startFakeStack(options = {}) {
         fake.close();
         // Only the reverse this run added: --remove-all would cut whatever else
         // on this desk is tunnelling to the emulator.
-        spawnSync('adb', ['reverse', '--remove', `tcp:${relayPort}`], { stdio: 'ignore' });
+        spawnSync('adb', ['reverse', '--remove', `tcp:${relayPort}`], { stdio: 'ignore', timeout: 10_000 });
         rmSync(root, { recursive: true, force: true });
     };
+    onCommandCleanup(stop);
 
     try {
         // The relay this run pairs against. Local authority mints the pairing
@@ -169,7 +175,8 @@ export async function startFakeStack(options = {}) {
         // bind host must be the one `self-host --connection-mode lan` would
         // choose, or the CLI refuses to adopt a relay it did not start.
         const relayLog = [];
-        const relay = spawn(process.execPath, [RELAY_ENTRY], {
+        const relay = spawn(process.execPath, [join(sourceRoot, RELAY_ENTRY)], {
+            cwd: sourceRoot,
             stdio: ['ignore', 'pipe', 'pipe'],
             env: childEnv(home, muxrHome, {
                 MUXR_RELAY_PORT: String(relayPort),
@@ -191,17 +198,18 @@ export async function startFakeStack(options = {}) {
         // the relay above. `--relay-only` is the one path that mints identity
         // without installing or restarting a service unit.
         const identity = await run(process.execPath, [
-            'scripts/cli.mjs', 'self-host', '--relay-only',
+            join(sourceRoot, 'scripts/cli.mjs'), 'self-host', '--relay-only',
             '--port', String(relayPort),
             '--advertise', `ws://127.0.0.1:${relayPort}`,
             '--connection-mode', 'lan',
-        ], { env: childEnv(home, muxrHome), timeout: 120_000 }).catch((cause) => {
+        ], { cwd: sourceRoot, env: childEnv(home, muxrHome), timeout: 120_000 }).catch((cause) => {
             throw new Error(`self-host identity failed: ${cause instanceof Error ? cause.message : String(cause)}`);
         });
 
         // The host under test, talking to the fake Herdr instead of the desk.
         const hostLog = [];
-        const host = spawn(process.execPath, [HOST_ENTRY], {
+        const host = spawn(process.execPath, [join(sourceRoot, HOST_ENTRY)], {
+            cwd: sourceRoot,
             stdio: ['ignore', 'pipe', 'pipe'],
             env: childEnv(home, muxrHome, {
                 MUXR_MODE: 'selfhost',
@@ -211,6 +219,7 @@ export async function startFakeStack(options = {}) {
                 HERDR_SOCKET_PATH: fake.socketPath,
                 HERDR_CLIENT_SOCKET_PATH: fake.clientSocketPath,
                 HERDR_BIN: fake.binPath,
+                ...fixtureEnv,
             }),
         });
         children.push(host);
@@ -246,7 +255,8 @@ export async function startFakeStack(options = {}) {
              * caller releases it once the flow has typed the code.
              */
             mintPairing: async () => {
-                const pairing = spawn(process.execPath, ['scripts/cli.mjs', 'pair'], {
+                const pairing = spawn(process.execPath, [join(sourceRoot, 'scripts/cli.mjs'), 'pair'], {
+                    cwd: sourceRoot,
                     stdio: ['ignore', 'pipe', 'pipe'],
                     env: childEnv(home, muxrHome),
                 });

--- a/perf/lib/fakeStack.mjs
+++ b/perf/lib/fakeStack.mjs
@@ -248,6 +248,7 @@ export async function startFakeStack(options = {}) {
             hostLog: () => hostLog.join(''),
             relayLog: () => relayLog.join(''),
             /** Did any attached phone declare cell pixels this run? */
+            cellMetricsJsonl: `${fake.socketPath}.cell-metrics.jsonl`,
             phoneDeclaredCellMetrics: () => existsSync(`${fake.socketPath}.cell-metrics`),
             /**
              * A real pairing string for this throwaway host. The CLI keeps

--- a/perf/lib/pairPhone.mjs
+++ b/perf/lib/pairPhone.mjs
@@ -8,11 +8,9 @@
  * to reach the screen is returned, because on a big herd that is the number
  * that matters.
  */
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { runCommand as run, assertCommandActive } from './commands.mjs';
 import { dismissPrompts } from './androidSignals.mjs';
 
-const run = promisify(execFile);
 
 async function herdOnScreen() {
     await run('adb', ['shell', 'uiautomator', 'dump', '/sdcard/pair-check.xml'], { timeout: 40_000 }).catch(() => undefined);
@@ -40,6 +38,7 @@ export async function waitForHerd(seconds) {
 export async function pairPhone({ stack, maestro, flow = 'pair.yaml', attempts = 2, patienceSeconds = 180 }) {
     let last = '';
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        assertCommandActive();
         // A dozing or locked emulator reports an empty screen, which reads as a
         // broken app; wake it and keep it awake before anything is asserted.
         for (const args of [

--- a/perf/lib/provenance.mjs
+++ b/perf/lib/provenance.mjs
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const sha256 = (path) => createHash('sha256').update(readFileSync(path)).digest('hex');
+export function patchedDependencies(cwd = '.') {
+    const files = new Set();
+    for (const patch of readdirSync(join(cwd, 'patches')).filter((name) => name.endsWith('.patch'))) {
+        const text = readFileSync(join(cwd, 'patches', patch), 'utf8');
+        for (const match of text.matchAll(/^\+\+\+ b\/(node_modules\/[^\r\n]+)$/gm)) files.add(match[1]);
+    }
+    return Object.fromEntries([...files].sort().map((path) => [path, sha256(join(cwd, path))]));
+}
+export function harnessIdentity(cwd = '.') {
+    const files = execFileSync('git', ['ls-files', '-co', '--exclude-standard', '-z', '--', 'perf', '.github/workflows'], { cwd, encoding: 'utf8' }).split('\0').filter(Boolean);
+    const hash = createHash('sha256');
+    for (const path of [...new Set(files)].sort()) hash.update(path).update('\0').update(readFileSync(join(cwd, path))).update('\0');
+    return { revision: execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim(), sha256: hash.digest('hex') };
+}
+export function sourceIdentity(cwd = '.') {
+    const git = (...args) => execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+    // Include untracked implementation files too; exclude generated outputs via gitignore.
+    const files = git('ls-files', '-co', '--exclude-standard', '-z', '--', 'apps', 'packages', 'plugins', 'scripts', 'patches', 'package.json', 'yarn.lock', 'tsconfig.base.json', 'tsconfig.json').split('\0').filter(Boolean);
+    const hash = createHash('sha256');
+    const mobile = createHash('sha256');
+    for (const path of [...new Set(files)].sort()) {
+        // Kotlin daemon liveness markers are generated outside build/ on some
+        // Gradle versions; they are not application source.
+        if (path.startsWith('apps/mobile/android/.kotlin/')) continue;
+        const bytes = readFileSync(join(cwd, path));
+        hash.update(path).update('\0').update(bytes).update('\0');
+        if (!/^(apps\/(host|relay|probe)\/|plugins\/|scripts\/)/.test(path)) mobile.update(path).update('\0').update(bytes).update('\0');
+    }
+    return { revision: git('rev-parse', 'HEAD'), sourceSha256: hash.digest('hex'), mobileSha256: mobile.digest('hex'), dirty: git('status', '--porcelain') !== '' };
+}

--- a/perf/prGate.mjs
+++ b/perf/prGate.mjs
@@ -148,13 +148,30 @@ async function viewerControls() {
     await requireScreen('native-diff', /beforeMarker/);
     const diff = await requireScreen('native-diff', /afterMarker/);
     check(diff.includes('beforeMarker'), 'Real native diff must show removed and added content');
+    const navigator = parseUiNodes(diff).filter((node) => /^(Previous file|Next file|Previous change|Next change|Zoom in$|Zoom out$|Toggle file and diff$)/.test(node.desc));
+    report.viewer = { navigator: { viewportWidthPx: report.device.width, controls: navigator }, scrubSourceLabels: 'device-unverified: no bounded scrub-to-source-line assertion' };
     await capture('native-diff.png');
-    await tapText('Toggle file and diff'); await tapText('File');
+    check(navigator.some((node) => /^Next file,/.test(node.desc)) && navigator.some((node) => /^Next change, 2 of 2$/.test(node.desc)), 'Multi-file, multi-hunk navigator did not mount');
+    check(navigator.some((node) => node.desc === 'Toggle file and diff'), 'Navigator overflow button missing');
+    for (const node of navigator) {
+        check(node.l >= 0 && node.r <= report.device.width && node.t >= 0 && node.b <= report.device.height && node.r > node.l && node.b > node.t, `Navigator control outside viewport: ${node.desc}`);
+        for (const other of navigator) if (other !== node) check(Math.min(node.r, other.r) <= Math.max(node.l, other.l) || Math.min(node.b, other.b) <= Math.max(node.t, other.t), `Navigator controls overlap: ${node.desc} / ${other.desc}`);
+    }
+    await tapText('Toggle file and diff');
+    const menu = await dump('native-nowrap-menu');
+    const wrapOff = (menu.match(/<node\b[^>]*>/g) ?? []).find((node) => node.includes('content-desc="Wrap long lines"'));
+    check(wrapOff?.includes('selected="false"'), 'CJK check requires Wrap long lines disabled');
+    await tapText('File');
     const initial = await requireScreen('native-file', /PR gate document line/);
     const lineHeight = (xml) => {
         const line = parseUiNodes(xml).find((node) => node.text?.includes('PR gate document line 1:'));
         return line && line.b - line.t;
     };
+    const cjk = parseUiNodes(initial).find((node) => node.text?.includes('CJK_START'));
+    check(cjk?.text.includes('CJK_END'), 'CJK row evidence missing: start and end must share one rendered Text node');
+    check(cjk && cjk.b - cjk.t > 0 && Math.abs(cjk.b - cjk.t - lineHeight(initial)) <= 2, 'Unwrapped CJK content must occupy one rendered row');
+    report.viewer.cjk = { startAndEndInSameTextNode: true, rowHeightPx: cjk.b - cjk.t, asciiRowHeightPx: lineHeight(initial), horizontalExtent: 'device-unverified: accessibility bounds clip to viewport' };
+    await capture('native-cjk-nowrap.png');
     await tapText('Zoom in');
     const zoomed = await requireScreen('native-zoom', /PR gate document line/);
     check(lineHeight(zoomed) > lineHeight(initial), 'Zoom did not increase actual rendered line height');
@@ -175,7 +192,7 @@ async function viewerControls() {
     check(control?.includes('selected="true"'), 'Wrap control did not retain enabled state');
     await tapText('Toggle file and diff');
     await capture('native-wrap.png');
-    report.viewer = { realDiff: true, zoomLineHeights: [lineHeight(initial), lineHeight(zoomed)], pan, wrapEnabled: true };
+    Object.assign(report.viewer, { realDiff: true, zoomLineHeights: [lineHeight(initial), lineHeight(zoomed)], pan, wrapEnabled: true });
 }
 async function main() {
     check(/^emulator-\d+$/.test(serial), 'PR gate only clears dedicated emulators');
@@ -214,12 +231,17 @@ async function main() {
     stack = await startFakeStack({ ...load, sourceRoot: hostRoot, setupHome: usageHome, setupPlugins: usagePlugins(hostRoot), graphicsEnableFile });
     report.fixtures = { usage: 'Synthetic SQLite aggregates + ccusage CLI output; scratch entry restores test env then imports actual usage plugin; no real auth/quota calls' };
     const lines = ['export function fixture() {', ...Array.from({ length: 250 }, (_, i) => `// PR gate document line ${i + 1}: deterministic readable content with a long tail for panning END_${i + 1}`), '}'];
+    lines[2] = `// CJK_START ${'漢字'.repeat(40)} CJK_END`;
     lines[4] = 'const value = "beforeMarker";';
+    lines[40] = 'const second = "beforeSecondHunk";';
+    writeFileSync(join(stack.world.cwd, 'zz-companion.ts'), 'export const companion = "beforeCompanion";\n');
     writeFileSync(join(stack.world.cwd, 'viewer.ts'), lines.join('\n'));
     await run('git', ['init', '-q', stack.world.cwd], { timeout: 10_000 });
     await run('git', ['-C', stack.world.cwd, 'add', '.'], { timeout: 10_000 });
     await run('git', ['-C', stack.world.cwd, '-c', 'user.name=Emulator Fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgsign=false', '-c', 'core.hooksPath=/dev/null', 'commit', '-qm', 'Baseline viewer fixture'], { timeout: 10_000 });
     lines[4] = 'const value = "afterMarker";';
+    lines[40] = 'const second = "afterSecondHunk";';
+    writeFileSync(join(stack.world.cwd, 'zz-companion.ts'), 'export const companion = "afterCompanion";\n');
     writeFileSync(join(stack.world.cwd, 'viewer.ts'), lines.join('\n'));
     const pairing = await pairPhone({ stack, maestro, attempts: 1, patienceSeconds: 30 });
     report.pairing = pairing;

--- a/perf/prGate.mjs
+++ b/perf/prGate.mjs
@@ -53,12 +53,22 @@ async function dump(name) {
     if (name) save(`${name}.xml`, xml);
     return xml;
 }
-async function requireScreen(name, pattern, timeout = 25_000) {
+async function requireScreen(name, pattern, timeout = 25_000, dismissStartup = false) {
     const start = Date.now();
     let xml;
     do {
         xml = await dump(name);
         if (pattern.test(xml)) return xml;
+        // This delayed app alert can arrive after the initial prompt sweep.
+        // Handle only its exact Cancel button before measurement, never mid-window.
+        if (dismissStartup && xml.includes('Show live agent updates?')) {
+            const cancel = parseUiNodes(xml).find((node) => node.text === 'CANCEL');
+            if (cancel) {
+                save(`${name}-startup-prompt.xml`, xml);
+                await adb('shell', 'input', 'tap', String(Math.round((cancel.l + cancel.r) / 2)), String(Math.round((cancel.t + cancel.b) / 2)));
+                (report.startupPrompts ??= []).push({ screen: name, at: new Date().toISOString(), action: 'CANCEL live updates alert' });
+            }
+        }
         await sleep(800);
     } while (Date.now() - start < timeout);
     throw new Error(`${name}: screen did not mount (expected ${pattern}); see ${name}.xml`);
@@ -102,7 +112,7 @@ async function maestro(flow, variables = {}) {
 }
 async function phase(name, mounted, drive = false) {
     await dismissPrompts();
-    const beforeXml = await requireScreen(name, mounted);
+    const beforeXml = await requireScreen(name, mounted, 25_000, true);
     await capture(`${name}-before.png`);
     await resetGfx(pkg);
     const initialPid = (await adb('shell', 'pidof', pkg)).trim();
@@ -279,7 +289,7 @@ async function main() {
         await phase('graphics', /text="(Terminal|ctrl)"|Type a prompt/, true);
         const events = JSON.parse(readFileSync(stack.journalPath, 'utf8')).events ?? [];
         const pipeline = events.filter((e) => e.event === 'graphics.pipeline' && Date.parse(e.at) >= since);
-        const cellSamples = readFileSync(stack.attachJsonl, 'utf8').trim().split('\n').map(JSON.parse).filter((row) => row.cellWidthPx > 0 && row.cellHeightPx > 0).slice(-3);
+        const cellSamples = (existsSync(stack.cellMetricsJsonl) ? readFileSync(stack.cellMetricsJsonl, 'utf8').trim().split('\n').map(JSON.parse) : []).filter((row) => row.source === 'terminal.resize' && row.pane_id === stack.world.panes[0].pane_id && [row.cols, row.rows, row.cellWidthPx, row.cellHeightPx].every((value) => Number.isFinite(value) && value > 0)).slice(-3);
         report.graphics = { pixels, cellSamples, declaredCellMetrics: stack.phoneDeclaredCellMetrics(), pipeline };
         check(cellSamples.length > 0, 'No positive terminal cell dimensions recorded');
         check(pipeline.some((event) => event.frames > 0), 'No delivered graphics frames during mounted phase');
@@ -345,7 +355,7 @@ async function finish(code) {
     }
     if (stack) {
         save('host.log', stack.hostLog()); save('relay.log', stack.relayLog());
-        for (const [name, path] of [['host-journal.json', stack.journalPath], ['attach.jsonl', stack.attachJsonl], ['graphics-input.jsonl', stack.graphicsInputJsonl]]) if (existsSync(path)) copyFileSync(path, join(out, name));
+        for (const [name, path] of [['host-journal.json', stack.journalPath], ['attach.jsonl', stack.attachJsonl], ['cell-metrics.jsonl', stack.cellMetricsJsonl], ['graphics-input.jsonl', stack.graphicsInputJsonl]]) if (existsSync(path)) copyFileSync(path, join(out, name));
     }
     await diagnostics.close().catch((error) => { terminated = false; report.failures.push(error.message); });
     scope.cleanup();

--- a/perf/prGate.mjs
+++ b/perf/prGate.mjs
@@ -1,0 +1,295 @@
+/** Bounded PR flow. Reuses the release gate's stack, pairing and OS samplers. */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { startFakeStack } from './lib/fakeStack.mjs';
+import { pairPhone } from './lib/pairPhone.mjs';
+import { deviceIdentity, samplePhase, resetGfx, jankReport, screenshot, screencapRaw, dismissPrompts } from './lib/androidSignals.mjs';
+import { CommandScope, useCommandScope } from './lib/commands.mjs';
+import { harnessIdentity, patchedDependencies, sha256, sourceIdentity } from './lib/provenance.mjs';
+import { usageHome, usagePlugins } from './fixtures/usageHome.mjs';
+
+const scope = new CommandScope();
+useCommandScope(scope);
+const run = scope.run.bind(scope);
+const spawn = scope.spawn.bind(scope);
+const args = process.argv.slice(2);
+const option = (key, fallback) => args.includes(key) ? args[args.indexOf(key) + 1] : fallback;
+const serial = option('--serial', 'emulator-5554');
+process.env.ANDROID_SERIAL = serial; // Also pins all existing helper adb calls.
+const out = resolve(option('--out', '/tmp/muxr-pr-gate'));
+const apk = resolve(option('--apk', '/tmp/muxr-pr-build/app-release.apk'));
+const hostRoot = resolve(option('--host-root', '.'));
+const seconds = Number(option('--seconds', '35'));
+const pkg = 'com.trymuxr.app';
+const load = { panes: 30, agents: 6, titleChurnHz: 2, terminalBytesPerSecond: 4096, graphicsFrameHz: 4 };
+const report = { startedAt: new Date().toISOString(), serial, load, phases: [], failures: [], limits: { minimumSampledSeconds: 25, jsBusyPercent: 60, pssDriftKb: 102400, frameStallSeconds: 30 }, performanceScope: 'Emulator pathology smoke; not physical-device feel or a release soak' };
+let stack;
+let ownsLock = false;
+let deviceTouched = false;
+const lock = `/tmp/muxr-pr-gate-${serial}.lock`;
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+const adb = async (...argv) => (await run('adb', argv, { timeout: 25_000, maxBuffer: 32 * 1024 * 1024 })).stdout;
+const check = (condition, message) => { if (!condition) throw new Error(message); };
+function publish(path, name = basename(path)) {
+    if (!process.env.HERDR_PANE_ID) return;
+    for (const pane of new Set([process.env.HERDR_PANE_ID, process.env.PERF_PARENT_PANE].filter(Boolean))) for (const app of ['.pocketherdr', '.muxr']) {
+        const dir = join(homedir(), app, 'attachments/pane', pane); mkdirSync(dir, { recursive: true });
+        copyFileSync(path, join(dir, `${basename(out)}-${name}`));
+    }
+}
+const save = (name, data) => {
+    writeFileSync(join(out, name), data);
+    if (name === 'report.json') publish(join(out, name));
+};
+async function capture(name) { await screenshot(join(out, name)); publish(join(out, name)); }
+async function dump(name) {
+    // Never read a stale dump after uiautomator fails.
+    await adb('shell', 'rm', '-f', '/sdcard/pr-gate.xml');
+    await adb('shell', 'uiautomator', 'dump', '/sdcard/pr-gate.xml');
+    const xml = await adb('shell', 'cat', '/sdcard/pr-gate.xml');
+    check(xml.includes('<hierarchy'), 'uiautomator returned no hierarchy');
+    if (name) save(`${name}.xml`, xml);
+    return xml;
+}
+async function requireScreen(name, pattern, timeout = 25_000) {
+    const start = Date.now();
+    let xml;
+    do {
+        xml = await dump(name);
+        if (pattern.test(xml)) return xml;
+        await sleep(800);
+    } while (Date.now() - start < timeout);
+    throw new Error(`${name}: screen did not mount (expected ${pattern}); see ${name}.xml`);
+}
+async function tapText(text) {
+    const xml = await dump();
+    const node = (xml.match(/<node\b[^>]*>/g) ?? []).find((node) => node.includes(`text="${text}"`) || node.includes(`content-desc="${text}"`));
+    const bounds = node && /bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"/.exec(node);
+    check(bounds, `Missing required control: ${text}`);
+    await adb('shell', 'input', 'tap', String((Number(bounds[1]) + Number(bounds[3])) / 2), String((Number(bounds[2]) + Number(bounds[4])) / 2));
+}
+async function herd() {
+    await dismissPrompts();
+    await adb('shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', 'muxr:///', pkg);
+    for (let n = 0; n < 5; n++) {
+        if (/text="LIVE"/.test(await dump())) return;
+        const { width, height } = report.device;
+        await adb('shell', 'input', 'swipe', String(width / 2), String(Math.round(height * .3)), String(width / 2), String(Math.round(height * .8)), '500');
+        await sleep(600);
+    }
+    throw new Error('Failed to return to herd');
+}
+async function maestro(flow, variables = {}) {
+    const argv = [ ...(process.env.MAESTRO_BIN ? [] : ['x', 'maestro@cli-2.7.0', '--', 'maestro']), '--device', serial, 'test', '--debug-output', join(out, 'maestro'), ...Object.entries(variables).flatMap(([key, value]) => ['-e', `${key}=${value}`]), join('perf/flows', flow)];
+    const result = await new Promise((done) => {
+        const child = spawn(process.env.MAESTRO_BIN ?? 'mise', argv, { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+        flowChildren.add(child);
+        let output = '';
+        const collect = (chunk) => { if (output.length < 8 * 1024 * 1024) output += chunk; };
+        child.stdout.on('data', collect); child.stderr.on('data', collect);
+        const deadline = setTimeout(() => killFlow(child), 160_000);
+        child.once('error', (error) => { output += error.message; });
+        child.once('close', (code) => {
+            clearTimeout(deadline); flowChildren.delete(child);
+            done({ code: code ?? 1, output });
+        });
+    });
+    // Pairing credentials are short-lived but do not belong in exported logs.
+    save(`${flow}.log`, result.output.replace(/wss?:\/\/\S+\?pair=\S+/g, '[pairing redacted]'));
+    return result;
+}
+async function phase(name, mounted, drive = false) {
+    await dismissPrompts();
+    const beforeXml = await requireScreen(name, mounted);
+    await capture(`${name}-before.png`);
+    await resetGfx(pkg);
+    const initialPid = (await adb('shell', 'pidof', pkg)).trim();
+    const metrics = await samplePhase({ pkg, seconds, intervalMs: 3000, onTick: drive ? async () => {
+        const { width, height } = report.device;
+        await adb('shell', 'input', 'swipe', String(Math.round(width * .5)), String(Math.round(height * .72)), String(Math.round(width * .5)), String(Math.round(height * .35)), '350');
+    } : undefined });
+    const jank = await jankReport(pkg);
+    save(`${name}-gfxinfo.txt`, await adb('shell', 'dumpsys', 'gfxinfo', pkg, 'framestats'));
+    report.phases.push({ name, mounted: true, metrics, jank });
+    const afterXml = await requireScreen(`${name}-after`, mounted);
+    await capture(`${name}-after.png`);
+    if (name === 'document') {
+        const first = (xml) => /PR gate document line (\d+)/.exec(xml)?.[1];
+        const movement = { firstLineBefore: first(beforeXml), firstLineAfter: first(afterXml) };
+        report.phases.at(-1).movement = movement;
+        check(movement.firstLineBefore !== movement.firstLineAfter, 'document: content did not scroll');
+    }
+    check((await adb('shell', 'pidof', pkg)).trim() === initialPid, `${name}: app process changed`);
+    check(metrics.sampledSeconds >= 25 && Number.isFinite(metrics.jsBusyPercent), `${name}: insufficient CPU measurement window`);
+    check(metrics.gaps === 0 && metrics.restarts === 0, `${name}: missing runtime samples or app restart`);
+    check(Number.isFinite(metrics.pssDriftKb), `${name}: missing PSS measurement`);
+    check(metrics.missingPss === 0 && metrics.pssSampledSeconds >= 25 && metrics.pssSamples.length >= 2, `${name}: insufficient timestamped PSS coverage`);
+    check(metrics.missingFrames === 0 && metrics.frameSamples.length >= 2, `${name}: missing timestamped gfxinfo frame observations`);
+    check(metrics.jsBusyPercent <= 60, `${name}: JS busy ${metrics.jsBusyPercent}% > 60%`);
+    check(metrics.pssDriftKb <= 102400, `${name}: PSS drift ${metrics.pssDriftKb} KiB > 100 MiB`);
+    check(jank.frames > 0 && metrics.frameStallSeconds < 30, `${name}: no rendered frames or 30-second frame stall`);
+    console.log(`ok: ${name}: ${metrics.sampledSeconds}s sampled, JS ${metrics.jsBusyPercent}%, PSS drift ${metrics.pssDriftKb} KiB, ${jank.frames} frames`);
+}
+async function feature(name, work) {
+    console.log(`start: ${name}`);
+    try { await work(); }
+    catch (error) { report.failures.push(`${name}: ${error.message}`); console.error(`FAIL: ${name}: ${error.message}`); }
+}
+async function main() {
+    check(/^emulator-\d+$/.test(serial), 'PR gate only clears dedicated emulators');
+    check(seconds >= 30 && seconds <= 120, '--seconds must be 30..120');
+    mkdirSync(lock); ownsLock = true;
+    writeFileSync(join(lock, 'owner.json'), JSON.stringify({ pid: process.pid, pane: process.env.HERDR_PANE_ID, startedAt: report.startedAt }));
+    check((await adb('get-state')).trim() === 'device', `${serial} is not online`);
+    report.apk = JSON.parse(readFileSync(`${apk}.json`, 'utf8'));
+    check(report.apk.variant === 'release' && /^[a-f0-9]{40}$/.test(report.apk.revision), 'Missing release APK revision provenance');
+    check(report.apk.apkSha256 === sha256(apk), 'APK SHA256 differs from build manifest');
+    check(report.apk.nativeDependencies && Object.keys(report.apk.nativeDependencies).length > 0, 'APK manifest lacks verified native patch provenance; rebuild with buildPrApk');
+    report.host = sourceIdentity(hostRoot);
+    check(report.apk.mobileSha256 === report.host.mobileSha256, 'APK mobile source digest differs from host checkout; rebuild APK');
+    check(JSON.stringify(report.apk.nativeDependencies) === JSON.stringify(patchedDependencies(hostRoot)), 'Host checkout patched dependency bytes differ from APK build');
+    await run(process.execPath, ['scripts/diagnostics/application/verifyNativePatches.mjs'], { cwd: hostRoot, timeout: 30_000 });
+    // Build the exact host checkout used by this run, without trusting stale dist.
+    await run('yarn', ['build'], { cwd: hostRoot, timeout: 180_000 });
+    report.host.entrySha256 = sha256(join(hostRoot, 'apps/host/dist/main.js'));
+    report.harness = harnessIdentity();
+    report.device = await deviceIdentity();
+    check(report.device.width > 0 && report.device.height > 0, 'Cannot read emulator dimensions');
+    // Intentional fresh install: gate owns this emulator, no fallback to an old APK.
+    deviceTouched = true;
+    await adb('uninstall', pkg).catch(() => {});
+    await adb('install', apk);
+    await adb('shell', 'pm', 'grant', pkg, 'android.permission.POST_NOTIFICATIONS');
+    const installed = (await adb('shell', 'pm', 'path', pkg)).trim().replace(/^package:/, '');
+    const pulled = join(out, 'installed.apk');
+    await adb('pull', installed, pulled);
+    report.installedApkSha256 = sha256(pulled); rmSync(pulled);
+    check(report.installedApkSha256 === report.apk.apkSha256, 'Installed APK bytes differ from tested artifact');
+    save('package.txt', await adb('shell', 'dumpsys', 'package', pkg));
+    await adb('logcat', '-c');
+    const graphicsEnableFile = join(out, '.graphics-enabled');
+    rmSync(graphicsEnableFile, { force: true });
+    stack = await startFakeStack({ ...load, sourceRoot: hostRoot, setupHome: usageHome, setupPlugins: usagePlugins(hostRoot), graphicsEnableFile });
+    report.fixtures = { usage: 'Synthetic SQLite aggregates + ccusage CLI output; scratch entry restores test env then imports actual usage plugin; no real auth/quota calls' };
+    writeFileSync(join(stack.world.cwd, 'notes.txt'), Array.from({ length: 250 }, (_, i) => `PR gate document line ${i + 1}: deterministic readable content`).join('\n'));
+    await run('git', ['init', '-q', stack.world.cwd], { timeout: 10_000 });
+    await run('git', ['-C', stack.world.cwd, 'add', 'README.md', 'notes.txt'], { timeout: 10_000 });
+    const pairing = await pairPhone({ stack, maestro, attempts: 1, patienceSeconds: 30 });
+    report.pairing = pairing;
+    check(pairing.ok, pairing.why);
+    await dismissPrompts();
+    await requireScreen('paired-herd', /text="LIVE"/);
+    await sleep(8000);
+    await dismissPrompts();
+    await feature('herd', () => phase('herd', /text="connected"/, true));
+    await feature('document', async () => {
+        await herd(); await tapText('Files');
+        await requireScreen('files', /text="(notes.txt|README.md|project)"/);
+        if (!(await dump()).includes('text="notes.txt"')) await tapText('project');
+        await requireScreen('file-list', /text="notes.txt"/);
+        await tapText('notes.txt');
+        await phase('document', /PR gate document line/, true);
+    });
+    await feature('terminal-text', async () => {
+        await herd();
+        const flow = await maestro('graphicsScroll.yaml');
+        check(flow.code === 0, 'terminal opening flow failed; see graphicsScroll.yaml.log');
+        await phase('terminal-text', /text="(Terminal|ctrl)"|Type a prompt/, true);
+        check(existsSync(stack.attachJsonl) && readFileSync(stack.attachJsonl, 'utf8').trim(), 'No real host terminal attach was observed');
+        check(!existsSync(graphicsEnableFile), 'Text phase accidentally enabled graphics');
+    });
+    await feature('graphics', async () => {
+        await requireScreen('graphics-mounted', /text="(Terminal|ctrl)"|Type a prompt/);
+        writeFileSync(graphicsEnableFile, 'enabled');
+        const pixels = await graphicsPixels();
+        report.graphics = { pixels };
+        await capture('graphics-pixels.png');
+        check(pixels.magenta > 100 && pixels.teal > 100, 'Kitty checkerboard did not paint in terminal region; see graphics-pixels.png');
+        const since = Date.now();
+        await phase('graphics', /text="(Terminal|ctrl)"|Type a prompt/, true);
+        const events = JSON.parse(readFileSync(stack.journalPath, 'utf8')).events ?? [];
+        const pipeline = events.filter((e) => e.event === 'graphics.pipeline' && Date.parse(e.at) >= since);
+        const cellSamples = readFileSync(stack.attachJsonl, 'utf8').trim().split('\n').map(JSON.parse).filter((row) => row.cellWidthPx > 0 && row.cellHeightPx > 0).slice(-3);
+        report.graphics = { pixels, cellSamples, declaredCellMetrics: stack.phoneDeclaredCellMetrics(), pipeline };
+        check(cellSamples.length > 0, 'No positive terminal cell dimensions recorded');
+        check(pipeline.some((event) => event.frames > 0), 'No delivered graphics frames during mounted phase');
+    });
+    await feature('usage-switch-and-recency', async () => {
+        await herd(); await tapText('Usage');
+        const xml = await requireScreen('usage-omp', /text="150"/);
+        check(xml.includes('text="OMP"') && xml.includes('text="OpenCode"'), 'Both provider tabs must mount');
+        check(xml.indexOf('text="OMP"') < xml.indexOf('text="OpenCode"'), 'OMP must precede OpenCode by latest event time');
+        await capture('usage-omp.png');
+        await tapText('OpenCode'); await requireScreen('usage-opencode', /text="300"/);
+        await capture('usage-opencode.png');
+        await tapText('OMP'); await requireScreen('usage-omp-return', /text="150"/);
+        report.usage = { passed: true, orderedProviders: ['OMP', 'OpenCode'], switchedTokens: [150, 300, 150] };
+    });
+    check(sourceIdentity(hostRoot).sourceSha256 === report.host.sourceSha256, 'Host sources changed during run');
+    check(JSON.stringify(patchedDependencies(hostRoot)) === JSON.stringify(report.apk.nativeDependencies), 'Patched dependencies changed during run');
+    check(harnessIdentity().sha256 === report.harness.sha256, 'Harness or workflow changed during run');
+}
+
+mkdirSync(out, { recursive: true });
+const watchdog = setTimeout(() => { console.error('FAIL: overall gate deadline (12 minutes)'); process.kill(process.pid, 'SIGTERM'); }, 12 * 60_000);
+// Signal handling interrupts pending commands; finally exports bounded diagnostics.
+process.once('SIGTERM', () => { report.failures.push('Interrupted or exceeded 12-minute deadline'); void finish(1); });
+process.once('SIGINT', () => { report.failures.push('Interrupted'); void finish(130); });
+let finishing = false;
+const flowChildren = new Set();
+function killFlow(child) {
+    scope.kill(child);
+}
+async function graphicsPixels() {
+    let result;
+    for (let attempt = 0; attempt < 10; attempt++) {
+        const raw = await screencapRaw();
+        check(raw.format === 1, 'Graphics pixel proof needs an RGBA8888 framebuffer');
+        result = { magenta: 0, teal: 0, samples: 0, region: 'x10..85%, y20..75%', tolerance: 12 };
+        for (let y = Math.round(raw.height * .2); y < raw.height * .75; y += 4) for (let x = Math.round(raw.width * .1); x < raw.width * .85; x += 4) {
+            const at = 16 + (y * raw.width + x) * 4;
+            const matches = (color) => color.every((value, channel) => Math.abs(raw.bytes[at + channel] - value) <= 12);
+            result.samples++;
+            if (matches([235, 35, 170])) result.magenta++;
+            if (matches([20, 215, 185])) result.teal++;
+        }
+        if (result.magenta > 100 && result.teal > 100) return result;
+        await sleep(1500);
+    }
+    return result;
+}
+async function finish(code) {
+    if (finishing) return;
+    finishing = true; clearTimeout(watchdog);
+    let terminated = true;
+    try { await scope.close(); }
+    catch (error) { terminated = false; report.failures.push(error.message); }
+    const diagnostics = new CommandScope();
+    const diagnosticAdb = async (...argv) => (await diagnostics.run('adb', argv, { timeout: 20_000 })).stdout;
+    if (deviceTouched) {
+        await diagnosticAdb('shell', 'uiautomator', 'dump', '/sdcard/pr-gate-final.xml').then(async () => save('final.xml', await diagnosticAdb('shell', 'cat', '/sdcard/pr-gate-final.xml'))).catch(() => {});
+        await diagnostics.run('adb', ['exec-out', 'screencap', '-p'], { encoding: null, timeout: 20_000 }).then(({ stdout }) => { save('final.png', stdout); publish(join(out, 'final.png')); }).catch(() => {});
+        const log = await diagnosticAdb('logcat', '-d', '-v', 'threadtime').catch((error) => { report.failures.push(`logcat evidence unavailable: ${error.message}`); return ''; });
+        save('logcat.txt', log);
+        if (/Maximum update depth exceeded|FATAL EXCEPTION|Fatal signal/.test(log)) report.failures.push('Fatal or React update-depth error in logcat');
+    }
+    if (stack) {
+        save('host.log', stack.hostLog()); save('relay.log', stack.relayLog());
+        for (const [name, path] of [['host-journal.json', stack.journalPath], ['attach.jsonl', stack.attachJsonl], ['graphics-input.jsonl', stack.graphicsInputJsonl]]) if (existsSync(path)) copyFileSync(path, join(out, name));
+    }
+    await diagnostics.close().catch((error) => { terminated = false; report.failures.push(error.message); });
+    scope.cleanup();
+    if (ownsLock && terminated) rmSync(lock, { recursive: true, force: true });
+    report.finishedAt = new Date().toISOString(); report.passed = code === 0 && report.failures.length === 0;
+    save('report.json', JSON.stringify(report, null, 2));
+    if (process.env.HERDR_PANE_ID) {
+        const bundle = `${out}.tar.gz`;
+        const exporter = new CommandScope();
+        try { await exporter.run('tar', ['-czf', bundle, '-C', out, '.'], { timeout: 20_000 }); publish(bundle, 'evidence.tar.gz'); }
+        finally { await exporter.close(); }
+    }
+    console.log(`${report.passed ? 'PASS' : 'FAIL'}: ${join(out, 'report.json')}`);
+    process.exit(report.passed ? 0 : code || 1);
+}
+main().then(() => finish(0), (error) => { report.failures.push(error.message); console.error(error); return finish(1); });

--- a/perf/prGate.mjs
+++ b/perf/prGate.mjs
@@ -6,6 +6,7 @@ import { startFakeStack } from './lib/fakeStack.mjs';
 import { pairPhone } from './lib/pairPhone.mjs';
 import { deviceIdentity, samplePhase, resetGfx, jankReport, screenshot, screencapRaw, dismissPrompts } from './lib/androidSignals.mjs';
 import { CommandScope, useCommandScope } from './lib/commands.mjs';
+import { cropRaw, pixelsMoved, parseUiNodes } from './lib/gestureMetrics.mjs';
 import { harnessIdentity, patchedDependencies, sha256, sourceIdentity } from './lib/provenance.mjs';
 import { usageHome, usagePlugins } from './fixtures/usageHome.mjs';
 
@@ -136,6 +137,46 @@ async function feature(name, work) {
     try { await work(); }
     catch (error) { report.failures.push(`${name}: ${error.message}`); console.error(`FAIL: ${name}: ${error.message}`); }
 }
+async function viewerControls() {
+    await herd();
+    check((await maestro('graphicsScroll.yaml')).code === 0, 'Could not open session for native file viewer');
+    await tapText('Session actions');
+    await requireScreen('session-actions', /Changes/);
+    await tapText('Changes');
+    await requireScreen('changed-files', /viewer.ts/);
+    await tapText('viewer.ts');
+    await requireScreen('native-diff', /beforeMarker/);
+    const diff = await requireScreen('native-diff', /afterMarker/);
+    check(diff.includes('beforeMarker'), 'Real native diff must show removed and added content');
+    await capture('native-diff.png');
+    await tapText('Toggle file and diff'); await tapText('File');
+    const initial = await requireScreen('native-file', /PR gate document line/);
+    const lineHeight = (xml) => {
+        const line = parseUiNodes(xml).find((node) => node.text?.includes('PR gate document line 1:'));
+        return line && line.b - line.t;
+    };
+    await tapText('Zoom in');
+    const zoomed = await requireScreen('native-zoom', /PR gate document line/);
+    check(lineHeight(zoomed) > lineHeight(initial), 'Zoom did not increase actual rendered line height');
+    await capture('native-zoom.png');
+    const { width, height } = report.device;
+    const region = { l: width * .1, r: width * .85, t: height * .25, b: height * .7 };
+    const before = cropRaw(await screencapRaw(), region);
+    await adb('shell', 'input', 'swipe', String(Math.round(width * .8)), String(Math.round(height * .5)), String(Math.round(width * .2)), String(Math.round(height * .5)), '450');
+    await sleep(500);
+    await requireScreen('native-pan', /viewer.ts/);
+    const pan = pixelsMoved(before, cropRaw(await screencapRaw(), region));
+    check(pan.moved, 'Unwrapped code did not visibly pan within the same file');
+    await capture('native-pan.png');
+    await tapText('Toggle file and diff'); await tapText('Wrap long lines');
+    await tapText('Toggle file and diff');
+    const wrapped = await dump('native-wrap');
+    const control = (wrapped.match(/<node\b[^>]*>/g) ?? []).find((node) => node.includes('content-desc="Wrap long lines"'));
+    check(control?.includes('selected="true"'), 'Wrap control did not retain enabled state');
+    await tapText('Toggle file and diff');
+    await capture('native-wrap.png');
+    report.viewer = { realDiff: true, zoomLineHeights: [lineHeight(initial), lineHeight(zoomed)], pan, wrapEnabled: true };
+}
 async function main() {
     check(/^emulator-\d+$/.test(serial), 'PR gate only clears dedicated emulators');
     check(seconds >= 30 && seconds <= 120, '--seconds must be 30..120');
@@ -172,9 +213,14 @@ async function main() {
     rmSync(graphicsEnableFile, { force: true });
     stack = await startFakeStack({ ...load, sourceRoot: hostRoot, setupHome: usageHome, setupPlugins: usagePlugins(hostRoot), graphicsEnableFile });
     report.fixtures = { usage: 'Synthetic SQLite aggregates + ccusage CLI output; scratch entry restores test env then imports actual usage plugin; no real auth/quota calls' };
-    writeFileSync(join(stack.world.cwd, 'notes.txt'), Array.from({ length: 250 }, (_, i) => `PR gate document line ${i + 1}: deterministic readable content`).join('\n'));
+    const lines = ['export function fixture() {', ...Array.from({ length: 250 }, (_, i) => `// PR gate document line ${i + 1}: deterministic readable content with a long tail for panning END_${i + 1}`), '}'];
+    lines[4] = 'const value = "beforeMarker";';
+    writeFileSync(join(stack.world.cwd, 'viewer.ts'), lines.join('\n'));
     await run('git', ['init', '-q', stack.world.cwd], { timeout: 10_000 });
-    await run('git', ['-C', stack.world.cwd, 'add', 'README.md', 'notes.txt'], { timeout: 10_000 });
+    await run('git', ['-C', stack.world.cwd, 'add', '.'], { timeout: 10_000 });
+    await run('git', ['-C', stack.world.cwd, '-c', 'user.name=Emulator Fixture', '-c', 'user.email=fixture@example.invalid', '-c', 'commit.gpgsign=false', '-c', 'core.hooksPath=/dev/null', 'commit', '-qm', 'Baseline viewer fixture'], { timeout: 10_000 });
+    lines[4] = 'const value = "afterMarker";';
+    writeFileSync(join(stack.world.cwd, 'viewer.ts'), lines.join('\n'));
     const pairing = await pairPhone({ stack, maestro, attempts: 1, patienceSeconds: 30 });
     report.pairing = pairing;
     check(pairing.ok, pairing.why);
@@ -185,11 +231,12 @@ async function main() {
     await feature('herd', () => phase('herd', /text="connected"/, true));
     await feature('document', async () => {
         await herd(); await tapText('Files');
-        await requireScreen('files', /text="(notes.txt|README.md|project)"/);
-        if (!(await dump()).includes('text="notes.txt"')) await tapText('project');
-        await requireScreen('file-list', /text="notes.txt"/);
-        await tapText('notes.txt');
+        await requireScreen('files', /text="(viewer.ts|README.md|project)"/);
+        if (!(await dump()).includes('text="viewer.ts"')) await tapText('project');
+        await requireScreen('file-list', /text="viewer.ts"/);
+        await tapText('viewer.ts');
         await phase('document', /PR gate document line/, true);
+        await viewerControls();
     });
     await feature('terminal-text', async () => {
         await herd();

--- a/perf/prGate.mjs
+++ b/perf/prGate.mjs
@@ -290,8 +290,9 @@ async function main() {
         const events = JSON.parse(readFileSync(stack.journalPath, 'utf8')).events ?? [];
         const pipeline = events.filter((e) => e.event === 'graphics.pipeline' && Date.parse(e.at) >= since);
         const cellSamples = (existsSync(stack.cellMetricsJsonl) ? readFileSync(stack.cellMetricsJsonl, 'utf8').trim().split('\n').map(JSON.parse) : []).filter((row) => row.source === 'terminal.resize' && row.pane_id === stack.world.panes[0].pane_id && [row.cols, row.rows, row.cellWidthPx, row.cellHeightPx].every((value) => Number.isFinite(value) && value > 0)).slice(-3);
-        report.graphics = { pixels, cellSamples, declaredCellMetrics: stack.phoneDeclaredCellMetrics(), pipeline };
-        check(cellSamples.length > 0, 'No positive terminal cell dimensions recorded');
+        const helloSamples = (existsSync(stack.graphicsInputJsonl) ? readFileSync(stack.graphicsInputJsonl, 'utf8').trim().split('\n').map(JSON.parse) : []).filter((row) => row.source === 'graphics.ClientHello' && [row.cols, row.rows, row.cellWidthPx, row.cellHeightPx].every((value) => Number.isFinite(value) && value > 0)).slice(-3);
+        report.graphics = { pixels, cellSamples, helloSamples, cellEvidenceScope: 'Native resize for first pane, or real graphics connection ClientHello populated from native attach', declaredCellMetrics: stack.phoneDeclaredCellMetrics(), pipeline };
+        check(cellSamples.length > 0 || helloSamples.length > 0, 'No positive native cell dimensions recorded in resize or graphics ClientHello');
         check(pipeline.some((event) => event.frames > 0), 'No delivered graphics frames during mounted phase');
     });
     await feature('usage-switch-and-recency', async () => {


### PR DESCRIPTION
The existing release performance gate could tap optional controls without proving the target screen mounted, and a copied native dependency tree could produce an APK that did not match the tracked patch files.

This adds a bounded emulator PR gate using the real host, relay, E2EE pairing, plugin transport and mobile screens, with isolated fake-Herdr and provider fixtures. It checks herd/document/text/graphics/Usage mounts, provider switching and recency, delivered graphics pixels and frames, and timestamped CPU/PSS/frame coverage. Missing measurements fail. Gesture-feel and physical-device acceptance remain the full release gate’s responsibility.

Build provenance includes source/mobile/harness hashes, actual patched dependency hashes, and SHA256 verification of the APK pulled back from the emulator. Commands and screenshots are bounded, cancellation owns process groups, and failure reports/screenshots/logs are preserved before cleanup. A manual workflow builds an explicit SHA on a disposable GitHub-hosted runner; no personal runner or automatic untrusted-PR execution is introduced.

Validation:

- Independent harness code review: PASS; fixture, cancellation, mixed-native rejection and existing fake-stack checks pass.
- Two exploratory emulator runs exposed missing fixture plugins/permissions and mismatched native dependencies. Their reports explicitly mark invalid native parity and do not count as release acceptance.
- Correctly patched integration APK built; final consolidated viewer + usage emulator run is pending and will be reported here.

Targets #209’s release branch. Usage fixture assertions require #210. Viewer #211 is being integrated for the final combined build. Instructions and exact evidence contract: `perf/PR_GATE.md`.
