### PR TITLE
test: add bounded local graphics and realtime voice probes

### DIFF
--- a/perf/lib/fakeStack.mjs
+++ b/perf/lib/fakeStack.mjs
@@ -13,7 +13,7 @@
  */
 import { spawnSync } from 'node:child_process';
 import { createServer } from 'node:net';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync, symlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync, symlinkSync, realpathSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { runCommand as run, spawnCommand as spawn, onCommandCleanup, commandSignal, assertCommandActive } from './commands.mjs';
@@ -92,8 +92,8 @@ async function relayHealthy(port) {
  * dropped: inheriting a machine id would retire the user's real host on their
  * real relay the moment ours connects.
  */
-function childEnv(home, muxrHome, extra) {
-    const env = { ...process.env, ...extra };
+function childEnv(home, muxrHome, extra, base = process.env) {
+    const env = { ...base, ...extra };
     for (const key of ['MUXR_RELAY_URL', 'MUXR_RELAY_TOKEN', 'MUXR_RELAY_AUTH', 'MUXR_MACHINE_ID', 'MUXR_MACHINE_NAME', 'MUXR_DATA_DIR', 'MUXR_MODE']) {
         if (!(key in (extra ?? {}))) delete env[key];
     }
@@ -112,6 +112,26 @@ function childEnv(home, muxrHome, extra) {
  *   terminalBytesPerSecond?: number, graphicsFrameHz?: number }} [options]
  */
 export async function startFakeStack(options = {}) {
+    return startStack(options);
+}
+
+/** Explicit live boundary: real auth HOME is never a cleanup or socket-write root. */
+export async function startLiveStack({ sourceRoot, authHome, socketPath, clientSocketPath, binPath }) {
+    const live = Object.fromEntries(Object.entries({ authHome, socketPath, clientSocketPath, binPath }).map(([key, path]) => {
+        if (typeof path !== 'string' || !path.startsWith('/')) throw new Error(`Live stack requires absolute ${key}`);
+        return [key, realpathSync(path)];
+    }));
+    if (!statSync(live.authHome).isDirectory()) throw new Error('Live auth HOME must be a directory');
+    for (const key of ['socketPath', 'clientSocketPath']) {
+        if (!statSync(live[key]).isSocket()) throw new Error(`Live ${key} must be an existing socket`);
+    }
+    if (!statSync(live.binPath).isFile()) throw new Error('Live Herdr CLI must be a file');
+    // Do not inherit relay identity, provider credentials, CODEX_HOME or fixture env.
+    live.env = Object.fromEntries(['PATH', 'LANG', 'LC_ALL'].filter((key) => process.env[key] !== undefined).map((key) => [key, process.env[key]]));
+    return startStack({ sourceRoot }, live);
+}
+
+async function startStack(options, live) {
     const sourceRoot = resolve(options.sourceRoot ?? '.');
     for (const entry of [RELAY_ENTRY, HOST_ENTRY]) {
         if (!existsSync(join(sourceRoot, entry))) throw new Error(`${entry} is missing; run \`yarn build\` first`);
@@ -155,11 +175,13 @@ export async function startFakeStack(options = {}) {
     // an adb dump - freezes every Herdr answer, which the phone sees as a
     // 15-second stall and reports as "reconnecting".
     const pluginsRoot = options.setupPlugins?.({ root, home, env: fixtureEnv }) ?? options.pluginsRoot;
-    const fake = await spawnFakeHerdr(join(root, 'herdr'), { ...options, pluginsRoot });
+    const fake = live ? { ...live, close() {} } : await spawnFakeHerdr(join(root, 'herdr'), { ...options, pluginsRoot });
     // Older host heads resolve the default HOME socket instead of the env override.
     // Keep both paths inside this run's isolated infrastructure.
-    mkdirSync(join(home, '.config/herdr'), { recursive: true });
-    symlinkSync(fake.socketPath, join(home, '.config/herdr/herdr.sock'));
+    if (!live) {
+        mkdirSync(join(home, '.config/herdr'), { recursive: true });
+        symlinkSync(fake.socketPath, join(home, '.config/herdr/herdr.sock'));
+    }
 
     const stop = () => {
         for (const child of children.splice(0)) {
@@ -189,7 +211,7 @@ export async function startFakeStack(options = {}) {
                 MUXR_RELAY_LOCAL_AUTHORITY: '1',
                 MUXR_RELAY_MDNS: '0',
                 MUXR_HOST_HTTP_URL: `http://127.0.0.1:${hostHttpPort}`,
-            }),
+            }, live?.env),
         });
         children.push(relay);
         relay.stdout.on('data', (chunk) => relayLog.push(String(chunk)));
@@ -206,16 +228,16 @@ export async function startFakeStack(options = {}) {
             '--port', String(relayPort),
             '--advertise', `ws://127.0.0.1:${relayPort}`,
             '--connection-mode', 'lan',
-        ], { cwd: sourceRoot, env: childEnv(home, muxrHome), timeout: 120_000 }).catch((cause) => {
+        ], { cwd: sourceRoot, env: childEnv(home, muxrHome, undefined, live?.env), timeout: 120_000 }).catch((cause) => {
             throw new Error(`self-host identity failed: ${cause instanceof Error ? cause.message : String(cause)}`);
         });
 
-        // The host under test, talking to the fake Herdr instead of the desk.
+        // Only an explicitly requested live probe connects to the real desk.
         const hostLog = [];
         const host = spawn(process.execPath, [join(sourceRoot, HOST_ENTRY)], {
             cwd: sourceRoot,
             stdio: ['ignore', 'pipe', 'pipe'],
-            env: childEnv(home, muxrHome, {
+            env: childEnv(live?.authHome ?? home, muxrHome, {
                 MUXR_MODE: 'selfhost',
                 MUXR_DATA_DIR: join(muxrHome, 'host'),
                 MUXR_HOST_HTTP_PORT: String(hostHttpPort),
@@ -224,7 +246,7 @@ export async function startFakeStack(options = {}) {
                 HERDR_CLIENT_SOCKET_PATH: fake.clientSocketPath,
                 HERDR_BIN: fake.binPath,
                 ...fixtureEnv,
-            }),
+            }, live?.env),
         });
         children.push(host);
         host.stdout.on('data', (chunk) => hostLog.push(String(chunk)));
@@ -263,7 +285,7 @@ export async function startFakeStack(options = {}) {
                 const pairing = spawn(process.execPath, [join(sourceRoot, 'scripts/cli.mjs'), 'pair'], {
                     cwd: sourceRoot,
                     stdio: ['ignore', 'pipe', 'pipe'],
-                    env: childEnv(home, muxrHome),
+                    env: childEnv(home, muxrHome, undefined, live?.env),
                 });
                 children.push(pairing);
                 const code = await new Promise((resolve) => {
@@ -285,7 +307,7 @@ export async function startFakeStack(options = {}) {
             stop,
         };
     } catch (cause) {
-        stop();
+        if (!live) stop();
         throw cause;
     }
 }

--- a/perf/liveProbe.mjs
+++ b/perf/liveProbe.mjs
@@ -1,0 +1,289 @@
+/** Local, supervised live probe. JSON commands on this dedicated shell's stdin. */
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir, homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { CommandScope, useCommandScope } from './lib/commands.mjs';
+import { startLiveStack } from './lib/fakeStack.mjs';
+import { pairPhone } from './lib/pairPhone.mjs';
+import { parseUiNodes } from './lib/gestureMetrics.mjs';
+import { sourceIdentity, harnessIdentity, patchedDependencies, sha256 } from './lib/provenance.mjs';
+
+const args = process.argv.slice(2);
+const option = (key) => args[args.indexOf(key) + 1];
+for (const key of ['--host-root', '--apk', '--out', '--auth-home', '--gate-report']) if (!args.includes(key)) throw new Error(`Required ${key}`);
+const hostRoot = realpathSync(option('--host-root')), apk = realpathSync(option('--apk'));
+const authHome = realpathSync(option('--auth-home')), out = resolve(option('--out'));
+const serial = 'emulator-5554', pkg = 'com.trymuxr.app';
+process.env.ANDROID_SERIAL = serial;
+const lock = `/tmp/muxr-pr-gate-${serial}.lock`;
+const scope = new CommandScope(); useCommandScope(scope);
+let operationDeadline = Infinity;
+const run = (bin, argv, options = {}) => {
+    const timeout = Math.min(options.timeout ?? 30000, operationDeadline - Date.now());
+    check(timeout > 0, 'Phase deadline reached');
+    return scope.run(bin, argv, { ...options, timeout });
+};
+const adb = async (...args) => (await run('adb', ['-s', serial, ...args], { timeout: 15_000 })).stdout;
+const shellQuote = (text) => `'${text.replaceAll("'", "'\\''")}'`;
+const check = (yes, why) => { if (!yes) throw new Error(why); };
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+const report = { startedAt: new Date().toISOString(), serial, checks: [], failures: [], acceptance: 'Pending supervised evidence review; never automatic live audio or GitHub paint PASS' };
+let scratchRoot, stack, ownsLock = false, ownsOut = false, deviceTouched = false, finishing = false, producer, tab, voiceTimer;
+let voicePhase = 'idle', voiceDeadline = 0;
+const save = (name, bytes) => writeFileSync(join(out, name), bytes);
+function publish(path) {
+    for (const pane of new Set([process.env.HERDR_PANE_ID, process.env.PERF_PARENT_PANE].filter(Boolean))) for (const app of ['.pocketherdr', '.muxr']) {
+        const dir = join(homedir(), app, 'attachments/pane', pane); mkdirSync(dir, { recursive: true });
+        copyFileSync(path, join(dir, `${basename(out)}-${basename(path)}`));
+    }
+}
+async function ui() {
+    await adb('shell', 'rm', '-f', '/sdcard/live-probe.xml');
+    await adb('shell', 'uiautomator', 'dump', '/sdcard/live-probe.xml');
+    const xml = await adb('shell', 'cat', '/sdcard/live-probe.xml');
+    check(xml.includes('<hierarchy'), 'Missing UI hierarchy'); return xml;
+}
+async function tap(text) {
+    const node = parseUiNodes(await ui()).find((node) => node.text === text || node.desc === text);
+    check(node && node.r > node.l && node.b > node.t, `Missing control ${text}`);
+    await adb('shell', 'input', 'tap', String((node.l + node.r) / 2), String((node.t + node.b) / 2));
+}
+async function capture(name) {
+    check(/^[a-z0-9-]+$/.test(name), 'Invalid evidence name');
+    save(`${name}.xml`, await ui());
+    save(`${name}.png`, (await run('adb', ['-s', serial, 'exec-out', 'screencap', '-p'], { timeout: 15_000, encoding: 'buffer' })).stdout);
+    publish(join(out, `${name}.png`));
+}
+const herdr = async (...args) => JSON.parse((await run('/usr/bin/herdr', args, { timeout: 15_000 })).stdout);
+async function open(uri) {
+    check(uri.startsWith('muxr:///') || uri.startsWith('muxr://session/'), 'Only muxr routes allowed');
+    await adb('shell', 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', shellQuote(uri), pkg);
+}
+async function maestro(_flow, variables) {
+    // Pairing credentials and Maestro output remain in private fresh scratch.
+    const argv = ['x', 'maestro@cli-2.7.0', '--', 'maestro', '--device', serial, 'test', '--debug-output', join(scratchRoot, 'maestro'), ...Object.entries(variables).flatMap(([k, v]) => ['-e', `${k}=${v}`]), 'perf/flows/pair.yaml'];
+    try { await run('mise', argv, { timeout: 160_000 }); return { code: 0, output: '' }; }
+    catch { return { code: 1, output: 'Pairing flow failed (private diagnostics)' }; }
+}
+function processStart(pid) {
+    try { return readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1].split(' ')[19]; } catch { return null; }
+}
+async function retireProducer() {
+    if (!producer || !processStart(producer.pid)) return;
+    check(processStart(producer.pid) === producer.start, 'Producer PID reused; refusing signal');
+    report.retirementSignalAt ??= new Date().toISOString();
+    process.kill(producer.pid, 'SIGTERM');
+    const end = Date.now() + 5000;
+    while (processStart(producer.pid) === producer.start && Date.now() < end) await sleep(100);
+    if (processStart(producer.pid) === producer.start) {
+        process.kill(producer.pid, 'SIGKILL');
+        const killEnd = Date.now() + 5000;
+        while (processStart(producer.pid) === producer.start && Date.now() < killEnd) await sleep(100);
+        check(processStart(producer.pid) !== producer.start, 'Owned producer did not terminate; retain lock');
+    }
+    report.retiredAt ??= new Date().toISOString();
+}
+async function memory(label, pid) {
+    check((await adb('shell', 'pidof', pkg)).trim() === pid, 'APK process died or changed');
+    const at = new Date().toISOString();
+    const raw = await adb('shell', 'dumpsys', 'meminfo', pid);
+    save(`${label}-meminfo.txt`, `${at}\n${raw}`);
+    const pss = Number(/TOTAL PSS:\s+(\d+)/.exec(raw)?.[1]);
+    check(Number.isFinite(pss) && pss > 0, 'Missing TOTAL PSS');
+    const completedAt = new Date().toISOString();
+    const phase = !producer ? 'baseline' : !report.retirementSignalAt || completedAt < report.retirementSignalAt ? 'paint' : report.retiredAt && at >= report.retiredAt ? 'retired' : 'transition';
+    const sample = { at, completedAt, phase, label, pid, pssKiB: pss, nativeHeapKiB: Number(/Native Heap:\s+(\d+)/.exec(raw)?.[1]), javaHeapKiB: Number(/Java Heap:\s+(\d+)/.exec(raw)?.[1]) };
+    check(Number.isFinite(sample.nativeHeapKiB) && Number.isFinite(sample.javaHeapKiB), 'Missing heap evidence');
+    (report.memory ??= []).push(sample);
+    check(pss <= 900000, `Memory stop: ${pss}KiB exceeds 900000KiB`);
+}
+async function github() {
+    check(tab && !producer, 'Create owned producer pane and mount it first');
+    const xml = await ui(); check(/text="(Terminal|ctrl)"/.test(xml), 'Terminal not mounted before producer');
+    const pid = (await adb('shell', 'pidof', pkg)).trim(); check(/^\d+$/.test(pid), 'Expected one APK PID');
+    await memory('baseline', pid);
+    // This script reports its own PID before exec; only that exact PID/start is retired.
+    const pidFile = join(scratchRoot, 'producer.pid');
+    const script = join(scratchRoot, 'producer.sh');
+    writeFileSync(script, `#!/bin/sh\necho $$ > ${shellQuote(pidFile)}\nexec terminal-browser open --no-toolbar --no-merge --no-frame https://github.com/\n`, { mode: 0o700 });
+    const launchAt = Date.now();
+    const paintDeadline = launchAt + 20000;
+    report.producerLaunchAt = new Date(launchAt).toISOString();
+    operationDeadline = paintDeadline;
+    const paintStop = setTimeout(() => void finish(new Error('Producer exceeded launch-to-retirement cap')), 20000);
+    try {
+        await herdr('pane', 'run', tab.pane, `${shellQuote(script)}; printf '\\nMEMORY PROBE RETIRED\\n'`);
+        const end = Math.min(Date.now() + 5000, paintDeadline);
+        while (!existsSync(pidFile) && Date.now() < end) await sleep(100);
+        check(existsSync(pidFile), 'Owned producer did not announce PID');
+        const producerPid = Number(readFileSync(pidFile, 'utf8').trim());
+        check(Number.isSafeInteger(producerPid) && producerPid > 1, 'Invalid owned PID');
+        producer = { pid: producerPid, start: processStart(producerPid) }; check(producer.start, 'Producer exited before identity capture');
+        report.producer = { ...producer, pane: tab.pane, url: 'https://github.com/' };
+        const deadline = paintDeadline - 1000;
+        for (let i = 0; Date.now() < deadline; i++) {
+            await memory(`paint-${i}`, pid);
+            if (i === 2) {
+                await capture('github-paint');
+                const inventory = JSON.parse((await run('terminal-browser', ['ls', '--all', '--json'], { timeout: 10000 })).stdout);
+                const owned = inventory.browsers.filter((browser) => browser.pane?.pane === tab.pane);
+                check(owned.length === 1, 'Cannot bind painted browser to owned pane');
+                report.browser = { key: owned[0].key, pid: owned[0].pid, pane: owned[0].pane, tabs: owned[0].tabs.map(({ id, url, title }) => ({ id, url, title })) };
+            }
+            await sleep(Math.min(2000, Math.max(0, deadline - Date.now())));
+        }
+    } finally { operationDeadline = Infinity; clearTimeout(paintStop); await retireProducer(); }
+    const retirementDeadline = Date.now() + 20000;
+    operationDeadline = retirementDeadline;
+    try {
+        for (let i = 0; Date.now() < retirementDeadline; i++) {
+            await memory(`retired-${i}`, pid);
+            await sleep(Math.min(2000, Math.max(0, retirementDeadline - Date.now())));
+        }
+    } finally { operationDeadline = Infinity; }
+    await capture('github-retired');
+    report.retiredPane = (await run('/usr/bin/herdr', ['pane', 'read', tab.pane, '--source', 'visible', '--lines', '8'], { timeout: 10000 })).stdout;
+    check(report.retiredPane?.includes('MEMORY PROBE RETIRED'), 'Owned shell did not return');
+    report.checks.push('GitHub bounded memory window complete; screenshots require actual painted-page review');
+}
+async function command(input) {
+    check(input && !Array.isArray(input) && typeof input === 'object', 'Expected command object');
+    check(Object.entries(input).every(([key, value]) => ['op', 'text', 'uri', 'name'].includes(key) && typeof value === 'string' && value.length <= 2048), 'Invalid command fields');
+    const { op, text, uri, name } = input;
+    if (op === 'capture') return capture(name);
+    if (op === 'tap') return tap(text);
+    if (op === 'open') return open(uri);
+    if (op === 'back') return adb('shell', 'input', 'keyevent', 'KEYCODE_BACK');
+    if (op === 'pane') {
+        check(!tab, 'Probe pane already exists');
+        const result = (await herdr('tab', 'create', '--workspace', process.env.HERDR_PANE_ID.split(':')[0], '--cwd', scratchRoot, '--label', 'Owned live graphics probe', '--no-focus')).result;
+        tab = { id: result.tab.tab_id, pane: result.root_pane.pane_id };
+        await herdr('pane', 'run', tab.pane, "printf '\\nMEMORY PROBE READY\\n'");
+        await herdr('tab', 'focus', tab.id);
+        await open(`muxr://session/${encodeURIComponent(`shell:${tab.pane}`)}`);
+        report.probePane = tab; return;
+    }
+    if (op === 'github') return github();
+    if (op === 'voice-start') {
+        check(voicePhase === 'idle', 'Voice attempt already used');
+        voicePhase = 'establishing'; voiceDeadline = Date.now() + 30000;
+        voiceTimer = setTimeout(() => void finish(new Error('Voice establishment exceeded 30 seconds')), 30000);
+        report.voiceStartedAt = new Date().toISOString();
+        return tap(text);
+    }
+    if (op === 'voice-connected') {
+        check(voicePhase === 'establishing' && Date.now() < voiceDeadline, 'Invalid voice connection transition');
+        voicePhase = 'connected'; voiceDeadline = Date.now() + 30000;
+        clearTimeout(voiceTimer);
+        voiceTimer = setTimeout(() => void finish(new Error('Voice interaction exceeded 30 seconds')), 30000);
+        report.voiceConnectedObservationAt = new Date().toISOString();
+        report.checks.push('Operator observed connection; real audio proof still requires separate evidence');
+        return;
+    }
+    if (op === 'voice-end') {
+        check(['establishing', 'connected'].includes(voicePhase), 'No active voice attempt');
+        voicePhase = 'ending';
+        await tap(text); // Existing absolute deadline stays armed until finish forces stop.
+        report.voiceEndRequestedAt = new Date().toISOString();
+        return;
+    }
+    if (op === 'voice-state') {
+        check(/^[a-z0-9-]+$/.test(name), 'Invalid voice state name');
+        save(`${name}-service.txt`, await adb('shell', 'dumpsys', 'activity', 'services', pkg));
+        save(`${name}-mic.txt`, await adb('shell', 'cmd', 'appops', 'get', pkg, 'RECORD_AUDIO'));
+        return capture(name);
+    }
+    if (op === 'finish') return finish();
+    throw new Error('Unknown probe command');
+}
+async function finish(error) {
+    if (finishing) return; finishing = true; clearTimeout(watchdog); clearTimeout(voiceTimer);
+    if (error) report.failures.push(error.message ?? String(error));
+    if (!ownsOut) { console.error('Probe setup failed before creating evidence:', report.failures); process.exit(1); }
+    let clean = true;
+    if (report.producerLaunchAt && !producer) { clean = false; report.failures.push('Producer launch lacks PID ownership proof; retaining lock and scratch'); }
+    try { await retireProducer(); } catch (cause) { report.failures.push(cause.message); clean = false; }
+    try { await scope.close(); } catch (cause) { report.failures.push(cause.message); clean = false; }
+    const diagnostics = new CommandScope();
+    const cleanupStep = async (action) => { try { await action(); } catch (cause) { clean = false; report.failures.push(cause.message); } };
+    if (deviceTouched) await cleanupStep(async () => {
+        await diagnostics.run('adb', ['-s', serial, 'shell', 'am', 'force-stop', pkg], { timeout: 15000 });
+        const status = await diagnostics.run('adb', ['-s', serial, 'shell', `pidof ${pkg} || true`], { timeout: 10000 });
+        check(status.stdout.trim() === '', 'APK remains after force-stop');
+    });
+    if (tab) await cleanupStep(() => diagnostics.run('/usr/bin/herdr', ['tab', 'close', tab.id], { timeout: 15000 }));
+    await cleanupStep(() => diagnostics.close());
+    if (clean) {
+        scope.cleanup();
+        if (scratchRoot) rmSync(scratchRoot, { recursive: true, force: true });
+        if (ownsLock) rmSync(lock, { recursive: true, force: true });
+    }
+
+    try {
+        check(sourceIdentity(hostRoot).sourceSha256 === report.host.sourceSha256, 'Host source changed');
+        check(sha256(join(hostRoot, 'apps/host/dist/main.js')) === report.host.entrySha256, 'Built host changed');
+        check(harnessIdentity().sha256 === report.harness.sha256, 'Harness changed');
+        check(JSON.stringify(patchedDependencies(hostRoot)) === JSON.stringify(report.apk.nativeDependencies), 'Native dependency bytes changed');
+        report.finalFreeze = true;
+    } catch (cause) { report.failures.push(cause.message); }
+    report.cleanup = clean; report.finishedAt = new Date().toISOString();
+    save('report.json', JSON.stringify(report, null, 2)); publish(join(out, 'report.json'));
+    const exporter = new CommandScope();
+    try {
+        const archive = `${out}.tar.gz`;
+        await exporter.run('tar', ['-czf', archive, '-C', out, '.'], { timeout: 30000 });
+        publish(archive);
+    } catch (cause) { console.error('Evidence archive failed:', cause.message); process.exitCode = 1; }
+    await exporter.close();
+    process.exit(report.failures.length || process.exitCode ? 1 : 0);
+}
+const watchdog = setTimeout(() => void finish(new Error('Live probe exceeded 10-minute deadline')), 600000);
+process.once('SIGTERM', () => void finish(new Error('Interrupted')));
+process.once('SIGINT', () => void finish(new Error('Interrupted')));
+async function main() {
+    mkdirSync(out); ownsOut = true; // Require a new evidence directory; never overwrite failed runs.
+    mkdirSync(lock); ownsLock = true;
+    writeFileSync(join(lock, 'owner.json'), JSON.stringify({ pid: process.pid, pane: process.env.HERDR_PANE_ID, startedAt: report.startedAt }));
+    scratchRoot = mkdtempSync(join(tmpdir(), 'muxr-live-probe-'));
+    report.apk = JSON.parse(readFileSync(`${apk}.json`, 'utf8'));
+    report.host = sourceIdentity(hostRoot); report.harness = harnessIdentity();
+    check(report.apk.variant === 'release' && /^[a-f0-9]{40}$/.test(report.apk.revision), 'Missing release revision');
+    check(report.apk.nativeDependencies && Object.keys(report.apk.nativeDependencies).length > 0, 'Missing native provenance');
+    check(report.apk.apkSha256 === sha256(apk), 'APK manifest mismatch');
+    check(report.apk.mobileSha256 === report.host.mobileSha256, 'APK mobile mismatch');
+    check(JSON.stringify(report.apk.nativeDependencies) === JSON.stringify(patchedDependencies(hostRoot)), 'APK native mismatch');
+    report.host.entrySha256 = sha256(join(hostRoot, 'apps/host/dist/main.js'));
+    const gate = JSON.parse(readFileSync(option('--gate-report'), 'utf8'));
+    check(gate.passed === true && gate.flow === 'full', 'Require a completed passing full gate');
+    check(gate.host.sourceSha256 === report.host.sourceSha256 && gate.host.entrySha256 === report.host.entrySha256, 'Host dist/source not bound to matching full-gate build');
+    check(gate.installedApkSha256 === report.apk.apkSha256, 'Full-gate APK mismatch');
+    report.buildEvidence = { path: resolve(option('--gate-report')), sha256: sha256(option('--gate-report')), host: gate.host, installedApkSha256: gate.installedApkSha256 };
+    const installed = (await adb('shell', 'pm', 'path', pkg)).trim().replace(/^package:/, '');
+    const pull = join(scratchRoot, 'installed.apk'); await adb('pull', installed, pull);
+    check(sha256(pull) === report.apk.apkSha256, 'Installed APK mismatch'); report.installedApkSha256 = sha256(pull);
+    deviceTouched = true;
+    await adb('shell', 'pm', 'clear', pkg);
+    stack = await startLiveStack({ sourceRoot: hostRoot, authHome, socketPath: join(authHome, '.config/herdr/herdr.sock'), clientSocketPath: join(authHome, '.config/herdr/herdr-client.sock'), binPath: '/usr/bin/herdr' });
+    report.pairing = await pairPhone({ stack, maestro, attempts: 1, patienceSeconds: 30 });
+    check(report.pairing.ok, report.pairing.why);
+    await sleep(8000);
+    const xml = await ui();
+    if (xml.includes('Show live agent updates?')) await tap('CANCEL');
+    check(/text="LIVE"/.test(await ui()), 'Paired herd did not mount');
+    console.log('LIVE_PROBE_READY: JSON stdin commands capture/tap/open/back/pane/github/voice-state/finish');
+    // Stream backpressure bounds queued chunks; cap both framing and command size.
+    let pending = '';
+    for await (const chunk of process.stdin) {
+        check(chunk.length <= 4096 && Buffer.byteLength(pending) + chunk.length <= 4096, 'Command input exceeds 4096 bytes');
+        pending += chunk.toString('utf8');
+        while (pending.includes('\n')) {
+            const newline = pending.indexOf('\n');
+            const line = pending.slice(0, newline); pending = pending.slice(newline + 1);
+            if (finishing) return;
+            await command(JSON.parse(line)); console.log('COMMAND_DONE');
+        }
+    }
+    check(pending.trim() === '', 'Incomplete command at EOF');
+    await finish();
+}
+main().catch((error) => void finish(error));


### PR DESCRIPTION
Add local real-producer and realtime voice probes after a successful provenance-matched full emulator gate. The runner binds the installed APK and built host to that report, isolates test state while using the intended local authentication, and scopes producer lifetime, device ownership, input size, and cleanup.

Independent review passed the frozen runner and live-stack boundary, including demonstrated cleanup-failure and repeated voice-transition checks. No real startup or audio/graphics acceptance is claimed by this commit. Those results must come from the consolidated release run; human speech and audible reply remain separate evidence. Local tooling only; no GitHub emulator workflow. Consolidates into draft #209.
