### PR TITLE
fix(release): pass selected app version to beta web export

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -96,6 +96,11 @@ jobs:
         # Smoke builds its own stable fixture. Final packaging below uses the selected version.
         run: env -u MUXR_RELEASE_VERSION -u MUXR_RELEASE_CHANNEL node scripts/diagnostics/application/checkPackageSmoke.mjs
       - name: Pack candidate once
+        # The Expo config rejects a release identity whose base version differs
+        # from the native app version, so pass the selected one to this step
+        # only; the smoke above deliberately keeps the repository fixture.
+        env:
+          APP_VERSION: ${{ needs.select.outputs.app_version }}
         run: |
           yarn run pack
           mkdir -p "$RUNNER_TEMP/npm-candidate"


### PR DESCRIPTION
The beta candidate failed during npm's web export: `MUXR_RELEASE_VERSION=0.1.27-beta.3.1` reached Expo while `APP_VERSION` defaulted to the repository's `0.1.26`. The existing identity guard correctly rejected that mismatch.

Pass the selected numeric app version to the **Pack candidate once** step, matching the Android job. Keep it scoped to that step so the preceding installed-package smoke retains its stable fixture. No application, native, dependency or signing changes.

Validation: reproduced the configuration failure without `APP_VERSION`; with `APP_VERSION=0.1.27`, Expo retains version `0.1.27` and release identity `0.1.27-beta.3.1`, and the complete production web export passes. Failed candidate [34033082154](https://github.com/umeranjum17/muxr/actions/runs/34033082154) is retained; the replacement beta will receive a fresh version/build number.
