### PR TITLE
Synchronize stable, beta and dev downloads after every release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.inspect.outputs.commit }}
+          # Publishing tooling comes from the commit this workflow file is
+          # running from, so a retained candidate built before a tooling change
+          # still publishes through the current pipeline. The release identity
+          # stays the candidate's: RELEASE_COMMIT and every manifest, tarball
+          # and registry check below are bound to it, and nothing is rebuilt.
+          ref: ${{ github.workflow_sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ on:
 concurrency:
   group: npm-publication
   cancel-in-progress: false
+  # Publications serialize. Without a queue, GitHub keeps only one pending run
+  # per group, so a third release would replace a publication still waiting.
+  queue: max
 permissions:
   contents: read
   actions: read
@@ -65,10 +68,14 @@ jobs:
     needs: [inspect, production-approval]
     if: always() && needs.inspect.result == 'success' && (needs.inspect.outputs.channel != 'stable' || needs.production-approval.result == 'success')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment: npm
     permissions:
       actions: read
-      contents: read
+      # Repository-wide write, used for two things only: the public channel
+      # catalog on its own branch, and release metadata when an accepted stable
+      # is marked non-prerelease and Latest. No source or artifact is written.
+      contents: write
       id-token: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -88,3 +95,10 @@ jobs:
         run: |
           gh run download "$BUILD_RUN_ID" --repo "$GITHUB_REPOSITORY" --name npm-candidate --dir "$RUNNER_TEMP/package"
           node scripts/release/presentation/publishNpm.mjs
+      - name: Promote the accepted stable release to GitHub Latest
+        if: needs.inspect.outputs.channel == 'stable'
+        run: node scripts/release/presentation/promoteReleaseVisibility.mjs --tag "v$RELEASE_VERSION"
+      - name: Point the public channel at this release
+        run: node scripts/release/presentation/updateChannelCatalog.mjs --tag "v$RELEASE_VERSION"
+      - name: Verify every public surface serves this release
+        run: node scripts/release/presentation/verifyPublicRelease.mjs --tag "v$RELEASE_VERSION" --channel "$RELEASE_CHANNEL"

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@
 <p align="center">
   <a href="https://play.google.com/apps/testing/com.trymuxr.app">Google Play testing</a> ·
   <a href="https://testflight.apple.com/join/aJSbs8pN">iOS TestFlight</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk">Beta APK 0.1.27 (build 360)</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.27-beta.4.1">Beta release notes</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.25">Stable 0.1.25</a>
+  <a href="https://trymuxr.com/downloads/stable/android">Download the Android APK</a> ·
+  <a href="https://trymuxr.com/downloads">Stable, beta and dev</a>
 </p>
 
 <p align="center">
@@ -128,18 +127,20 @@ Terminal text, prompts, responses, keystrokes, files, pairing secrets, and crede
 You need [Node.js 22 or newer](https://nodejs.org/) on Linux, macOS, or WSL. muxr installs [Herdr](https://herdr.dev) during setup if it is missing.
 
 ```bash
-npm install -g --ignore-scripts @trymuxr/cli@0.1.26
+npm install -g --ignore-scripts @trymuxr/cli@latest
 muxr
 ```
 
+Prefer the beta? Install it with `npm install -g --ignore-scripts @trymuxr/cli@beta` and take its APK from the [beta channel](https://trymuxr.com/downloads/beta). The [dev channel](https://trymuxr.com/downloads/dev) tracks the newest build; its **Android app** installs alongside a stable or beta app rather than replacing it. On your computer every channel is the same CLI, so switching npm tags replaces the host you already run rather than adding a second one.
+
 Then install the mobile companion:
 
-- **Android:** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the latest signed APK](https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk) · [SHA256SUMS](https://github.com/umeranjum17/muxr/releases/latest/download/SHA256SUMS)
-- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — 0.1.24 (build 45); Apple is not accepting new testers right now
+- **Android (stable):** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the stable APK](https://trymuxr.com/downloads/stable/android) · [stable checksum](https://trymuxr.com/downloads/stable/checksums)
+- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now. Store tracks review and roll out on their own schedule, so they do not move with the beta APK
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
-- **All builds:** [muxr 0.1.26 release](https://github.com/umeranjum17/muxr/releases/tag/v0.1.26)
+- **All builds:** [every download channel](https://trymuxr.com/downloads)
 
-Verify a downloaded APK with `sha256sum --ignore-missing -c SHA256SUMS`, then run `muxr`. Setup explains one recommended route—the healthy current route, Tailscale, an existing private network, an installed temporary tunnel, or same Wi-Fi—and changes nothing until **Apply setup**. Scan the one-use QR from the phone when it is ready.
+Save the channel's checksum next to the downloaded APK as `SHA256SUMS`, verify it with `sha256sum --ignore-missing -c SHA256SUMS`, then run `muxr`. Each channel publishes its own checksum, so verify against the channel you downloaded from. Setup explains one recommended route—the healthy current route, Tailscale, an existing private network, an installed temporary tunnel, or same Wi-Fi—and changes nothing until **Apply setup**. Scan the one-use QR from the phone when it is ready.
 
 [Read the step-by-step quickstart →](https://trymuxr.com/docs/quickstart)
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@
 <p align="center">
   <a href="https://play.google.com/apps/testing/com.trymuxr.app">Google Play testing</a> ·
   <a href="https://testflight.apple.com/join/aJSbs8pN">iOS TestFlight</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/latest/download/muxr-android.apk">Direct APK: latest signed build</a> ·
-  <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.26">Release 0.1.26</a>
+  <a href="https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk">Beta APK 0.1.27 (build 360)</a> ·
+  <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.27-beta.4.1">Beta release notes</a> ·
+  <a href="https://github.com/umeranjum17/muxr/releases/tag/v0.1.25">Stable 0.1.25</a>
 </p>
 
 <p align="center">

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -28,6 +28,44 @@ Every successful candidate attaches a signed ARM64 APK/AAB, npm tarball, compile
 
 Build numbers are reserved through the `release-build-numbers` Git branch. Fast-forward-only updates serialize concurrent reservations; failed builds and retries consume numbers permanently. Never reset/delete this ledger or use git commit count as versionCode. The legacy manual Android builder accepts an explicit number for maintenance only: reserve through the same ledger first. The candidate workflow does that automatically.
 
+## Public channel record
+
+Every successful publication points one channel at the release that now holds it, and then proves that every public surface agrees. Versioned releases stay immutable: nothing is retagged, no artifact is copied, and no second GitHub Release is created to act as a pointer.
+
+The pointer is one small catalog, `channels.json`, on the dedicated `release-channels` branch:
+
+```
+https://raw.githubusercontent.com/umeranjum17/muxr/release-channels/channels.json
+```
+
+```json
+{ "schema": 1, "channels": { "beta": { "version": "0.1.27-beta.4.1", "appVersion": "0.1.27", "tag": "v0.1.27-beta.4.1",
+  "releaseUrl": "…/releases/tag/v0.1.27-beta.4.1", "npmDistTag": "beta", "publishedAt": "…", "manifestUrl": "…/release-manifest.json",
+  "android": { "url": "…/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk", "sha256": "…", "bytes": 176639520, "versionCode": 360, "applicationId": "com.trymuxr.app" } } } }
+```
+
+Every field is derived from that release's own combined `release-manifest.json` — the npm-only candidate manifest carries no Android identity and is never used for this. Artifact URLs are always canonical `github.com/umeranjum17/muxr/releases/download/<tag>/<name>` with the manifest's exact digests. `npmDistTag` is `latest` for stable, `beta` and `dev` for the others. `manifestUrl` may be null only for the legacy stable `0.1.25` seed, which predates sealed manifests.
+
+`publish npm` performs this automatically after a verified publication, in steps that can also be run by hand:
+
+```
+node scripts/release/presentation/promoteReleaseVisibility.mjs --tag v0.1.27   # stable only
+node scripts/release/presentation/updateChannelCatalog.mjs --tag v0.1.27-beta.4.1
+node scripts/release/presentation/verifyPublicRelease.mjs --tag v0.1.27-beta.4.1 --channel beta
+```
+
+The catalog update is idempotent and backfills any retained release without rebuilding. Before it writes anything it checks identity rather than names: the tag must point at the commit its manifest was sealed from, the APK asset GitHub serves must match the manifest's name, size and sha256 digest, the retained tarball must match its manifest digest and hash to the sha512 integrity npm published, and the npm dist-tag must already name that exact version. It then updates only its own channel, serializing concurrent writers through fast-forward-only ref updates — never a force push, never a backwards move, never the same version pointing at different bytes.
+
+Verification is bound to the release being published, not to whatever a surface reports: the expected record is derived from the exact tag, and the check fails unless the catalog, `/api/releases/<channel>`, both redirects and the checksum line all carry that record, the npm dist-tag names that version, and GitHub's prerelease/Latest status is right for the channel.
+
+Splitting the commands lets an initial migration seed the catalog before the website routes exist; the normal release path always runs all of them, and there is no bypass flag in CI.
+
+Publications serialize through the `npm-publication` concurrency group with `cancel-in-progress: false` and `queue: max`, so a release that arrives while another is publishing waits its turn instead of replacing an already waiting one. The catalog is safe independently of that: its writes serialize through fast-forward-only ref updates and refuse backwards moves.
+
+Durable website paths, served from that catalog: `/downloads/<channel>` for the human page, `/downloads/<channel>/android` redirecting to the canonical APK, `/downloads/<channel>/release` for the release page and `/downloads/<channel>/checksums` for digests, with `/api/releases/<channel>` returning the entry itself. Verification tolerates their short cache by retrying, never by weakening the comparison: it fails unless the served version and APK digest match the catalog and the redirect target is exactly the canonical artifact URL.
+
+Release titles are `muxr <version>`. PR and build provenance belongs in the notes, not the title. Every candidate is created with `--prerelease --latest=false`, so a preview never becomes GitHub's Latest. Stable promotion clears the prerelease flag on that same release and makes it Latest, after the explicit approval and the npm integrity checks — without creating a release or rebuilding a binary — so `releases/latest/download/<asset>` follows the accepted stable instead of going stale. Beta and dev stay prereleases permanently.
+
 ## Stable promotion — only after the user accepts the candidate
 
 1. Select the accepted source. Build a **stable** candidate with its final version. A beta npm tarball cannot be renamed into a stable version: this is a new package, and its exact installed artifact must pass checks before promotion. Preserve the beta evidence and compare source/native bytes. Repeat local emulator/phone checks when relevant bytes change.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -60,6 +60,8 @@ Verification is bound to the release being published, not to whatever a surface 
 
 Splitting the commands lets an initial migration seed the catalog before the website routes exist; the normal release path always runs all of them, and there is no bypass flag in CI.
 
+Publication runs the tooling from the commit the workflow file itself is running from, while the release identity — source commit, manifest, tarball and registry checks — stays bound to the candidate being published, so an older retained candidate is promoted by the current pipeline without rebuilding it.
+
 Publications serialize through the `npm-publication` concurrency group with `cancel-in-progress: false` and `queue: max`, so a release that arrives while another is publishing waits its turn instead of replacing an already waiting one. The catalog is safe independently of that: its writes serialize through fast-forward-only ref updates and refuse backwards moves.
 
 Durable website paths, served from that catalog: `/downloads/<channel>` for the human page, `/downloads/<channel>/android` redirecting to the canonical APK, `/downloads/<channel>/release` for the release page and `/downloads/<channel>/checksums` for digests, with `/api/releases/<channel>` returning the entry itself. Verification tolerates their short cache by retrying, never by weakening the comparison: it fails unless the served version and APK digest match the catalog and the redirect target is exactly the canonical artifact URL.

--- a/scripts/diagnostics/application/checkReleaseCatalog.mjs
+++ b/scripts/diagnostics/application/checkReleaseCatalog.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import {
+    channelEntry, checksumLineMismatch, emptyCatalog, mergeCatalog, parseCatalog, publicRecordMismatch, serializeCatalog,
+} from '../../release/index.mjs';
+
+// The real sealed manifest of v0.1.27-beta.4.1, trimmed to the fields the
+// catalog derives from. Deriving from the combined GitHub release manifest is
+// the contract: the npm-only candidate manifest carries no Android identity.
+const betaManifest = {
+    schema: 1,
+    release: { version: '0.1.27-beta.4.1', appVersion: '0.1.27', channel: 'beta', distTag: 'beta', id: '0.1.27-beta.4.1-2ba5483803d9' },
+    source: { commit: '2ba5483803d9cf0d4421ef813491d1f28de3770c', tree: '2ab276b3a0188144071203274fce950d474dc167', dirty: false },
+    build: { runId: '34034219166', runAttempt: '1' },
+    artifacts: [
+        { name: 'muxr-0.1.27-360.aab', bytes: 138332936, sha256: '56c9f635081c760219ad17de60851e88bd1646f711c2d6a22cb900f9283edc3b' },
+        { name: 'muxr-0.1.27-360.apk', bytes: 176639520, sha256: 'e1a50185292c6fefcf6ccf069674957353116c0aae298114cee71131d25b8b76' },
+        { name: 'trymuxr-cli-0.1.27-beta.4.1.tgz', bytes: 11615642, sha256: '14959d2298f80ddac5633ff8e2478edc5d411dffffffffffffffffffffffffff' },
+    ],
+    android: { applicationId: 'com.trymuxr.app', versionCode: 360, signerSha256: '9c33841142483611257fcdf772f5e8fc30d6fac803f6da28e7eacfcaec12b08d' },
+};
+// The one legacy stable entry, seeded before sealed manifests existed.
+const legacyStable = {
+    version: '0.1.25', appVersion: '0.1.25', tag: 'v0.1.25',
+    releaseUrl: 'https://github.com/umeranjum17/muxr/releases/tag/v0.1.25',
+    npmDistTag: 'latest', publishedAt: '2026-08-31T01:07:31.000Z', manifestUrl: null,
+    android: {
+        url: 'https://github.com/umeranjum17/muxr/releases/download/v0.1.25/muxr-android.apk',
+        sha256: 'c4dd3bd905658b79a58f1b28d919d89da0d3fb6c0b2fed6c7eb1a211f5c59305',
+        bytes: 174880788, versionCode: 53, applicationId: 'com.trymuxr.app',
+    },
+};
+
+const { channel, entry } = channelEntry({ tag: 'v0.1.27-beta.4.1', manifest: betaManifest, publishedAt: '2026-09-06T13:17:22Z' });
+assert.equal(channel, 'beta');
+assert.equal(entry.npmDistTag, 'beta');
+assert.equal(entry.appVersion, '0.1.27');
+assert.equal(entry.releaseUrl, 'https://github.com/umeranjum17/muxr/releases/tag/v0.1.27-beta.4.1');
+assert.equal(entry.manifestUrl, 'https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/release-manifest.json');
+assert.deepEqual(entry.android, {
+    url: 'https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk',
+    sha256: 'e1a50185292c6fefcf6ccf069674957353116c0aae298114cee71131d25b8b76',
+    bytes: 176639520, versionCode: 360, applicationId: 'com.trymuxr.app',
+});
+
+// Publishing one channel preserves the others and survives a round trip.
+const seeded = mergeCatalog(emptyCatalog(), 'stable', legacyStable);
+const published = mergeCatalog(seeded, channel, entry);
+assert.deepEqual(published.channels.stable, legacyStable, 'publishing beta disturbed the stable entry');
+assert.equal(published.channels.beta.version, '0.1.27-beta.4.1');
+const serialized = serializeCatalog(published);
+assert.deepEqual(parseCatalog(serialized), published);
+assert.equal(serializeCatalog(mergeCatalog(published, channel, entry)), serialized, 'republishing the same release was not idempotent');
+
+// A channel never moves backwards, and a published version never changes bytes.
+assert.throws(() => mergeCatalog(published, 'beta', channelEntry({
+    tag: 'v0.1.27-beta.3.1',
+    manifest: { ...betaManifest, release: { ...betaManifest.release, version: '0.1.27-beta.3.1' } },
+    publishedAt: '2026-09-06T10:00:00Z',
+}).entry), /backwards/);
+const tampered = { ...entry, android: { ...entry.android, sha256: 'f'.repeat(64) } };
+assert.throws(() => mergeCatalog(published, 'beta', tampered), /different bytes/);
+
+// Only the legacy stable seed may omit a manifest; anything else is rejected.
+assert.throws(() => mergeCatalog(published, 'beta', { ...entry, manifestUrl: null }), /invalid channel entry/i);
+assert.throws(() => parseCatalog(JSON.stringify({ schema: 2, channels: {} })), /schema/);
+assert.deepEqual(parseCatalog(''), emptyCatalog());
+
+// Public routes must agree with the same record the catalog publishes.
+const served = JSON.parse(JSON.stringify(entry));
+assert.equal(publicRecordMismatch(entry, served, 'beta'), undefined, 'an exact copy of the entry was rejected');
+assert.equal(publicRecordMismatch(entry, { ...served, channel: 'beta' }, 'beta'), undefined);
+assert.match(publicRecordMismatch(entry, { ...served, channel: 'dev' }, 'beta'), /channel dev/);
+assert.match(publicRecordMismatch(entry, { ...served, publishedAt: '2026-01-01T00:00:00.000Z' }, 'beta'), /publishedAt/);
+assert.match(publicRecordMismatch(entry, { ...served, android: { ...served.android, bytes: 1 } }, 'beta'), /android.bytes/);
+assert.match(publicRecordMismatch(entry, undefined, 'beta'), /no record/);
+const apkName = entry.android.url.split('/').pop();
+assert.equal(checksumLineMismatch(entry, `${entry.android.sha256}  ${apkName}\n`), undefined);
+assert.equal(checksumLineMismatch(entry, `# digests\n${entry.android.sha256} *${apkName}\n`), undefined);
+assert.match(checksumLineMismatch(entry, `${'0'.repeat(64)}  ${apkName}\n`), /no line pairing/);
+assert.match(checksumLineMismatch(entry, `${entry.android.sha256}  muxr-other.apk\n`), /no line pairing/);
+assert.match(checksumLineMismatch(entry, ''), /no checksums/);
+
+// The dev channel carries the separate development application identity.
+assert.throws(() => mergeCatalog(published, 'dev', { ...entry, version: '0.1.27-dev.9.1', tag: 'v0.1.27-dev.9.1' }), /invalid channel entry/i);
+
+process.stdout.write('release catalog flow passed\n');

--- a/scripts/diagnostics/application/runSuite.mjs
+++ b/scripts/diagnostics/application/runSuite.mjs
@@ -47,6 +47,7 @@ const checks = [
     // The lifecycle flow needs a packed tree, so the package smoke drives it
     // against its own snapshot instead of a second entry against the root.
     ['package: install/setup + full lifecycle smoke', 'node', ['scripts/diagnostics/application/checkPackageSmoke.mjs'], undefined, 300000],
+    ['release: public channel catalog flow', 'node', ['scripts/diagnostics/application/checkReleaseCatalog.mjs']],
     ['policy: core purity (no cloud refs in OSS)', 'node', ['scripts/diagnostics/application/checkCorePurity.mjs']],
     ['policy: tooling architecture (named use cases, layers, no nested ternaries)', 'node', ['scripts/diagnostics/application/checkArchitecture.mjs']],
     ['security: tracked/package secret scan', 'node', ['scripts/diagnostics/application/checkNoSecrets.mjs']],

--- a/scripts/release/application/promoteReleaseVisibility.mjs
+++ b/scripts/release/application/promoteReleaseVisibility.mjs
@@ -1,0 +1,30 @@
+import { CANONICAL_REPOSITORY, channelEntry } from '../domain/channelCatalog.mjs';
+import { markReleaseLatest, readLatestReleaseTag, readReleaseManifestAsset, readReleaseMetadata } from '../infrastructure/catalogBranch.mjs';
+import { readRegistryDistTag } from '../infrastructure/publicRecord.mjs';
+
+const PACKAGE = '@trymuxr/cli';
+
+/**
+ * Stable promotion clears the prerelease flag on the release that already
+ * exists and makes it GitHub's Latest, so `releases/latest/download` follows
+ * the accepted stable. No new release, no new binary, no retagging; beta and
+ * dev keep their prerelease status and never become Latest.
+ */
+export async function promoteReleaseVisibility({ repository = CANONICAL_REPOSITORY, tag } = {}) {
+    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag ?? '')) throw new Error('An exact release tag is required to promote visibility');
+    const release = readReleaseMetadata({ repository, tag });
+    const manifest = readReleaseManifestAsset({ repository, tag });
+    const { channel, entry } = channelEntry({ repository, tag, manifest, publishedAt: release.publishedAt });
+    if (channel !== 'stable') throw new Error(`${tag} is a ${channel} release; only stable becomes GitHub's Latest`);
+    const registryVersion = await readRegistryDistTag({ package: PACKAGE, tag: entry.npmDistTag });
+    if (registryVersion !== entry.version) {
+        throw new Error(`npm latest is ${registryVersion}, not ${entry.version}; promote the package before promoting its release`);
+    }
+    const name = `muxr ${entry.version}`;
+    // Being non-prerelease is not the same as being Latest: another release can
+    // hold that pointer, and a rerun has to be able to repair exactly that.
+    const alreadyLatest = release.prerelease === false && release.name === name && readLatestReleaseTag({ repository }) === tag;
+    if (alreadyLatest) return { tag, changed: false, name };
+    markReleaseLatest({ repository, id: release.id, name });
+    return { tag, changed: true, name };
+}

--- a/scripts/release/application/publishCandidate.mjs
+++ b/scripts/release/application/publishCandidate.mjs
@@ -26,5 +26,5 @@ export async function publishCandidate() {
     const notes = join(RUNNER_TEMP, 'candidate-notes.md');
     writeFileSync(notes, `Development candidate; **not production**.\n\nChannel: ${CHANNEL}. Source: ${GITHUB_SHA}. Android build: ${BUILD_CODE}.\n\nDownload the APK below. ${CHANNEL === 'dev' ? 'The dev app installs separately and uses manual self-host pairing.' : 'This beta updates the existing direct-install muxr app; it shares its data.'}\n\nThe npm tarball can be installed directly with npm. Registry publication uses the separate verified publisher. Production promotion is manual.\n\n[Build and checks](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Local emulator and phone acceptance are recorded separately; a build is not device acceptance.\n`);
     execFileSync('gh', ['release', 'create', `v${VERSION}`, ...readdirSync(directory).map((name) => join(directory, name)), '--repo', GITHUB_REPOSITORY,
-        '--target', GITHUB_SHA, '--title', `muxr ${VERSION} · ${CHANNEL}`, '--prerelease', '--latest=false', '--notes-file', notes], { stdio: 'inherit' });
+        '--target', GITHUB_SHA, '--title', `muxr ${VERSION}`, '--prerelease', '--latest=false', '--notes-file', notes], { stdio: 'inherit' });
 }

--- a/scripts/release/application/publishNpm.mjs
+++ b/scripts/release/application/publishNpm.mjs
@@ -14,10 +14,31 @@ export async function publishNpm() {
     const path = join(directory, packages[0].name);
     const integrity = `sha512-${createHash('sha512').update(readFileSync(path)).digest('base64')}`;
     function npm(args, allowMissing = false) {
-        const result = spawnSync('npm', args, { encoding: 'utf8', timeout: 180000 });
+        // Metadata reads are small and must fail fast; publishing uploads the
+        // whole tarball and keeps the longer budget.
+        const timeout = args[0] === 'publish' ? 180000 : 20000;
+        const result = spawnSync('npm', args, { encoding: 'utf8', timeout });
         if (result.status === 0) return result.stdout.trim();
         if (allowMissing && /E404/.test(result.stderr)) return undefined;
-        throw new Error(`npm operation failed: ${args[0]}`);
+        const detail = (result.stderr || result.error?.message || 'no output').trim().slice(-400);
+        throw new Error(`npm ${args.join(' ')} failed (${result.status ?? 'no exit status'}): ${detail}`);
+    }
+    // The registry is read-after-write eventually consistent: a view issued
+    // within a second of publish can miss on a replica, answer empty, or still
+    // serve the previous dist-tag. Retry until the exact expected value shows.
+    // `retryMismatch` separates "not caught up yet" from "wrong bytes": a tag
+    // catches up, a differing integrity never does and must fail at once.
+    async function confirm(args, expected, { retryMismatch = false } = {}) {
+        let seen;
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+            if (attempt > 0) await new Promise((done) => setTimeout(done, 3000));
+            const value = npm(args, true);
+            if (value === undefined || value === '') continue;
+            seen = JSON.parse(value);
+            if (seen === expected || !retryMismatch) return seen;
+        }
+        const detail = seen === undefined ? 'never became visible' : `still reports ${JSON.stringify(seen)}, expected ${JSON.stringify(expected)}`;
+        throw new Error(`${spec} was published but ${args.slice(1).join(' ')} ${detail} on the registry; re-run this job to confirm it`);
     }
     const spec = `@trymuxr/cli@${RELEASE_VERSION}`;
     const existing = npm(['view', spec, 'dist.integrity', '--json'], true);
@@ -28,7 +49,8 @@ export async function publishNpm() {
     if (current && compareVersions(current, RELEASE_VERSION) > 0) throw new Error('Refusing to move the channel backwards');
     if (existing === undefined) npm(['publish', path, '--tag', manifest.release.distTag, '--access', 'public', '--provenance']);
     else if (current !== RELEASE_VERSION) npm(['dist-tag', 'add', spec, manifest.release.distTag]);
-    if (JSON.parse(npm(['view', spec, 'dist.integrity', '--json'])) !== integrity) throw new Error('Published npm integrity mismatch');
-    if (JSON.parse(npm(['view', '@trymuxr/cli', `dist-tags.${manifest.release.distTag}`, '--json'])) !== RELEASE_VERSION) throw new Error('Published channel mismatch');
+    // Different bytes under the same version is never a propagation delay.
+    if (await confirm(['view', spec, 'dist.integrity', '--json'], integrity) !== integrity) throw new Error('Published npm integrity mismatch');
+    await confirm(['view', '@trymuxr/cli', `dist-tags.${manifest.release.distTag}`, '--json'], RELEASE_VERSION, { retryMismatch: true });
     process.stdout.write(`Verified ${spec} on ${manifest.release.distTag}; published bytes match the candidate.\n`);
 }

--- a/scripts/release/application/updateChannelCatalog.mjs
+++ b/scripts/release/application/updateChannelCatalog.mjs
@@ -1,0 +1,84 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import {
+    CANONICAL_REPOSITORY, CATALOG_BRANCH, MANIFEST_ASSET, catalogUrl, channelEntry, mergeCatalog, parseCatalog, serializeCatalog,
+} from '../domain/channelCatalog.mjs';
+import {
+    commitCatalogBranch, readCatalogBranch, readReleaseManifestAsset, readReleaseMetadata, readTagCommit, withReleaseAsset,
+} from '../infrastructure/catalogBranch.mjs';
+import { readPublicJson, readRegistryDistTag, readRegistryIntegrity } from '../infrastructure/publicRecord.mjs';
+
+const PACKAGE = '@trymuxr/cli';
+
+/**
+ * Points one public channel at an already published, already verified release.
+ * Every field is derived from that release's own combined manifest, and every
+ * artifact it names is re-checked against the bytes GitHub and npm actually
+ * hold. No rebuild, no retagging, nothing copied.
+ */
+export async function updateChannelCatalog({ repository = CANONICAL_REPOSITORY, tag, branch = CATALOG_BRANCH, verifyCatalog = true } = {}) {
+    if (repository !== CANONICAL_REPOSITORY) throw new Error('The public catalog belongs to the canonical repository');
+    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag ?? '')) throw new Error('An exact release tag is required, such as v0.1.27-beta.4.1');
+    const release = readReleaseMetadata({ repository, tag });
+    const assets = new Map(release.assets.map((asset) => [asset.name, asset]));
+    if (!assets.has(MANIFEST_ASSET)) throw new Error(`${tag} has no retained ${MANIFEST_ASSET} to derive from`);
+
+    // The combined GitHub release manifest, never the npm-only candidate one:
+    // only it carries the Android artifact digest and build identity.
+    const manifest = readReleaseManifestAsset({ repository, tag });
+    const taggedCommit = readTagCommit({ repository, tag });
+    if (manifest.source?.commit !== taggedCommit) {
+        throw new Error(`${tag} points at ${taggedCommit}, but its manifest was sealed from ${manifest.source?.commit}`);
+    }
+    const { channel, entry } = channelEntry({ repository, tag, manifest, publishedAt: release.publishedAt });
+
+    // The APK the catalog advertises must be the artifact GitHub is serving.
+    const apkName = entry.android.url.split('/').pop();
+    const apk = assets.get(apkName);
+    if (apk === undefined) throw new Error(`${tag} does not carry the APK its manifest names (${apkName})`);
+    if (apk.size !== entry.android.bytes) throw new Error(`${apkName} is ${apk.size} bytes on the release, ${entry.android.bytes} in its manifest`);
+    if (apk.digest !== `sha256:${entry.android.sha256}`) {
+        throw new Error(`${apkName} reports digest ${apk.digest ?? 'none'}, expected sha256:${entry.android.sha256}; re-upload or verify the release asset`);
+    }
+
+    // The published package must be the retained tarball, byte for byte.
+    const tarball = manifest.artifacts.find((item) => item.name.endsWith('.tgz'));
+    if (tarball === undefined) throw new Error(`${tag} has no npm tarball in its manifest`);
+    const registryIntegrity = await readRegistryIntegrity({ package: PACKAGE, version: entry.version });
+    await withReleaseAsset({ repository, tag, name: tarball.name }, async (asset) => {
+        if (asset.bytes !== tarball.bytes || asset.sha256 !== tarball.sha256) {
+            throw new Error(`${tarball.name} on the release does not match its manifest digest`);
+        }
+        const integrity = `sha512-${createHash('sha512').update(readFileSync(asset.path)).digest('base64')}`;
+        if (integrity !== registryIntegrity) throw new Error(`npm ${entry.version} was published from different bytes than ${tarball.name}`);
+    });
+
+    // The registry decides what a channel currently is; the catalog mirrors it.
+    const registryVersion = await readRegistryDistTag({ package: PACKAGE, tag: entry.npmDistTag });
+    if (registryVersion !== entry.version) {
+        throw new Error(`npm ${entry.npmDistTag} is ${registryVersion}, not ${entry.version}; publish the package before pointing the public channel at it`);
+    }
+
+    let published;
+    for (let attempt = 0; attempt < 8 && published === undefined; attempt += 1) {
+        const { parent, text } = readCatalogBranch({ repository, branch });
+        const next = serializeCatalog(mergeCatalog(parseCatalog(text), channel, entry));
+        if (text === next) { published = { channel, entry, changed: false }; break; }
+        if (commitCatalogBranch({ repository, branch, parent, text: next, message: `Point ${channel} at ${entry.version}` })) {
+            published = { channel, entry, changed: true };
+        }
+    }
+    if (published === undefined) throw new Error('The catalog branch kept advancing; no update was recorded');
+    if (verifyCatalog) {
+        await readPublicJson(catalogUrl(repository, branch), {
+            bust: true,
+            expect: (value) => {
+                const recorded = value?.channels?.[channel];
+                if (recorded?.version !== entry.version) return `raw catalog still reports ${recorded?.version ?? 'nothing'} for ${channel}`;
+                if (JSON.stringify(recorded) !== JSON.stringify(entry)) return `raw catalog holds a different ${channel} record`;
+                return undefined;
+            },
+        });
+    }
+    return published;
+}

--- a/scripts/release/application/verifyPublicRelease.mjs
+++ b/scripts/release/application/verifyPublicRelease.mjs
@@ -1,0 +1,61 @@
+import {
+    CANONICAL_REPOSITORY, CATALOG_BRANCH, catalogUrl, channelEntry, checksumLineMismatch, publicRecordMismatch,
+} from '../domain/channelCatalog.mjs';
+import { readLatestReleaseTag, readReleaseManifestAsset, readReleaseMetadata } from '../infrastructure/catalogBranch.mjs';
+import { readPublicJson, readPublicText, readRegistryDistTag, requireRedirect } from '../infrastructure/publicRecord.mjs';
+
+const SITE = 'https://trymuxr.com';
+const PACKAGE = '@trymuxr/cli';
+
+/**
+ * A release is public when every surface agrees with the release itself: the
+ * expectation comes from the exact tag, never from whatever a surface happens
+ * to report. Caches are tolerated by retrying, never by relaxing a comparison.
+ */
+export async function verifyPublicRelease({
+    tag, channel, version, repository = CANONICAL_REPOSITORY, branch = CATALOG_BRANCH, site = SITE,
+} = {}) {
+    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag ?? '')) throw new Error('An exact release tag is required to verify a public release');
+    const release = readReleaseMetadata({ repository, tag });
+    const manifest = readReleaseManifestAsset({ repository, tag });
+    const expected = channelEntry({ repository, tag, manifest, publishedAt: release.publishedAt });
+    const entry = expected.entry;
+    if (channel !== undefined && channel !== expected.channel) throw new Error(`${tag} belongs to ${expected.channel}, not ${channel}`);
+    if (version !== undefined && version !== entry.version) throw new Error(`${tag} publishes ${entry.version}, not the expected ${version}`);
+
+    // GitHub visibility is part of the contract: only stable is ever Latest.
+    const latestTag = readLatestReleaseTag({ repository });
+    const stable = expected.channel === 'stable';
+    if (stable && (release.prerelease || latestTag !== tag)) {
+        throw new Error(`${tag} is stable but GitHub still reports prerelease=${release.prerelease} and Latest=${latestTag ?? 'none'}`);
+    }
+    if (!stable && (!release.prerelease || latestTag === tag)) {
+        throw new Error(`${tag} is a ${expected.channel} release but GitHub reports prerelease=${release.prerelease} and Latest=${latestTag ?? 'none'}`);
+    }
+
+    const registryVersion = await readRegistryDistTag({ package: PACKAGE, tag: entry.npmDistTag });
+    if (registryVersion !== entry.version) throw new Error(`npm ${entry.npmDistTag} serves ${registryVersion}, not ${entry.version}`);
+
+    await readPublicJson(catalogUrl(repository, branch), {
+        bust: true,
+        expect: (value) => {
+            const recorded = value?.channels?.[expected.channel];
+            if (recorded === undefined) return `catalog has no ${expected.channel} entry`;
+            if (JSON.stringify(recorded) !== JSON.stringify(entry)) return `catalog serves ${recorded.version} for ${expected.channel}, expected the ${entry.version} record`;
+            return undefined;
+        },
+    });
+    await readPublicJson(`${site}/api/releases/${expected.channel}`, {
+        attempts: 12,
+        delayMs: 5000,
+        expect: (value) => publicRecordMismatch(entry, value, expected.channel),
+    });
+    const android = await requireRedirect(`${site}/downloads/${expected.channel}/android`, entry.android.url);
+    await requireRedirect(`${site}/downloads/${expected.channel}/release`, entry.releaseUrl);
+    await readPublicText(`${site}/downloads/${expected.channel}/checksums`, {
+        attempts: 12,
+        delayMs: 5000,
+        expect: (text) => checksumLineMismatch(entry, text),
+    });
+    return { channel: expected.channel, version: entry.version, apk: entry.android.url, redirectStatus: android.status, latestTag };
+}

--- a/scripts/release/domain/channelCatalog.mjs
+++ b/scripts/release/domain/channelCatalog.mjs
@@ -1,0 +1,151 @@
+import { channelTags, compareVersions, distribution } from './channel.mjs';
+
+/**
+ * The public channel catalog: one small record per channel, pointing at the
+ * immutable artifacts of the release that currently holds that channel.
+ * Versioned releases are never retagged; only this pointer moves.
+ */
+export const CATALOG_BRANCH = 'release-channels';
+export const CATALOG_PATH = 'channels.json';
+export const CANONICAL_REPOSITORY = 'umeranjum17/muxr';
+// The one legacy entry predating sealed manifests; every later release carries one.
+const LEGACY_MANIFEST_EXEMPTION = Object.freeze({ channel: 'stable', version: '0.1.25' });
+export const MANIFEST_ASSET = 'release-manifest.json';
+// A dev build carries the separate development identity; nothing else may.
+const CHANNEL_APPLICATION_ID = Object.freeze({ stable: 'com.trymuxr.app', beta: 'com.trymuxr.app', dev: 'app.muxr.local.dev' });
+
+export function catalogUrl(repository = CANONICAL_REPOSITORY, branch = CATALOG_BRANCH) {
+    return `https://raw.githubusercontent.com/${repository}/${branch}/${CATALOG_PATH}`;
+}
+
+export function releaseTag(version) {
+    return `v${distribution(version).version}`;
+}
+
+export function assetUrl(repository, tag, name) {
+    if (repository !== CANONICAL_REPOSITORY) throw new Error('Catalog URLs require the canonical repository');
+    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag) || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,120}$/.test(name)) throw new Error('Invalid release asset identity');
+    return `https://github.com/${repository}/releases/download/${tag}/${name}`;
+}
+
+export function emptyCatalog() {
+    return { schema: 1, channels: {} };
+}
+
+function canonicalTimestamp(value) {
+    const parsed = Date.parse(value ?? '');
+    if (!Number.isFinite(parsed)) return undefined;
+    return new Date(parsed).toISOString();
+}
+
+function validEntry(entry, channel) {
+    if (!entry || typeof entry !== 'object') return false;
+    const release = distribution(entry.version, channel);
+    const android = entry.android;
+    if (android === null || typeof android !== 'object' || entry.tag !== releaseTag(entry.version)) return false;
+    const legacy = channel === LEGACY_MANIFEST_EXEMPTION.channel && entry.version === LEGACY_MANIFEST_EXEMPTION.version;
+    const manifestExact = entry.manifestUrl === assetUrl(CANONICAL_REPOSITORY, entry.tag, MANIFEST_ASSET);
+    const manifestAllowed = manifestExact || (entry.manifestUrl === null && legacy);
+    const apkName = typeof android.url === 'string' ? android.url.split('/').pop() : '';
+    return release.appVersion === entry.appVersion
+        && entry.npmDistTag === channelTags[channel]
+        && entry.releaseUrl === `https://github.com/${CANONICAL_REPOSITORY}/releases/tag/${entry.tag}`
+        && manifestAllowed
+        && entry.publishedAt === canonicalTimestamp(entry.publishedAt)
+        && apkName.endsWith('.apk')
+        && android.url === assetUrl(CANONICAL_REPOSITORY, entry.tag, apkName)
+        && /^[0-9a-f]{64}$/.test(android.sha256 ?? '')
+        && Number.isSafeInteger(android.bytes) && android.bytes > 0
+        && Number.isSafeInteger(android.versionCode) && android.versionCode > 0
+        && android.applicationId === CHANNEL_APPLICATION_ID[channel];
+}
+
+/** Builds one channel entry from a sealed release manifest; no rebuild, no guessing. */
+export function channelEntry({ repository = CANONICAL_REPOSITORY, tag, manifest, publishedAt }) {
+    if (manifest?.schema !== 1) throw new Error('Release manifest schema is not supported');
+    const release = distribution(manifest.release?.version, manifest.release?.channel);
+    if (tag !== releaseTag(release.version)) throw new Error('Release tag does not match its manifest version');
+    if (manifest.release.distTag !== release.distTag) throw new Error('Release manifest dist-tag does not match its channel');
+    const artifacts = Array.isArray(manifest.artifacts) ? manifest.artifacts : [];
+    const apks = artifacts.filter((item) => item?.name?.endsWith('.apk'));
+    if (apks.length !== 1) throw new Error('Exactly one Android APK artifact is required');
+    const android = manifest.android;
+    if (!android || !Number.isSafeInteger(android.versionCode) || typeof android.applicationId !== 'string') {
+        throw new Error('Release manifest carries no Android build identity');
+    }
+    const entry = {
+        version: release.version,
+        appVersion: release.appVersion,
+        tag,
+        releaseUrl: `https://github.com/${repository}/releases/tag/${tag}`,
+        npmDistTag: release.distTag,
+        publishedAt: canonicalTimestamp(publishedAt),
+        manifestUrl: assetUrl(repository, tag, MANIFEST_ASSET),
+        android: {
+            url: assetUrl(repository, tag, apks[0].name),
+            sha256: apks[0].sha256,
+            bytes: apks[0].bytes,
+            versionCode: android.versionCode,
+            applicationId: android.applicationId,
+        },
+    };
+    if (!validEntry(entry, release.channel)) throw new Error('Derived channel entry is invalid');
+    return { channel: release.channel, entry };
+}
+
+export function parseCatalog(text) {
+    if (text === undefined || text.trim() === '') return emptyCatalog();
+    const catalog = JSON.parse(text);
+    if (catalog?.schema !== 1 || !catalog.channels || typeof catalog.channels !== 'object') throw new Error('Unsupported channel catalog schema');
+    for (const [channel, entry] of Object.entries(catalog.channels)) {
+        if (!Object.hasOwn(channelTags, channel) || !validEntry(entry, channel)) throw new Error(`Invalid catalog entry: ${channel}`);
+    }
+    return { schema: 1, channels: { ...catalog.channels } };
+}
+
+/** Replaces one channel and preserves every other; never moves a channel backwards. */
+export function mergeCatalog(catalog, channel, entry) {
+    if (!Object.hasOwn(channelTags, channel)) throw new Error('Channel must be dev, beta or stable');
+    if (!validEntry(entry, channel)) throw new Error('Refusing to publish an invalid channel entry');
+    const current = catalog.channels[channel];
+    if (current !== undefined) {
+        const order = compareVersions(current.version, entry.version);
+        if (order === undefined) throw new Error('Existing catalog version cannot be compared');
+        if (order > 0) throw new Error(`Refusing to move ${channel} backwards from ${current.version} to ${entry.version}`);
+        if (order === 0 && JSON.stringify(current) !== JSON.stringify(entry)) throw new Error('Published version already points at different bytes');
+    }
+    return { schema: 1, channels: { ...catalog.channels, [channel]: entry } };
+}
+
+export function serializeCatalog(catalog) {
+    const channels = {};
+    for (const channel of Object.keys(channelTags).sort()) {
+        if (catalog.channels[channel] !== undefined) channels[channel] = catalog.channels[channel];
+    }
+    return `${JSON.stringify({ schema: 1, channels }, undefined, 2)}\n`;
+}
+
+/** Public surfaces must serve the catalog entry itself, field for field. */
+export function publicRecordMismatch(entry, record, channel) {
+    if (record === null || typeof record !== 'object') return 'served no record';
+    if (record.channel !== undefined && record.channel !== channel) return `served channel ${record.channel}`;
+    for (const field of ['version', 'appVersion', 'tag', 'releaseUrl', 'npmDistTag', 'publishedAt', 'manifestUrl']) {
+        if (record[field] !== entry[field]) return `served ${field} ${JSON.stringify(record[field])}, expected ${JSON.stringify(entry[field])}`;
+    }
+    for (const field of ['url', 'sha256', 'bytes', 'versionCode', 'applicationId']) {
+        if (record.android?.[field] !== entry.android[field]) return `served android.${field} ${JSON.stringify(record.android?.[field])}, expected ${JSON.stringify(entry.android[field])}`;
+    }
+    return undefined;
+}
+
+/** The checksum page must carry the APK's own digest line, not a summary. */
+export function checksumLineMismatch(entry, text) {
+    if (typeof text !== 'string' || text.trim() === '') return 'served no checksums';
+    const name = entry.android.url.split('/').pop();
+    for (const line of text.split('\n')) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length !== 2) continue;
+        if (parts[0] === entry.android.sha256 && parts[1].replace(/^\*/, '') === name) return undefined;
+    }
+    return `no line pairing ${entry.android.sha256} with ${name}`;
+}

--- a/scripts/release/index.mjs
+++ b/scripts/release/index.mjs
@@ -2,3 +2,4 @@ export { updateCli } from './application/updateCli.mjs';
 export { packageInfoFromPath, packagePathFromInput } from './infrastructure/audit.mjs';
 export { sealRelease } from './application/sealRelease.mjs';
 export { verifyRelease } from './application/verifyRelease.mjs';
+export { channelEntry, checksumLineMismatch, emptyCatalog, mergeCatalog, parseCatalog, publicRecordMismatch, serializeCatalog } from './domain/channelCatalog.mjs';

--- a/scripts/release/infrastructure/catalogBranch.mjs
+++ b/scripts/release/infrastructure/catalogBranch.mjs
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CATALOG_PATH, MANIFEST_ASSET } from '../domain/channelCatalog.mjs';
+import { digestFile } from './artifacts.mjs';
+
+/**
+ * The catalog branch is arbitrated the same way as the Android build ledger:
+ * fast-forward-only ref updates, never a force push. A losing writer retries
+ * against the branch it did not see.
+ */
+export function gh(repository, path, method, body) {
+    const args = ['api', `repos/${repository}/${path}`];
+    if (method !== undefined) args.push('--method', method);
+    if (body !== undefined) args.push('--input', '-');
+    const input = body === undefined ? undefined : JSON.stringify(body);
+    const output = execFileSync('gh', args, { input, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    // A local gh wrapper may print its own banner before the payload.
+    const start = output.search(/[[{]/);
+    if (start < 0) return null;
+    return JSON.parse(output.slice(start));
+}
+
+export function readCatalogBranch({ repository, branch }) {
+    let parent;
+    try { parent = gh(repository, `git/ref/heads/${branch}`).object.sha; }
+    catch (cause) { if (!String(cause.stderr).includes('404')) throw cause; }
+    if (parent === undefined) return { parent: undefined, text: undefined };
+    const file = gh(repository, `contents/${CATALOG_PATH}?ref=${parent}`);
+    return { parent, text: Buffer.from(file.content, 'base64').toString('utf8') };
+}
+
+/** Returns false when another writer advanced the branch first. */
+export function commitCatalogBranch({ repository, branch, parent, text, message }) {
+    const tree = gh(repository, 'git/trees', 'POST', { tree: [{ path: CATALOG_PATH, mode: '100644', type: 'blob', content: text }] });
+    const commit = gh(repository, 'git/commits', 'POST', { message, tree: tree.sha, parents: parent === undefined ? [] : [parent] });
+    try {
+        if (parent === undefined) gh(repository, 'git/refs', 'POST', { ref: `refs/heads/${branch}`, sha: commit.sha });
+        else gh(repository, `git/refs/heads/${branch}`, 'PATCH', { sha: commit.sha, force: false });
+        return true;
+    } catch (cause) {
+        if (/409|422/.test(String(cause.stderr))) return false;
+        throw cause;
+    }
+}
+
+export function readReleaseMetadata({ repository, tag }) {
+    const release = gh(repository, `releases/tags/${tag}`);
+    if (release.draft !== false) throw new Error('A draft release cannot hold a public channel');
+    return {
+        publishedAt: release.published_at,
+        prerelease: release.prerelease === true,
+        id: release.id,
+        name: release.name,
+        assets: release.assets.map((asset) => ({ name: asset.name, size: asset.size, digest: asset.digest ?? undefined })),
+    };
+}
+
+/** The commit a tag actually points at; asset names alone prove nothing. */
+export function readTagCommit({ repository, tag }) {
+    const ref = gh(repository, `git/ref/tags/${tag}`).object;
+    if (ref.type === 'commit') return ref.sha;
+    return gh(repository, `git/tags/${ref.sha}`).object.sha;
+}
+
+export function readLatestReleaseTag({ repository }) {
+    try { return gh(repository, 'releases/latest').tag_name; }
+    catch (cause) {
+        if (String(cause.stderr).includes('404')) return undefined;
+        throw cause;
+    }
+}
+
+export function markReleaseLatest({ repository, id, name }) {
+    return gh(repository, `releases/${id}`, 'PATCH', { prerelease: false, make_latest: 'true', name });
+}
+
+/** Downloads one retained asset and returns its path, size and digest. */
+export async function withReleaseAsset({ repository, tag, name }, use) {
+    const directory = mkdtempSync(join(tmpdir(), 'muxr-release-asset-'));
+    try {
+        downloadReleaseAsset({ repository, tag, name, directory });
+        const path = join(directory, name);
+        return await use({ path, bytes: statSync(path).size, sha256: await digestFile(path) });
+    } finally { rmSync(directory, { recursive: true, force: true }); }
+}
+
+export function readReleaseManifestAsset({ repository, tag }) {
+    const directory = mkdtempSync(join(tmpdir(), 'muxr-release-manifest-'));
+    try {
+        downloadReleaseAsset({ repository, tag, name: MANIFEST_ASSET, directory });
+        return JSON.parse(readFileSync(join(directory, MANIFEST_ASSET), 'utf8'));
+    } finally { rmSync(directory, { recursive: true, force: true }); }
+}
+
+export function downloadReleaseAsset({ repository, tag, name, directory }) {
+    execFileSync('gh', ['release', 'download', tag, '--repo', repository, '--pattern', name, '--dir', directory, '--clobber'],
+        { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+}

--- a/scripts/release/infrastructure/publicRecord.mjs
+++ b/scripts/release/infrastructure/publicRecord.mjs
@@ -1,0 +1,95 @@
+/**
+ * Public surfaces are cached and remote: every read is individually timed out,
+ * bounded in attempts, and retried on a wrong answer as well as a failed one.
+ */
+const sleep = (ms) => new Promise((done) => setTimeout(done, ms));
+const REQUEST_TIMEOUT_MS = 20000;
+// Registry metadata reads are small; a stalled one must not eat the job budget.
+const REGISTRY_READ_TIMEOUT_MS = 20000;
+
+function request(url, options = {}) {
+    return fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS), ...options });
+}
+
+/** Metadata URLs sit behind minutes-long CDN caches; revalidate and bust them. */
+export function cacheBusted(url, attempt) {
+    const target = new URL(url);
+    target.searchParams.set('t', `${Math.floor(Date.now() / 1000)}-${attempt}`);
+    return target.toString();
+}
+
+export async function readPublicJson(url, { attempts = 10, delayMs = 3000, expect, bust = false } = {}) {
+    let detail = 'no response';
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await sleep(delayMs);
+        try {
+            const response = await request(bust ? cacheBusted(url, attempt) : url, {
+                redirect: 'follow',
+                headers: { accept: 'application/json', 'cache-control': 'no-cache' },
+            });
+            if (!response.ok) { detail = `HTTP ${response.status}`; continue; }
+            const value = await response.json();
+            const mismatch = expect === undefined ? undefined : expect(value);
+            if (mismatch === undefined) return value;
+            detail = mismatch;
+        } catch (cause) { detail = cause.message; }
+    }
+    throw new Error(`${url} did not serve the expected record (${detail})`);
+}
+
+export async function readPublicText(url, { attempts = 10, delayMs = 3000, expect } = {}) {
+    let detail = 'no response';
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await sleep(delayMs);
+        try {
+            const response = await request(url, { redirect: 'follow', headers: { 'cache-control': 'no-cache' } });
+            if (!response.ok) { detail = `HTTP ${response.status}`; continue; }
+            const value = await response.text();
+            const mismatch = expect === undefined ? undefined : expect(value);
+            if (mismatch === undefined) return value;
+            detail = mismatch;
+        } catch (cause) { detail = cause.message; }
+    }
+    throw new Error(`${url} did not serve the expected content (${detail})`);
+}
+
+/** Requires a real redirect to the exact expected target, retrying a wrong one. */
+export async function requireRedirect(url, expectedLocation, { attempts = 12, delayMs = 5000 } = {}) {
+    let detail = 'no response';
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await sleep(delayMs);
+        try {
+            const response = await request(url, { redirect: 'manual', headers: { 'cache-control': 'no-cache' } });
+            const location = response.headers.get('location');
+            if (response.status < 300 || response.status > 399) { detail = `HTTP ${response.status} is not a redirect`; continue; }
+            if (location === expectedLocation) return { status: response.status, location };
+            detail = `redirects to ${location ?? 'nothing'}`;
+        } catch (cause) { detail = cause.message; }
+    }
+    throw new Error(`${url} did not redirect to ${expectedLocation} (${detail})`);
+}
+
+/** The registry is the channel's source of truth; reads are retried, never assumed. */
+export async function readRegistryDistTag({ package: name, tag, attempts = 10, delayMs = 3000 }) {
+    const { spawnSync } = await import('node:child_process');
+    let detail = 'no response';
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await sleep(delayMs);
+        const result = spawnSync('npm', ['view', name, `dist-tags.${tag}`, '--json'], { encoding: 'utf8', timeout: REGISTRY_READ_TIMEOUT_MS });
+        if (result.status === 0 && result.stdout.trim() !== '') return JSON.parse(result.stdout.trim());
+        detail = (result.stderr || result.error?.message || 'empty registry response').trim().slice(-300);
+    }
+    throw new Error(`npm dist-tag ${tag} for ${name} could not be read (${detail})`);
+}
+
+export async function readRegistryIntegrity({ package: name, version, attempts = 10, delayMs = 3000 }) {
+    const { spawnSync } = await import('node:child_process');
+    let detail = 'no response';
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await sleep(delayMs);
+        const result = spawnSync('npm', ['view', `${name}@${version}`, 'dist.integrity', '--json'], { encoding: 'utf8', timeout: REGISTRY_READ_TIMEOUT_MS });
+        if (result.status === 0 && result.stdout.trim() !== '') return JSON.parse(result.stdout.trim());
+        detail = (result.stderr || result.error?.message || 'empty registry response').trim().slice(-300);
+    }
+    throw new Error(`npm integrity for ${name}@${version} could not be read (${detail})`);
+}

--- a/scripts/release/presentation/promoteReleaseVisibility.mjs
+++ b/scripts/release/presentation/promoteReleaseVisibility.mjs
@@ -1,0 +1,11 @@
+import { promoteReleaseVisibility } from '../application/promoteReleaseVisibility.mjs';
+
+const option = (key) => {
+    const index = process.argv.indexOf(`--${key}`);
+    if (index < 0) return undefined;
+    return process.argv[index + 1];
+};
+const version = option('version') ?? process.env.RELEASE_VERSION;
+const result = await promoteReleaseVisibility({ tag: option('tag') ?? `v${version}` });
+const state = result.changed ? 'is now' : 'already was';
+process.stdout.write(`${result.tag} ${state} the Latest release, titled ${result.name}\n`);

--- a/scripts/release/presentation/updateChannelCatalog.mjs
+++ b/scripts/release/presentation/updateChannelCatalog.mjs
@@ -1,0 +1,11 @@
+import { updateChannelCatalog } from '../application/updateChannelCatalog.mjs';
+
+const option = (key) => {
+    const index = process.argv.indexOf(`--${key}`);
+    if (index < 0) return undefined;
+    return process.argv[index + 1];
+};
+const tag = option('tag') ?? process.env.RELEASE_TAG;
+const published = await updateChannelCatalog({ tag, verifyCatalog: !process.argv.includes('--no-verify') });
+const state = published.changed ? 'now points at' : 'already pointed at';
+process.stdout.write(`${published.channel} ${state} ${published.entry.version} (${published.entry.android.url})\n`);

--- a/scripts/release/presentation/verifyPublicRelease.mjs
+++ b/scripts/release/presentation/verifyPublicRelease.mjs
@@ -1,0 +1,15 @@
+import { verifyPublicRelease } from '../application/verifyPublicRelease.mjs';
+
+const option = (key) => {
+    const index = process.argv.indexOf(`--${key}`);
+    if (index < 0) return undefined;
+    return process.argv[index + 1];
+};
+const version = option('version') ?? process.env.RELEASE_VERSION;
+const result = await verifyPublicRelease({
+    tag: option('tag') ?? `v${version}`,
+    version,
+    ...(option('channel') === undefined ? {} : { channel: option('channel') }),
+    ...(option('site') === undefined ? {} : { site: option('site') }),
+});
+process.stdout.write(`${result.channel} is public: ${result.version}, download redirects (${result.redirectStatus}) to ${result.apk}\n`);


### PR DESCRIPTION
Published builds drifted across npm, GitHub Latest, README links, and the website because each surface used separate version strings. A verified channel catalog now records stable, beta, and dev, and the README links through permanent website download routes.

After npm verifies the retained package, publication derives the channel record from the combined release manifest, checks the GitHub APK and npm tarball identities, advances only that channel, and verifies the live website record, APK redirect, release redirect, and checksum. Accepted stable promotion also repairs GitHub Latest; beta/dev remain prereleases. Catalog updates preserve other channels and refuse rollback or changed bytes under an existing version. Pending publications queue, registry reads retry within bounded timeouts, and the publication job has a 15-minute limit.

Validation: all required CI and CodeQL checks passed on d0e64a0f. Catalog flow, architecture, and secret checks passed. The actual published beta manifest/catalog/npm package passed the new public-surface verifier against the local website. The companion website implementation is https://github.com/umeranjum17/muxr-cloud/pull/23, with production image packaging and pre-merge smoke checks in https://github.com/umeranjum17/muxr-cloud/pull/24. The website deployment succeeded, and all three live channel APIs, APK redirects, release redirects, and checksums passed verification before these README links merged. No Android rebuild, new package version, or store promotion is part of this change.

Retained candidates use publishing tooling from the exact workflow commit while all artifact checks remain bound to the original candidate commit and bytes. The existing beta candidate passed the complete new GitHub publication workflow without rebuilding: https://github.com/umeranjum17/muxr/actions/runs/34038485132. Website deployment: https://github.com/umeranjum17/muxr-cloud/actions/runs/34038296443. Live desktop (1280px) and phone (390px) download-page checks passed with no horizontal overflow.
