### PR TITLE
fix: select realtime voice targets from fresh live sessions

### DIFF
--- a/apps/mobile/sources/conversation/application/realtimeSessionState.ts
+++ b/apps/mobile/sources/conversation/application/realtimeSessionState.ts
@@ -110,19 +110,39 @@ export function realtimeMachineSwitchGuard(machineId: string): RealtimeMachineSw
 /** Desk focus only if that agent is busy; otherwise the phone's last session. */
 export async function resolveRealtimeTarget(): Promise<RealtimeTarget | null> {
     const machineId = getCachedConnectionSettings().machineId;
-    const tree = await sync.request('herdr.tree', {}).catch(() => undefined);
-    const focused = tree?.workspaces
+    // The local catalog can contain routes from a previous Herdr snapshot. Resolve
+    // only against the two fresh host views: session.list is the authoritative
+    // session inventory and herdr.tree supplies the pane-to-route membership.
+    const fresh = await Promise.all([
+        sync.request('herdr.tree', {}),
+        sync.request('session.list', {}),
+    ]).catch(() => undefined);
+    if (fresh === undefined) return null;
+    const [tree, listedSessions] = fresh;
+    if (!Array.isArray(listedSessions) || !Array.isArray(tree?.workspaces)
+        || !tree.workspaces.every((workspace) => workspace !== null && typeof workspace === 'object'
+            && Array.isArray(workspace.tabs)
+            && workspace.tabs.every((tab) => tab !== null && typeof tab === 'object' && Array.isArray(tab.panes)))) return null;
+    const listedIds = new Set(listedSessions
+        .filter((session) => typeof session?.id === 'string' && session.id !== '')
+        .map((session) => session.id));
+    const liveRoutes = new Set(tree.workspaces
+        .flatMap((workspace) => workspace.tabs)
+        .flatMap((tab) => tab.panes)
+        .flatMap((pane) => typeof pane.sessionId === 'string' && listedIds.has(pane.sessionId) ? [pane.sessionId] : []));
+    if (liveRoutes.size === 0) return null;
+    const focused = tree.workspaces
         .filter((workspace) => workspace.focused)
         .flatMap((workspace) => workspace.tabs.filter((tab) => tab.focused))
         .flatMap((tab) => tab.panes)
-        .find((pane) => pane.focused && pane.sessionId !== undefined);
-    const sessions = Object.values(storage.getState().sessions);
+        .find((pane) => pane.focused && typeof pane.sessionId === 'string' && liveRoutes.has(pane.sessionId));
+    const sessions = Object.values(storage.getState().sessions).filter((session) => liveRoutes.has(session.id));
     const focusedRoute = focusAgent({
         machineId,
         deskFocus: focused?.sessionId === undefined
             ? undefined
             : { agentRoute: focused.sessionId, agentStatus: focused.agentStatus },
-        remembered: realtimeTarget === null
+        remembered: realtimeTarget === null || !liveRoutes.has(realtimeTarget.sessionId)
             ? null
             : { machineId: realtimeTarget.machineId, agentRoute: realtimeTarget.sessionId },
         listed: sessions.map((session) => ({

--- a/apps/mobile/sources/conversation/application/realtimeSessionState.ts
+++ b/apps/mobile/sources/conversation/application/realtimeSessionState.ts
@@ -122,7 +122,9 @@ export async function resolveRealtimeTarget(): Promise<RealtimeTarget | null> {
     if (!Array.isArray(listedSessions) || !Array.isArray(tree?.workspaces)
         || !tree.workspaces.every((workspace) => workspace !== null && typeof workspace === 'object'
             && Array.isArray(workspace.tabs)
-            && workspace.tabs.every((tab) => tab !== null && typeof tab === 'object' && Array.isArray(tab.panes)))) return null;
+            && workspace.tabs.every((tab) => tab !== null && typeof tab === 'object'
+                && Array.isArray(tab.panes)
+                && tab.panes.every((pane) => pane !== null && typeof pane === 'object')))) return null;
     const listedIds = new Set(listedSessions
         .filter((session) => typeof session?.id === 'string' && session.id !== '')
         .map((session) => session.id));

--- a/apps/mobile/sources/utils/dictation.spec.ts
+++ b/apps/mobile/sources/utils/dictation.spec.ts
@@ -233,7 +233,7 @@ describe('on-device dictation flow', () => {
         mocks.syncRequest.mockRejectedValue(new Error('fresh route unavailable'));
         await expect(resolveRealtimeTarget()).resolves.toBeNull();
         mocks.syncRequest.mockImplementation(async (method: string) => method === 'herdr.tree'
-            ? { workspaces: [{ tabs: null }] }
+            ? { workspaces: [{ tabs: [{ panes: [null] }] }] }
             : [{ id: 'live-session' }]);
         await expect(resolveRealtimeTarget()).resolves.toBeNull();
     });

--- a/apps/mobile/sources/utils/dictation.spec.ts
+++ b/apps/mobile/sources/utils/dictation.spec.ts
@@ -198,12 +198,15 @@ describe('on-device dictation flow', () => {
     });
 
     it('starts notification Talk on the pane last used on the phone, not a stale desk focus', async () => {
-        mocks.syncRequest.mockResolvedValue({
+        const tree = {
             workspaces: [
                 { focused: true, tabs: [{ focused: true, panes: [{ sessionId: 'session-a', focused: true, agentStatus: 'idle' }] }] },
                 { focused: false, tabs: [{ focused: true, panes: [{ sessionId: 'session-b', focused: true, agentStatus: 'working' }] }] },
             ],
-        });
+        };
+        mocks.syncRequest.mockImplementation(async (method: string) => method === 'herdr.tree'
+            ? tree
+            : method === 'session.list' ? [{ id: 'session-a' }, { id: 'session-b' }] : { text: 'unused' });
         const setMuted = vi.fn();
         mocks.startRealtimeSession.mockReturnValue({ stop: vi.fn(), setMuted, speak: vi.fn() });
         await expect(resolveRealtimeTarget()).resolves.toEqual({ machineId: '', sessionId: 'session-b' });
@@ -215,6 +218,24 @@ describe('on-device dictation flow', () => {
 
         mocks.notificationAction?.('mute');
         expect(setMuted).toHaveBeenCalledWith(true);
+    });
+
+    it('keeps a newer historical route out of notification voice targeting', async () => {
+        mocks.sessions = {
+            'live-session': { id: 'live-session', activeAt: 1, updatedAt: 1 },
+            'historical-session': { id: 'historical-session', activeAt: 99, updatedAt: 99 },
+        };
+        mocks.syncRequest.mockImplementation(async (method: string) => method === 'herdr.tree'
+            ? { workspaces: [{ focused: true, tabs: [{ focused: true, panes: [{ sessionId: 'live-session', focused: true, agentStatus: 'idle' }] }] }] }
+            : method === 'session.list' ? [{ id: 'live-session' }] : { text: 'unused' });
+
+        await expect(resolveRealtimeTarget()).resolves.toEqual({ machineId: '', sessionId: 'live-session' });
+        mocks.syncRequest.mockRejectedValue(new Error('fresh route unavailable'));
+        await expect(resolveRealtimeTarget()).resolves.toBeNull();
+        mocks.syncRequest.mockImplementation(async (method: string) => method === 'herdr.tree'
+            ? { workspaces: [{ tabs: null }] }
+            : [{ id: 'live-session' }]);
+        await expect(resolveRealtimeTarget()).resolves.toBeNull();
     });
 
     it('keeps live-session standby enabled and arms it once realtime ends', async () => {


### PR DESCRIPTION
The global realtime voice shortcut could select a newer historical session from mobile storage even when that route no longer existed on the host, producing “That agent is no longer available.”

Restrict remembered and fallback targets to the intersection of fresh host session inventory and tree pane membership. Preserve focus and machine checks, and return no target when fresh RPC data is unavailable or malformed, including null pane entries.

Validation: existing dictation flow 8/8 passed; independent review of the corrected two-file change passed. Native voice transport and provider adapters are unchanged. This mobile change still requires a fresh consolidated APK/full emulator gate and live voice validation; no audio or entitlement PASS is claimed.

Consolidation target: #209. Signed commits 75548353 and 02050909.
