### PR TITLE
fix(terminal): preserve graphics operations under backpressure

### DIFF
--- a/apps/host/src/agent/infrastructure/terminalManager.test.ts
+++ b/apps/host/src/agent/infrastructure/terminalManager.test.ts
@@ -86,6 +86,7 @@ vi.mock('ws', async () => {
 });
 
 import { TerminalManager } from './terminalManager.js';
+import { HerdrGraphicsBridge, type HerdrGraphicsRegistration } from './herdrGraphicsBridge.js';
 
 describe('TerminalManager stream exit', () => {
     beforeEach(() => {
@@ -158,6 +159,67 @@ describe('TerminalManager stream exit', () => {
         await expect(manager.attach({ sessionId: 'session', channel: 'channel', cols: 100, rows: 30 }))
             .rejects.toThrow('could not start Herdr');
         expect(fakes.sockets[0]?.close).toHaveBeenCalledOnce();
+    });
+
+    it('preserves graphics placements and deletes through backpressure and closes on bounded overflow', async () => {
+        let writeGraphics!: (frame: string) => void;
+        const bridge = {
+            register: vi.fn((registration: HerdrGraphicsRegistration) => {
+                writeGraphics = registration.write;
+                return true;
+            }),
+            unregister: vi.fn(),
+            hasRegistrations: () => false,
+            close: vi.fn(),
+        };
+        vi.spyOn(HerdrGraphicsBridge, 'open').mockResolvedValue(bridge as unknown as HerdrGraphicsBridge);
+        const manager = new TerminalManager({
+            relayUrl: 'ws://relay.test', machineId: 'machine', resolvePane: async () => 'workspace:pane',
+        });
+        await manager.attach({ sessionId: 'session', channel: 'graphics', cols: 100, rows: 30, cellWidthPx: 8, cellHeightPx: 16 });
+        await vi.waitFor(() => expect(bridge.register).toHaveBeenCalled());
+        const socket = fakes.sockets[0]!;
+        const graphic = (bytes: string, graphics = true) => JSON.stringify({
+            type: 'terminal.frame', seq: 0, encoding: 'ansi', width: 100, height: 30,
+            full: false, graphics, graphicsSurface: 'inline', bytes: Buffer.from(bytes).toString('base64'),
+        });
+        const frames = [
+            graphic('\x1b_Ga=p,i=1,p=1;\x1b\\'),
+            graphic('\x1b_Ga=p,i=2,p=2;\x1b\\'),
+            graphic('\x1b_Ga=d,d=i,i=1;\x1b\\', false),
+            graphic('\x1b_Ga=p,i=3,p=3;\x1b\\'),
+        ];
+        vi.useFakeTimers();
+        try {
+            socket.bufferedAmount = 600 * 1024;
+            for (const frame of frames) writeGraphics(frame);
+            await vi.advanceTimersByTimeAsync(32);
+            expect(socket.send).not.toHaveBeenCalled();
+            socket.bufferedAmount = 0;
+            // A drain can fill the socket again: preserve the remaining queue.
+            socket.send.mockImplementationOnce(() => { socket.bufferedAmount = 600 * 1024; });
+            await vi.advanceTimersByTimeAsync(16);
+            expect(socket.send.mock.calls.map(([frame]) => frame)).toEqual(frames.slice(0, 1));
+            socket.bufferedAmount = 0;
+            await vi.advanceTimersByTimeAsync(16);
+            expect(socket.send.mock.calls.map(([frame]) => frame)).toEqual(frames);
+
+            socket.send.mockClear();
+            socket.bufferedAmount = 600 * 1024;
+            const large = graphic('x'.repeat(25 * 1024 * 1024));
+            writeGraphics(large);
+            expect(socket.close).not.toHaveBeenCalled();
+            writeGraphics(large);
+            expect(socket.close).toHaveBeenCalledOnce();
+            expect(JSON.parse(socket.send.mock.calls[0]![0])).toMatchObject({
+                type: 'terminal.closed', reason: 'terminal graphics backlog exceeded',
+            });
+            await vi.advanceTimersByTimeAsync(64);
+            expect(socket.send).toHaveBeenCalledOnce();
+        } finally {
+            manager.closeAll();
+            vi.useRealTimers();
+        }
     });
 
     it('does not write a late client frame into a cleanly exited stream', async () => {

--- a/apps/host/src/agent/infrastructure/terminalManager.ts
+++ b/apps/host/src/agent/infrastructure/terminalManager.ts
@@ -37,7 +37,8 @@ interface Attachment {
     rows: number;
     cellWidthPx: number | undefined;
     cellHeightPx: number | undefined;
-    pendingGraphics?: string;
+    pendingGraphics: { frame: string; bytes: number }[];
+    pendingGraphicsBytes: number;
     graphicsFlushTimer?: ReturnType<typeof setTimeout>;
     close: (reason?: string) => void;
 }
@@ -46,6 +47,8 @@ const ATTACH_TIMEOUT_MS = 10_000;
 const GRAPHICS_BUFFER_HIGH_BYTES = 512 * 1024;
 const GRAPHICS_BUFFER_LOW_BYTES = 128 * 1024;
 const GRAPHICS_DRAIN_POLL_MS = 16;
+const MAX_PENDING_GRAPHICS_BYTES = 64 * 1024 * 1024;
+const MAX_PENDING_GRAPHICS_FRAMES = 128;
 
 export class TerminalManager {
     private readonly attachments = new Map<string, Attachment>();
@@ -200,6 +203,8 @@ export class TerminalManager {
             rows: params.rows,
             cellWidthPx: params.cellWidthPx,
             cellHeightPx: params.cellHeightPx,
+            pendingGraphics: [],
+            pendingGraphicsBytes: 0,
             close: () => undefined,
         };
 
@@ -213,7 +218,8 @@ export class TerminalManager {
             removeInput();
             if (attachment.graphicsFlushTimer !== undefined) clearTimeout(attachment.graphicsFlushTimer);
             delete attachment.graphicsFlushTimer;
-            delete attachment.pendingGraphics;
+            attachment.pendingGraphics = [];
+            attachment.pendingGraphicsBytes = 0;
             if (reason !== undefined && socket.readyState === WebSocket.OPEN) {
                 const plaintext = JSON.stringify({ type: 'terminal.closed', reason });
                 if (this.hosted === undefined) {
@@ -472,11 +478,21 @@ export class TerminalManager {
 
     private sendGraphicsToPhone(attachment: Attachment, frame: string): void {
         if (this.attachments.get(attachment.channel) !== attachment || attachment.socket.readyState !== WebSocket.OPEN) return;
-        if (attachment.pendingGraphics === undefined && attachment.socket.bufferedAmount <= GRAPHICS_BUFFER_HIGH_BYTES) {
+        if (attachment.pendingGraphics.length === 0 && attachment.socket.bufferedAmount <= GRAPHICS_BUFFER_HIGH_BYTES) {
             this.sendToPhone(attachment, frame);
             return;
         }
-        attachment.pendingGraphics = frame;
+        const bytes = Buffer.byteLength(frame);
+        if (attachment.pendingGraphicsBytes + bytes > MAX_PENDING_GRAPHICS_BYTES
+            || attachment.pendingGraphics.length >= MAX_PENDING_GRAPHICS_FRAMES) {
+            attachment.close('terminal graphics backlog exceeded');
+            return;
+        }
+        // These records can update independent placements or delete old images.
+        // Only the bridge knows which operations supersede others; preserve its
+        // order here instead of treating every frame as a complete snapshot.
+        attachment.pendingGraphics.push({ frame, bytes });
+        attachment.pendingGraphicsBytes += bytes;
         if (attachment.graphicsFlushTimer === undefined) {
             attachment.graphicsFlushTimer = setTimeout(() => { this.flushGraphics(attachment); }, GRAPHICS_DRAIN_POLL_MS);
         }
@@ -485,16 +501,20 @@ export class TerminalManager {
     private flushGraphics(attachment: Attachment): void {
         delete attachment.graphicsFlushTimer;
         if (this.attachments.get(attachment.channel) !== attachment || attachment.socket.readyState !== WebSocket.OPEN) {
-            delete attachment.pendingGraphics;
+            attachment.pendingGraphics = [];
+            attachment.pendingGraphicsBytes = 0;
             return;
         }
-        if (attachment.socket.bufferedAmount > GRAPHICS_BUFFER_LOW_BYTES) {
+        if (attachment.socket.bufferedAmount <= GRAPHICS_BUFFER_LOW_BYTES) {
+            while (attachment.pendingGraphics.length > 0 && attachment.socket.bufferedAmount <= GRAPHICS_BUFFER_HIGH_BYTES) {
+                const next = attachment.pendingGraphics.shift()!;
+                attachment.pendingGraphicsBytes -= next.bytes;
+                this.sendToPhone(attachment, next.frame);
+            }
+        }
+        if (attachment.pendingGraphics.length > 0) {
             attachment.graphicsFlushTimer = setTimeout(() => { this.flushGraphics(attachment); }, GRAPHICS_DRAIN_POLL_MS);
-            return;
         }
-        const frame = attachment.pendingGraphics;
-        delete attachment.pendingGraphics;
-        if (frame !== undefined) this.sendToPhone(attachment, frame);
     }
 
     private sendToPhone(attachment: Attachment, plaintext: string): void {


### PR DESCRIPTION
Socket backpressure previously retained only one pending graphics operation, so an independent inline placement or delete could be silently overwritten. This keeps graphics operations in order, bounds the queue at 64 MiB/128 frames, and closes explicitly on overflow instead of losing protocol operations.

Independent review PASS; existing real terminal manager flow 4/4 and bridge flow 2/2 pass. Includes mixed placements/deletes under congestion. Only two host files change. This component is being consolidated into release PR #209; final combined emulator validation follows there.
