### PR TITLE
fix: reconnect when the initial authenticated host hello times out

### DIFF
--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.spec.ts
@@ -107,7 +107,7 @@ describe('mobile relay liveness', () => {
         vi.useRealTimers();
     });
 
-    it('proves host liveness, reconnects a closed route, and replaces a timed-out half-open route', async () => {
+    it('recovers a silent initial hello, proves host liveness, and replaces closed or half-open routes', async () => {
         vi.useFakeTimers();
         vi.stubGlobal('WebSocket', FakeWebSocket);
         resetConnectionDiagnostics();
@@ -120,9 +120,21 @@ describe('mobile relay liveness', () => {
         });
         client.connect();
         await Promise.resolve();
-        const first = FakeWebSocket.current!;
+        const silent = FakeWebSocket.current!;
         expect(client.isLive()).toBe(false);
         await expect(client.request('herdr.tree', {})).rejects.toThrow('not connected');
+        await vi.advanceTimersByTimeAsync(24);
+        expect(client.state).toBe('connecting');
+        expect(silent.readyState).toBe(FakeWebSocket.OPEN);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(client.state).toBe('closed');
+        expect(silent.readyState).not.toBe(FakeWebSocket.OPEN);
+        expect(formatConnectionDiagnosticsForReport()).toMatch(/socket\.fail liveness no-host-frame/);
+
+        await vi.advanceTimersByTimeAsync(10);
+        const first = FakeWebSocket.current!;
+        expect(first).not.toBe(silent);
+        expect(client.isLive()).toBe(false);
         first.onmessage?.({ data: JSON.stringify({
             header: { machineId: 'machine-1', seq: 1, at: Date.now() },
             payload: encodePayload({ type: 'plugins.invalidated', reason: 'changed', pluginIds: ['example.ui'] } as never),
@@ -130,7 +142,13 @@ describe('mobile relay liveness', () => {
         await Promise.resolve();
         expect(client.state).toBe('open');
         expect(client.isLive()).toBe(true);
+        // A frame already decoding must not revive a socket retired meanwhile.
+        first.onmessage?.({ data: JSON.stringify({
+            header: { machineId: 'machine-1', seq: 2, at: Date.now() },
+            payload: encodePayload({ type: 'plugins.invalidated', reason: 'changed', pluginIds: ['example.ui'] } as never),
+        }) });
         first.failClose(1012, 'raw relay restart with internal details');
+        await Promise.resolve();
         expect(client.state).toBe('closed');
         const report = formatConnectionDiagnosticsForReport();
         expect(report).toMatch(/socket\.fail close socket-closed 1012 service-restart/);

--- a/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
+++ b/apps/mobile/sources/pairing/infrastructure/muxrClient.ts
@@ -236,6 +236,8 @@ export class MuxrClient {
                     stage: 'liveness',
                     code: sawHostFrame ? 'all-frames-rejected' : 'no-host-frame',
                 });
+                this.retireSocket(socket);
+                socket.close();
             }, this.options.requestTimeoutMs ?? 20_000);
         };
         socket.onmessage = (message: MessageEvent) => {
@@ -418,6 +420,8 @@ export class MuxrClient {
             this.recordDecodeFailure(socket, 'open-failed');
             return;
         }
+
+        if (this.socket !== socket) return;
 
         // Socket open only proves the relay accepted us; the first frame that
         // survives the machine's E2EE context proves the host is really there.


### PR DESCRIPTION
A newly paired phone can send its first encrypted hello before the host reloads enrollment. The current liveness timer only logs the missing authenticated response, leaving an open socket stuck connecting. Retire and close that socket at the existing deadline so the normal admission/reconnect path can recover; ignore decoded results from an already retired socket.

Four production lines plus an extension to the existing liveness flow. Independent review passed: focused flow 4/4 (baseline 3/4), generated-key real client/host encrypted automatic recovery, and strict crypto self-check. Encryption, permanent credential refusal, the existing deadline, and admission logic remain intact. The controlled reproduction proves the race mechanism; device diagnostics are consistent with it and recovered after reopening the same enrollment.

A fresh consolidated APK and full local gate/live probes are required before release acceptance. This component targets draft release #209, not main independently.
