### PR TITLE
fix(release): keep Bundler caches out of source provenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ dist-npm/
 # git worktrees for parallel sessions
 .dev/
 .firecrawl/
+
+# ruby/setup-ruby local Bundler configuration and downloaded gems
+/.bundle/
+/vendor/bundle/


### PR DESCRIPTION
The first automated beta stopped before Gradle because ruby/setup-ruby creates `.bundle/config` and downloads gems into `vendor/bundle`, making the clean checkout appear dirty. Ignore those two generated cache directories so the existing strict provenance guard can run.

Validation: reproduced both untracked paths, then verified sourceIdentity reports clean with caches present; a new application source file still reports dirty and changes the source digest. No application or provenance guard changes. Failed beta run: https://github.com/umeranjum17/muxr/actions/runs/33952896064.
