### PR TITLE
fix(voice): restore provider settings and Codex default setup

### DIFF
--- a/apps/mobile/sources/app/(app)/settings/voice.tsx
+++ b/apps/mobile/sources/app/(app)/settings/voice.tsx
@@ -15,7 +15,7 @@ import { useUnistyles } from 'react-native-unistyles';
 import { configureVadStandby } from '@/conversation/session';
 import { ensureRealtimeProviderConfigured, requestRealtimePermission } from '@/conversation';
 
-type ProviderOption = { id: string; name: string; selected: boolean };
+type ProviderOption = { id: string; name: string; selected: boolean; configurationContributionId: string };
 type ProviderList = { selected: string; providers: ProviderOption[] };
 
 async function loadVoicePlugin() {
@@ -88,9 +88,9 @@ export default function VoiceProviderScreen() {
                 return;
             }
             const plugin = access.plugin;
-            const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'settings.items' && contribution.type === 'settings-item');
-            if (settings?.action.type !== 'screen') throw new Error('This provider has no configuration screen.');
-            router.push(pluginHref(plugin!.summary.pluginId, settings.action.contributionId) as any);
+            const settings = plugin?.manifest?.contributions.find((contribution) => contribution.slot === 'navigation.content' && contribution.type === 'screen' && contribution.id === selected.configurationContributionId);
+            if (settings === undefined) throw new Error('This provider has no configuration screen.');
+            router.push(pluginHref(plugin!.summary.pluginId, settings.id) as any);
         } catch (cause) {
             Modal.alert('Provider settings unavailable', cause instanceof Error ? cause.message : String(cause));
         } finally {

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -1,9 +1,7 @@
 # muxr Voice plugin
 
-The bundled xAI Grok speech-to-speech provider plugin. It uses the same public primitives, actions, slots, and `voice.*` semantic capabilities available to another provider.
+One backend plugin provides native realtime speech-to-speech through Codex Voice, Grok, Gemini Live, or OpenAI Realtime. Provider policy and credentials stay on the connected machine; the phone uses generic PCM or WebRTC realtime transport.
 
-- **Host:** `rpc.mjs` owns the provider key (`~/.muxr/xai.key`, owner-only). `stream.mjs` is the persistent `host.stream` adapter: it holds the xAI WebSocket, auth, model (`grok-voice-think-fast-2.0`), prompt, and event translation, and speaks only the generic realtime NDJSON frames.
-- **Phone:** generic `icon-button` controls, a provider-neutral `realtime-session-overlay`, and PCM capture/playback. No API key, model name, provider URL, or provider event vocabulary is stored or known on the phone.
-- **Settings:** choose Grok under Settings → Realtime voice, then open Configure. Secure prompt values go directly to its write RPC and are never persisted or rendered by declarative UI.
-- **Swap:** the app asks the host to serialize the switch between plugins declaring `voice.session`; adding a provider never adds a React Native transport branch.
-- **Removal:** clear the key from the plugin-owned Settings row, then `herdr plugin unlink muxr.voice`.
+Settings → Realtime voice is the single provider picker. A machine with no saved choice defaults to Codex Voice (experimental); explicit saved choices and migrated legacy choices remain selected. Configure opens the selected provider’s backend-declared setup screen. Codex uses the machine’s ChatGPT CLI login (`codex login`), not an API key. Login readiness does not guarantee realtime subscription entitlement. Other providers use owner-only API key files and secure prompts.
+
+`rpc.mjs` lists/selects providers and reports readiness. `stream.mjs` dispatches to the selected adapter. The native microphone foreground service must be ready before capture starts. No transcription/LLM/TTS fallback is used.

--- a/plugins/voice/muxr-ui.json
+++ b/plugins/voice/muxr-ui.json
@@ -207,7 +207,7 @@
         },
         {
           "type": "text",
-          "text": "Sign in with ChatGPT using codex login on the connected machine. Codex Voice uses that login; no API key is needed. Realtime subscription access is experimental and may be unavailable for your account."
+          "text": "Run codex login with ChatGPT on this machine. No API key needed. Experimental realtime access depends on your account."
         }
       ]
     }

--- a/plugins/voice/muxr-ui.json
+++ b/plugins/voice/muxr-ui.json
@@ -96,44 +96,6 @@
       }
     },
     {
-      "slot": "settings.items",
-      "id": "settings",
-      "type": "settings-item",
-      "label": {
-        "default": "Realtime voice",
-        "translations": {
-          "ru": "Голосовой ассистент",
-          "pl": "Asystent głosowy",
-          "es": "Asistente de voz",
-          "it": "Assistente vocale",
-          "pt": "Assistente de voz",
-          "ca": "Assistent de veu",
-          "zh-Hans": "语音助手",
-          "zh-Hant": "語音助理",
-          "ja": "音声アシスタント"
-        }
-      },
-      "subtitle": {
-        "default": "Configure the provider on the connected machine",
-        "translations": {
-          "ru": "Настройка предпочтений голосового взаимодействия",
-          "pl": "Konfiguruj preferencje interakcji głosowej",
-          "es": "Configura las preferencias de voz",
-          "it": "Configura le preferenze vocali",
-          "pt": "Configure as preferências de interação por voz",
-          "ca": "Configura les preferències d'interacció per veu",
-          "zh-Hans": "配置语音交互偏好",
-          "zh-Hant": "設定語音互動偏好",
-          "ja": "音声操作の設定"
-        }
-      },
-      "icon": "pulse-outline",
-      "action": {
-        "type": "screen",
-        "contributionId": "settings-screen"
-      }
-    },
-    {
       "slot": "navigation.content",
       "id": "settings-screen",
       "type": "screen",
@@ -222,6 +184,32 @@
         "type": "capability",
         "name": "voice.start"
       }
+    },
+    {
+      "slot": "navigation.content",
+      "id": "login-screen",
+      "type": "screen",
+      "title": "Codex Voice setup",
+      "data": {
+        "type": "plugin.call",
+        "contributionId": "status"
+      },
+      "children": [
+        {
+          "type": "row",
+          "title": "Provider",
+          "value": "{{data.providerName}}"
+        },
+        {
+          "type": "row",
+          "title": "Login",
+          "value": "{{data.statusLabel}}"
+        },
+        {
+          "type": "text",
+          "text": "Sign in with ChatGPT using codex login on the connected machine. Codex Voice uses that login; no API key is needed. Realtime subscription access is experimental and may be unavailable for your account."
+        }
+      ]
     }
   ]
 }

--- a/plugins/voice/provider.mjs
+++ b/plugins/voice/provider.mjs
@@ -6,13 +6,13 @@ import { join } from 'node:path';
  * $MUXR_HOME; adapters that authenticate through an existing CLI login have none.
  */
 export const PROVIDERS = [
-    { id: 'xai', name: 'Grok', secret: 'xai.key', keyLabel: 'xAI', placeholder: 'xai-…' },
-    { id: 'gemini', name: 'Gemini Live', secret: 'gemini.key', keyLabel: 'Gemini', placeholder: 'AIza…' },
-    { id: 'openai', name: 'OpenAI Realtime', secret: 'openai.key', keyLabel: 'OpenAI', placeholder: 'sk-…' },
-    { id: 'codex', name: 'Codex Voice (experimental)', keyLabel: 'Codex', placeholder: '' },
+    { id: 'xai', name: 'Grok', configurationContributionId: 'settings-screen', secret: 'xai.key', keyLabel: 'xAI', placeholder: 'xai-…' },
+    { id: 'gemini', name: 'Gemini Live', configurationContributionId: 'settings-screen', secret: 'gemini.key', keyLabel: 'Gemini', placeholder: 'AIza…' },
+    { id: 'openai', name: 'OpenAI Realtime', configurationContributionId: 'settings-screen', secret: 'openai.key', keyLabel: 'OpenAI', placeholder: 'sk-…' },
+    { id: 'codex', name: 'Codex Voice (experimental)', configurationContributionId: 'login-screen', keyLabel: 'Codex', placeholder: '' },
 ];
 
-const DEFAULT_ID = 'xai';
+const DEFAULT_ID = 'codex';
 const LEGACY_PLUGIN_IDS = new Map([
     ['muxr.voice-gemini', 'gemini'],
     ['muxr.voice-openai', 'openai'],

--- a/plugins/voice/providerRefusal.spec.mjs
+++ b/plugins/voice/providerRefusal.spec.mjs
@@ -336,12 +336,14 @@ describe('providerRefusal', () => {
             socket.on('message', (data) => connection.frames.push(JSON.parse(String(data))));
         });
 
+        await writeFile(join(muxrHome, 'provider'), 'xai\n');
         const child = spawn(process.execPath, [fileURLToPath(new URL('./stream.mjs', import.meta.url))], {
             cwd: fileURLToPath(new URL('../..', import.meta.url)),
             env: {
                 ...process.env,
                 NODE_ENV: 'test',
                 MUXR_HOME: muxrHome,
+                MUXR_PLUGIN_STATE_DIR: muxrHome,
                 MUXR_TEST_XAI_REALTIME_URL: `ws://127.0.0.1:${address.port}`,
                 MUXR_VOICE_COORDINATOR_SOCKET: access.socketPath,
                 MUXR_VOICE_COORDINATOR_CAPABILITY: access.capability,
@@ -621,12 +623,14 @@ describe('providerRefusal', () => {
             socket.on('message', (data) => connection.frames.push(JSON.parse(String(data))));
         });
 
+        await writeFile(join(muxrHome, 'provider'), 'xai\n');
         const child = spawn(process.execPath, [fileURLToPath(new URL('./stream.mjs', import.meta.url))], {
             cwd: fileURLToPath(new URL('../..', import.meta.url)),
             env: {
                 ...process.env,
                 NODE_ENV: 'test',
                 MUXR_HOME: muxrHome,
+                MUXR_PLUGIN_STATE_DIR: muxrHome,
                 MUXR_TEST_XAI_REALTIME_URL: `ws://127.0.0.1:${address.port}`,
             },
             stdio: ['pipe', 'pipe', 'pipe'],

--- a/plugins/voice/rpc.mjs
+++ b/plugins/voice/rpc.mjs
@@ -39,13 +39,13 @@ if (method === 'status') {
 } else if (method === 'provider.list') {
     output = {
         selected: provider.id,
-        providers: PROVIDERS.map(({ id, name }) => ({ id, name, selected: id === provider.id })),
+        providers: PROVIDERS.map(({ id, name, configurationContributionId }) => ({ id, name, configurationContributionId, selected: id === provider.id })),
     };
 } else if (method === 'provider.set') {
     const next = selectProvider(input?.providerId);
     output = {
         selected: next.id,
-        providers: PROVIDERS.map(({ id, name }) => ({ id, name, selected: id === next.id })),
+        providers: PROVIDERS.map(({ id, name, configurationContributionId }) => ({ id, name, configurationContributionId, selected: id === next.id })),
     };
 } else if (method === 'report') {
     output = { say: reportAgentOutcome(input) };

--- a/scripts/diagnostics/application/checkVoicePlugin.mjs
+++ b/scripts/diagnostics/application/checkVoicePlugin.mjs
@@ -20,10 +20,26 @@ const run = (method, input) => spawnSync(process.execPath, [rpc, method], {
     cwd: root,
     encoding: 'utf8',
     input: JSON.stringify(input ?? null),
-    env: { PATH: process.env.PATH, HOME: home, MUXR_HOME: home },
+    env: { PATH: process.env.PATH, HOME: home, MUXR_HOME: home, MUXR_PLUGIN_STATE_DIR: home },
 });
 
-let result = run('status');
+let result = run('provider.list');
+assert.equal(JSON.parse(result.stdout).selected, 'codex', 'fresh voice configuration defaults to Codex');
+const providers = JSON.parse(result.stdout).providers;
+const manifest = JSON.parse(readFileSync(join(root, 'plugins/voice/muxr-ui.json'), 'utf8'));
+for (const provider of providers) {
+    assert.ok(manifest.contributions.some((entry) => entry.slot === 'navigation.content' && entry.type === 'screen' && entry.id === provider.configurationContributionId), 'every provider has a configuration screen');
+}
+assert.equal(providers.find((entry) => entry.id === 'codex').configurationContributionId, 'login-screen');
+assert.ok(!manifest.contributions.some((entry) => entry.slot === 'settings.items'), 'setup must not duplicate the native provider picker');
+const loginScreen = manifest.contributions.find((entry) => entry.id === 'login-screen');
+assert.doesNotMatch(JSON.stringify(loginScreen), /secure-prompt|key-set|key-clear/, 'Codex login setup must not offer API-key actions');
+result = run('provider.set', { providerId: 'xai' });
+assert.equal(result.status, 0, result.stderr);
+assert.equal(JSON.parse(run('provider.list').stdout).selected, 'xai', 'explicit selection survives another invocation');
+assert.notEqual(run('provider.set', { providerId: 'unknown' }).status, 0);
+assert.equal(JSON.parse(run('provider.list').stdout).selected, 'xai', 'failed switch retains selection');
+result = run('status');
 assert.equal(result.status, 0);
 assertStatus(result, { configured: false, statusLabel: 'No key set' });
 result = run('key.set', { key: 'xai-test-not-a-live-secret' });
@@ -36,6 +52,9 @@ result = run('key.clear');
 assert.equal(result.status, 0, result.stderr);
 result = run('status');
 assertStatus(result, { configured: false, statusLabel: 'No key set' });
+result = run('provider.set', { providerId: 'codex' });
+assert.equal(result.status, 0, result.stderr);
+assert.equal(JSON.parse(run('provider.list').stdout).selected, 'codex');
 result = run('unknown');
 assert.notEqual(result.status, 0);
 const realtimeActions = readFileSync(join(root, 'apps/mobile/sources/conversation/application/realtimeActions.ts'), 'utf8');


### PR DESCRIPTION
Realtime voice settings could bypass provider selection or open API-key controls after Codex was selected. This restores one provider picker and makes Configure resolve the selected provider’s declared setup screen. Codex opens login setup, with no API-key actions, and becomes the default when no valid saved choice exists.

Provider policy stays in the backend plugin. Native realtime WebRTC and microphone-service ordering are unchanged. Independent code review PASS; existing voice RPC flow, 11 provider checks and one WebRTC flow pass. Live Codex entitlement/audio and rebuilt Android UI verification remain pending in consolidated release #209. No API credentials are exposed on mobile.
