### PR TITLE
test: preserve browser cleanup followup for local probes

### DIFF
--- a/perf/liveProbe.mjs
+++ b/perf/liveProbe.mjs
@@ -241,8 +241,18 @@ async function github() {
             }
             await sleep(Math.min(2000, Math.max(0, deadline - Date.now())));
         }
-    } finally { operationDeadline = Infinity; clearTimeout(paintStop); await retireProducer(); }
-    await retireOwnedBrowser(report.browser);
+    } finally {
+        operationDeadline = Infinity;
+        clearTimeout(paintStop);
+        try {
+            await retireProducer();
+        } finally {
+            // Retire only the browser bound to this run. Keep this nested
+            // finally so a controller retirement failure cannot strand the
+            // owned browser or pane. A failed browser cleanup retains lock.
+            if (report.browser) await retireOwnedBrowser(report.browser);
+        }
+    }
     const retirementDeadline = Date.now() + 20000;
     operationDeadline = retirementDeadline;
     try {


### PR DESCRIPTION
A failed GitHub paint assertion exits before the normal owned-browser shutdown. Put pane-bound browser retirement in a nested finally so it is attempted even when controller retirement throws.

This PR preserves the remaining local harness work for consolidation review. **Draft: not ready to merge or run as live acceptance.**

Validation: syntax and diff checks pass. Focused review confirmed independent cleanup attempts, but root follow-up found an unresolved end-to-end cleanup issue: if browser retirement itself throws, finish(error) starts clean=true and may remove the lock/scratch after its other cleanup steps, without proving browser absence. The earlier review claim that propagating the error alone guarantees lock retention is superseded. Finish must account for browser cleanup failure or retry/verify its absence before clean=true.

Real GitHub body paint remains unverified. The existing probe checks once around 4–7 seconds despite a 20-second budget; timestamped repeated strict body checks within the same absolute budget are proposed, not implemented here. No cap extension or weaker pixel assertion is included.

Only perf/liveProbe.mjs changes. No production/mobile change, APK build, device run, or audio acceptance is claimed for this commit. Release #209 stays at the tested 32edfc54 while this followup is held. User requested consolidation and reduced agent activity, so no further probe work is being started.
