### PR TITLE
fix: resolve cold session file links after catalog hydration

### DIFF
--- a/apps/mobile/sources/app/(app)/session/[id]/file.tsx
+++ b/apps/mobile/sources/app/(app)/session/[id]/file.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
-import { storage, useSessionFileCache } from '@/catalog/store';
+import { storage, useSession, useSessionFileCache, useSessionsLoaded } from '@/catalog/store';
 import { Modal } from '@/modal';
 import { t } from '@/text';
 import { resolveSessionFilePath } from '@/terminal';
@@ -13,6 +13,14 @@ interface FileContent {
     isBinary: boolean;
     deleted?: boolean;
 }
+
+/**
+ * How long a relative deep link waits for its session root before saying so.
+ * Longer than `waitUntilClientOpen`'s own 5 s reject (sync.ts:545), so a
+ * transport that is merely slow still wins and only a genuine failure to
+ * reach the host lands here.
+ */
+const ROOT_WAIT_MS = 8000;
 
 /**
  * Thin host-file adapter: load the session file and optional git patch, then
@@ -29,9 +37,42 @@ export default React.memo(function FileScreen() {
     const columnParam = searchParams.column as string | undefined;
     const requestedLine = lineParam ? Number.parseInt(lineParam, 10) : null;
     const requestedColumn = columnParam ? Number.parseInt(columnParam, 10) : null;
-    const session = storage.getState().sessions[sessionId!];
+    // `storage.getState()` is a snapshot, not a subscription. On a cold start
+    // the catalog has not hydrated yet, so this read returned undefined and
+    // nothing ever told React to look again - `sessionPath` stayed null for
+    // the life of the screen. `useSession` subscribes, so the effects below
+    // re-run the moment the session arrives.
+    const session = useSession(sessionId!);
+    const sessionsLoaded = useSessionsLoaded();
     const sessionPath = session?.metadata?.path ?? null;
     const resolvedPath = resolveSessionFilePath(rawPath, sessionPath);
+    // A relative path cannot be resolved without the session root:
+    // `resolvePath` returns null for it, and the old `?? rawPath` fallback
+    // then handed the host a relative string it resolved against its own cwd,
+    // producing an ENOENT alert on every cold deep link. An absolute path
+    // resolves with no root at all, so `rootMissing` is never true for one.
+    //
+    // `rootMissing` and `awaitingCatalog` are deliberately separate. Folding
+    // `!sessionsLoaded` into the first made a completed catalog that simply
+    // has no such session look resolvable, and the raw relative path went to
+    // the host after all - the exact misdiagnosis this change removes. A
+    // missing root is unavailable whether the catalog is still arriving or
+    // has arrived and does not contain it; only the waiting differs.
+    const rootMissing = resolvedPath === null;
+    // The wait is bounded. `sessionsLoaded` is only set on a successful
+    // refresh or when there is no transport at all, so a saved transport
+    // pointing at an unreachable host leaves it false forever and an
+    // unbounded wait would spin for the life of the screen. After
+    // `ROOT_WAIT_MS` we stop waiting and say so; the session subscription
+    // stays live, so if the catalog arrives later the screen still recovers.
+    //
+    // The deadline belongs to one target, not to the screen. Keyed by
+    // session and raw path, so timing out on A cannot deny B its own wait,
+    // and coming back to A starts a fresh one.
+    const targetKey = `${sessionId ?? ''}\u0000${rawPath}`;
+    const [expiredTarget, setExpiredTarget] = React.useState<string | null>(null);
+    const rootWaitExpired = expiredTarget === targetKey;
+    const awaitingCatalog = rootMissing && !sessionsLoaded && !rootWaitExpired;
     const filePath = resolvedPath?.absolutePath ?? rawPath;
     const fileName = filePath.split('/').pop() || filePath;
     const fileNavigation = sessionId === undefined || navKey === undefined
@@ -53,13 +94,52 @@ export default React.memo(function FileScreen() {
     const [alertable, setAlertable] = React.useState(true);
     const neighborLoads = React.useRef(new Map<string, { cancelled: boolean }>());
 
+    // One deadline per target. Any change of target drops the expiry recorded
+    // against the old one, so timing out on A cannot deny B its wait, and
+    // coming back to A later starts A's wait again rather than failing at
+    // once on a verdict reached minutes ago.
+    const lastTarget = React.useRef(targetKey);
+    if (lastTarget.current !== targetKey) {
+        lastTarget.current = targetKey;
+        if (expiredTarget !== null) setExpiredTarget(null);
+    }
+    React.useEffect(() => {
+        // Only while the root is genuinely missing and the catalog may still
+        // bring it. The cleanup clears the pending timer on retarget.
+        if (!rootMissing || sessionsLoaded || rootWaitExpired) return;
+        const timer = setTimeout(() => setExpiredTarget(targetKey), ROOT_WAIT_MS);
+        return () => { clearTimeout(timer); };
+    }, [rootMissing, rootWaitExpired, sessionsLoaded, targetKey]);
+
     React.useEffect(() => {
         const signal = { cancelled: false };
+        // Clear the previous file's state before anything else, so a stale
+        // error or a stale body can never be shown against a new target.
         setError(null);
+        setAlertable(true);
         setFileContent(cached ? { content: cached.content ?? '', isBinary: cached.isBinary, ...(cached.deleted === true ? { deleted: true } : {}) } : null);
         setDiffContent(cached?.diff ?? null);
         setIsLoading(cached === null);
         if (sessionId === undefined) return;
+        // Nothing to ask the host yet: the path is relative and the root that
+        // would make it absolute has not arrived. Stay loading rather than
+        // failing, and let the session landing here run this again.
+        if (awaitingCatalog) {
+            setIsLoading(true);
+            return;
+        }
+        // The root is not coming: either the wait ran out, or the catalog
+        // finished and has no such session. Say so in the screen rather than
+        // an alert, because retrying is the reader's call. The relative path
+        // is NOT sent to the host: it would resolve against the host's own
+        // working directory and report a missing file that is really a
+        // missing session, the misdiagnosis this change exists to fix.
+        if (rootMissing) {
+            setError(t('files.sessionRootUnavailable'));
+            setAlertable(false);
+            setIsLoading(false);
+            return;
+        }
         void loadSessionDocument(sessionId, filePath, sessionPath, signal).then((result) => {
             if (signal.cancelled || result.status === 'cancelled') return;
             // A folder is an expected destination, not a fault: it belongs in the
@@ -81,7 +161,9 @@ export default React.memo(function FileScreen() {
             setIsLoading(false);
         });
         return () => { signal.cancelled = true; };
-    }, [filePath, sessionId, sessionPath]);
+        // `cached` is deliberately not a dependency: the load writes the cache,
+        // so depending on it would re-enter this effect on its own result.
+    }, [awaitingCatalog, filePath, rootMissing, sessionId, sessionPath]);
 
     const previous = fileNavigation !== null && fileNavigation.index > 0 ? fileNavigation.entries[fileNavigation.index - 1] : undefined;
     const next = fileNavigation !== null && fileNavigation.index < fileNavigation.entries.length - 1

--- a/apps/mobile/sources/text/_default.ts
+++ b/apps/mobile/sources/text/_default.ts
@@ -530,6 +530,7 @@ export const en = {
         file: 'File',
         fileEmpty: 'File is empty',
         fileDeleted: 'This file no longer exists',
+        sessionRootUnavailable: 'This session is not available, so the file could not be located. Check the connection and try again.',
         previousDocument: 'Previous document',
         nextDocument: 'Next document',
         previousChange: 'Previous change',

--- a/apps/mobile/sources/text/translations/ca.ts
+++ b/apps/mobile/sources/text/translations/ca.ts
@@ -515,6 +515,7 @@ export const ca: TranslationStructure = {
         file: 'Fitxer',
         fileEmpty: 'El fitxer està buit',
         fileDeleted: 'Aquest fitxer ja no existeix',
+        sessionRootUnavailable: "Aquesta sessió no està disponible, així que no s'ha pogut localitzar el fitxer. Comprova la connexió i torna-ho a provar.",
         previousDocument: 'Document anterior',
         nextDocument: 'Document següent',
         previousChange: 'Canvi anterior',

--- a/apps/mobile/sources/text/translations/es.ts
+++ b/apps/mobile/sources/text/translations/es.ts
@@ -515,6 +515,7 @@ export const es: TranslationStructure = {
         file: 'Archivo',
         fileEmpty: 'El archivo está vacío',
         fileDeleted: 'Este archivo ya no existe',
+        sessionRootUnavailable: 'Esta sesión no está disponible, por lo que no se pudo localizar el archivo. Comprueba la conexión e inténtalo de nuevo.',
         previousDocument: 'Documento anterior',
         nextDocument: 'Documento siguiente',
         previousChange: 'Cambio anterior',

--- a/apps/mobile/sources/text/translations/it.ts
+++ b/apps/mobile/sources/text/translations/it.ts
@@ -514,6 +514,7 @@ export const it: TranslationStructure = {
         file: 'File',
         fileEmpty: 'File vuoto',
         fileDeleted: 'Questo file non esiste più',
+        sessionRootUnavailable: 'Questa sessione non è disponibile, quindi il file non è stato trovato. Controlla la connessione e riprova.',
         previousDocument: 'Documento precedente',
         nextDocument: 'Documento successivo',
         previousChange: 'Modifica precedente',

--- a/apps/mobile/sources/text/translations/ja.ts
+++ b/apps/mobile/sources/text/translations/ja.ts
@@ -517,6 +517,7 @@ export const ja: TranslationStructure = {
         file: 'ファイル',
         fileEmpty: 'ファイルは空です',
         fileDeleted: 'このファイルはもう存在しません',
+        sessionRootUnavailable: 'このセッションを利用できないため、ファイルを特定できませんでした。接続を確認して、もう一度お試しください。',
         previousDocument: '前のドキュメント',
         nextDocument: '次のドキュメント',
         previousChange: '前の変更',

--- a/apps/mobile/sources/text/translations/pl.ts
+++ b/apps/mobile/sources/text/translations/pl.ts
@@ -531,6 +531,7 @@ export const pl: TranslationStructure = {
         file: 'Plik',
         fileEmpty: 'Plik jest pusty',
         fileDeleted: 'Ten plik już nie istnieje',
+        sessionRootUnavailable: 'Ta sesja jest niedostępna, więc nie udało się odnaleźć pliku. Sprawdź połączenie i spróbuj ponownie.',
         previousDocument: 'Poprzedni dokument',
         nextDocument: 'Następny dokument',
         previousChange: 'Poprzednia zmiana',

--- a/apps/mobile/sources/text/translations/pt.ts
+++ b/apps/mobile/sources/text/translations/pt.ts
@@ -515,6 +515,7 @@ export const pt: TranslationStructure = {
         file: 'Arquivo',
         fileEmpty: 'Arquivo está vazio',
         fileDeleted: 'Este arquivo não existe mais',
+        sessionRootUnavailable: 'Esta sessão não está disponível, por isso não foi possível localizar o ficheiro. Verifica a ligação e tenta novamente.',
         previousDocument: 'Documento anterior',
         nextDocument: 'Próximo documento',
         previousChange: 'Alteração anterior',

--- a/apps/mobile/sources/text/translations/ru.ts
+++ b/apps/mobile/sources/text/translations/ru.ts
@@ -532,6 +532,7 @@ export const ru: TranslationStructure = {
         file: 'Файл',
         fileEmpty: 'Файл пустой',
         fileDeleted: 'Этот файл больше не существует',
+        sessionRootUnavailable: 'Эта сессия недоступна, поэтому файл не удалось найти. Проверьте подключение и попробуйте снова.',
         previousDocument: 'Предыдущий документ',
         nextDocument: 'Следующий документ',
         previousChange: 'Предыдущее изменение',

--- a/apps/mobile/sources/text/translations/zh-Hans.ts
+++ b/apps/mobile/sources/text/translations/zh-Hans.ts
@@ -517,6 +517,7 @@ export const zhHans: TranslationStructure = {
         file: '文件',
         fileEmpty: '文件为空',
         fileDeleted: '此文件已不存在',
+        sessionRootUnavailable: '此会话不可用，因此无法定位该文件。请检查连接后重试。',
         previousDocument: '上一份文档',
         nextDocument: '下一份文档',
         previousChange: '上一处更改',

--- a/apps/mobile/sources/text/translations/zh-Hant.ts
+++ b/apps/mobile/sources/text/translations/zh-Hant.ts
@@ -516,6 +516,7 @@ export const zhHant: TranslationStructure = {
         file: '檔案',
         fileEmpty: '檔案為空',
         fileDeleted: '此檔案已不存在',
+        sessionRootUnavailable: '此工作階段無法使用，因此找不到該檔案。請檢查連線後再試一次。',
         previousDocument: '上一份文件',
         nextDocument: '下一份文件',
         previousChange: '上一處變更',


### PR DESCRIPTION
Cold-start session file links with relative paths could reach the host before session metadata loaded, producing an ENOENT error against the host working directory. Subscribe to the session catalog, load only resolved paths, and show a bounded inline error when the root remains unavailable. Each target receives its own eight-second deadline; late hydration recovers. Absolute paths remain resolvable immediately.

Independent code review passed the frozen 11-file change: one route and one localized message across ten locale files. Owner reports typecheck clean and existing two flow files / nine tests passing. No device acceptance is claimed yet: the consolidated release APK must pass the unchanged cold relative line-200 assertion and the offline error check. This component is consolidated into draft release #209, not merged into main independently.
