### PR TITLE
Consolidate releases into stable and nightly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: publish npm
+name: publish release
+run-name: publish ${{ inputs.run_id && format('candidate run {0}', inputs.run_id) || format('{0}', github.event.workflow_run.display_title) }}
 
 on:
   workflow_run:
@@ -51,7 +52,7 @@ jobs:
           const run = JSON.parse(readFileSync(`${process.env.RUNNER_TEMP}/build.json`));
           const m = JSON.parse(readFileSync(`${process.env.RUNNER_TEMP}/package/release-manifest.json`));
           if (!/^[0-9a-f]{40}$/.test(run.head_sha) || m.source.commit !== run.head_sha || m.build.runId !== process.env.RUN_ID) throw new Error('Candidate provenance mismatch');
-          if (!['dev','beta','stable'].includes(m.release.channel) || !/^[0-9A-Za-z.-]{1,120}$/.test(m.release.version)) throw new Error('Invalid release metadata');
+          if (!['nightly','stable'].includes(m.release.channel) || !/^[0-9A-Za-z.-]{1,120}$/.test(m.release.version)) throw new Error('Invalid release metadata');
           if (m.release.channel === 'stable' && process.env.GITHUB_EVENT_NAME === 'workflow_dispatch' && process.env.CONFIRMATION !== `promote-${m.release.version}`) throw new Error('Stable promotion requires exact confirmation');
           appendFileSync(process.env.GITHUB_OUTPUT, `commit=${run.head_sha}\nversion=${m.release.version}\nchannel=${m.release.channel}\nrun_id=${process.env.RUN_ID}\n`);
           JS
@@ -107,3 +108,17 @@ jobs:
         run: node scripts/release/presentation/updateChannelCatalog.mjs --tag "v$RELEASE_VERSION"
       - name: Verify every public surface serves this release
         run: node scripts/release/presentation/verifyPublicRelease.mjs --tag "v$RELEASE_VERSION" --channel "$RELEASE_CHANNEL"
+      - name: Summarize the completed release
+        run: |
+          set -euo pipefail
+          # The npm tag is the domain's, not the channel name: stable is latest.
+          tag=$(node -e "import('./scripts/release/domain/channel.mjs').then((m) => process.stdout.write(m.channelTags[process.env.RELEASE_CHANNEL] ?? ''))")
+          [ -n "$tag" ] || { echo "no npm dist-tag for channel $RELEASE_CHANNEL" >&2; exit 1; }
+          {
+            echo "## muxr $RELEASE_VERSION published on $RELEASE_CHANNEL"
+            echo
+            echo "- Download: https://trymuxr.com/downloads/$RELEASE_CHANNEL/android"
+            echo "- Channel page: https://trymuxr.com/downloads/$RELEASE_CHANNEL"
+            echo "- Release notes: https://github.com/${GITHUB_REPOSITORY}/releases/tag/v$RELEASE_VERSION"
+            echo "- Install: \`npm install -g --ignore-scripts @trymuxr/cli@$tag\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: Dev nightly, beta for phone testing, or unpublished final-version stable candidate
+        description: Nightly from tested main, or an unpublished final-version stable candidate
         type: choice
-        options: [beta, dev, stable]
-        default: beta
+        options: [nightly, stable]
+        default: nightly
       version:
-        description: Exact npm version (empty generates next patch dev/beta version)
+        description: Exact npm version (empty generates the next patch nightly version)
         type: string
         default: ''
 
@@ -44,21 +44,37 @@ jobs:
         name: Select an exact green commit and channel
         env:
           GH_TOKEN: ${{ github.token }}
-          REQUESTED_CHANNEL: ${{ inputs.channel || 'dev' }}
+          REQUESTED_CHANNEL: ${{ inputs.channel || 'nightly' }}
           REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$GITHUB_SHA&status=success" > "$RUNNER_TEMP/ci.json"
           jq -e --arg sha "$GITHUB_SHA" '.workflow_runs | any(.head_sha == $sha and .event == "push" and .head_branch == "main")' "$RUNNER_TEMP/ci.json"
-          if [ "$GITHUB_EVENT_NAME" = schedule ]; then
-            gh api "repos/$GITHUB_REPOSITORY/actions/workflows/release-candidate.yml/runs?head_sha=$GITHUB_SHA&status=success" > "$RUNNER_TEMP/previous.json"
-            if jq -e --arg sha "$GITHUB_SHA" '.workflow_runs | any(.head_sha == $sha)' "$RUNNER_TEMP/previous.json" >/dev/null; then
-              echo 'build=false' >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
           node --input-type=module <<'JS'
           import { appendFileSync, readFileSync } from 'node:fs';
           import { distribution } from './scripts/release/domain/channel.mjs';
+          import { CATALOG_BRANCH, parseCatalog } from './scripts/release/domain/channelCatalog.mjs';
+          import { readCatalogBranch, readTagCommit } from './scripts/release/infrastructure/catalogBranch.mjs';
+          const repository = process.env.GITHUB_REPOSITORY;
+          // A nightly is due unless this exact commit is already the published
+          // nightly. A candidate run alone proves nothing: a manual stable
+          // candidate, or a build whose publication failed, must not suppress
+          // the nightly for this commit. A manual run is never skipped.
+          if (process.env.GITHUB_EVENT_NAME === 'schedule') {
+            let publishedCommit;
+            try {
+              const published = parseCatalog(readCatalogBranch({ repository, branch: CATALOG_BRANCH }).text).channels.nightly;
+              // The tag's own commit, not its name: the publisher only writes an
+              // entry whose manifest was sealed from that exact commit.
+              if (published !== undefined) publishedCommit = readTagCommit({ repository, tag: published.tag });
+            } catch (cause) {
+              // Unproven is not proven equal: build rather than skip, loudly.
+              process.stderr.write(`could not read the published nightly (${cause.message}); building this commit\n`);
+            }
+            if (publishedCommit === process.env.GITHUB_SHA) {
+              appendFileSync(process.env.GITHUB_OUTPUT, 'build=false\n');
+              process.exit(0);
+            }
+          }
           const base = JSON.parse(readFileSync('package.json')).version.split('-')[0].split('.').map(Number);
           base[2] += 1;
           const channel = process.env.REQUESTED_CHANNEL;
@@ -133,7 +149,7 @@ jobs:
       version: ${{ needs.select.outputs.app_version }}
       release_version: ${{ needs.select.outputs.version }}
       version_code: ${{ needs.select.outputs.version_code }}
-      development: ${{ needs.select.outputs.channel == 'dev' }}
+      development: ${{ needs.select.outputs.channel == 'nightly' }}
     secrets: inherit
 
   release:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://play.google.com/apps/testing/com.trymuxr.app">Google Play testing</a> ·
   <a href="https://testflight.apple.com/join/aJSbs8pN">iOS TestFlight</a> ·
   <a href="https://trymuxr.com/downloads/stable/android">Download the Android APK</a> ·
-  <a href="https://trymuxr.com/downloads">Stable, beta and dev</a>
+  <a href="https://trymuxr.com/downloads">Stable and nightly</a>
 </p>
 
 <p align="center">
@@ -131,12 +131,12 @@ npm install -g --ignore-scripts @trymuxr/cli@latest
 muxr
 ```
 
-Prefer the beta? Install it with `npm install -g --ignore-scripts @trymuxr/cli@beta` and take its APK from the [beta channel](https://trymuxr.com/downloads/beta). The [dev channel](https://trymuxr.com/downloads/dev) tracks the newest build; its **Android app** installs alongside a stable or beta app rather than replacing it. On your computer every channel is the same CLI, so switching npm tags replaces the host you already run rather than adding a second one.
+Want the newest build? Install it with `npm install -g --ignore-scripts @trymuxr/cli@nightly` and take its APK from the [nightly channel](https://trymuxr.com/downloads/nightly). The **Android app** installs alongside a stable one rather than replacing it, so you can keep both on the phone. On your computer both channels are the same CLI, so switching npm tags replaces the host you already run rather than adding a second one. Beta and dev are retired: moving across is that one install, and an older binary will not upgrade itself to a `-nightly` version.
 
 Then install the mobile companion:
 
 - **Android (stable):** [join Google Play testing](https://play.google.com/apps/testing/com.trymuxr.app) · [download the stable APK](https://trymuxr.com/downloads/stable/android) · [stable checksum](https://trymuxr.com/downloads/stable/checksums)
-- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now. Store tracks review and roll out on their own schedule, so they do not move with the beta APK
+- **iOS:** [open the public TestFlight link](https://testflight.apple.com/join/aJSbs8pN) — Apple is not accepting new testers right now. Store tracks review and roll out on their own schedule, so they do not move with the nightly APK
 - **Web:** pair an eight-hour read-only browser during self-hosted setup
 - **All builds:** [every download channel](https://trymuxr.com/downloads)
 
@@ -175,6 +175,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and pull requests.
 
 muxr is licensed under [Apache License 2.0](LICENSE). Third-party notices are recorded in [NOTICE](NOTICE) and the [license inventory](docs/license-inventory.md). The muxr name and marks are covered by [TRADEMARK.md](TRADEMARK.md).
 
-## Development and beta builds
+## Development and nightly builds
 
-Merging into `main` advances development, not production. Use the [release channel workflow](docs/RELEASING.md) for signed dev/beta APKs, verified npm artifacts and explicit stable promotion. Emulator acceptance stays local.
+Merging into `main` advances development, not production. Use the [release channel workflow](docs/RELEASING.md) for signed nightly APKs, verified npm artifacts and explicit stable promotion. Emulator acceptance stays local.

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -128,7 +128,7 @@ android {
         manifestPlaceholders = [muxrScheme: developmentDistribution ? 'muxr-dev' : 'muxr',
             muxrExpoScheme: developmentDistribution ? 'exp+muxr-dev' : 'exp+muxr',
             muxrPairHost: developmentDistribution ? 'dev.invalid' : 'trymuxr.com',
-            muxrAppLabel: developmentDistribution ? 'muxr Dev' : 'muxr',
+            muxrAppLabel: developmentDistribution ? 'muxr Nightly' : 'muxr',
             muxrShortcuts: developmentDistribution ? '@xml/dev_shortcuts' : '@xml/shortcuts']
         resValue 'string', 'muxr_application_id', applicationId
         resValue 'string', 'muxr_link_scheme', developmentDistribution ? 'muxr-dev' : 'muxr'
@@ -152,6 +152,9 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            // The local development launcher and its messages still say Dev;
+            // only the signed nightly distribution carries the Nightly label.
+            if (developmentDistribution) manifestPlaceholders.muxrAppLabel = 'muxr Dev'
         }
         release {
             signingConfig signingConfigs.findByName('release')

--- a/apps/mobile/sources/settings/presentation/ConnectionSupport.tsx
+++ b/apps/mobile/sources/settings/presentation/ConnectionSupport.tsx
@@ -51,7 +51,7 @@ export function ConnectionSupport({ hostVersion: reportedHost }: { hostVersion?:
             <Item title={Platform.OS === 'web' ? 'Web app' : 'Installed app'} subtitle={`Version ${exactRelease ?? appVersion}${build ? ` · build ${build}` : ''}`}
                 subtitleLines={0} onPress={versionClick} showChevron={false} />
             <Item title="Connected host" subtitle={hostVersion ? `Version ${hostVersion}` : 'Version unavailable until the host reports it'} subtitleLines={0} />
-            <Item title="Get mobile builds" subtitle="Choose the stable or beta release you want to test" subtitleLines={0}
+            <Item title="Get mobile builds" subtitle="Choose the stable or nightly release you want to test" subtitleLines={0}
                 onPress={() => openExternalUrl('https://github.com/umeranjum17/muxr/releases')} />
         </ItemGroup>
         <ItemGroup title="Troubleshooting" footer="Diagnostics contain durations, counts and status codes. Credentials, terminal content and private identifiers are excluded.">

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,9 +5,8 @@
 ```mermaid
 flowchart LR
  PR[Reviewed PR + local acceptance] --> MAIN[main + CI]
- MAIN --> DEV[Nightly dev candidate]
- MAIN --> BETA[Manual beta candidate]
- BETA --> PHONE[Install APK and test on phone]
+ MAIN --> NIGHTLY[Nightly candidate]
+ NIGHTLY --> PHONE[Install APK and test on phone]
  PHONE --> FINAL[Build final-version candidate]
  FINAL --> APPROVE[Explicit maintainer production approval]
  APPROVE --> NPM[npm latest: exact retained tarball]
@@ -18,13 +17,15 @@ flowchart LR
 
 ## Build and try a candidate
 
-Run **release candidate** on `main` after its CI succeeds. Choose `beta` for the current phone-testing cycle. Leave version empty for an automatically unique next-patch prerelease, or give an exact version such as `0.1.27-beta.1`. Nightly runs choose `dev` and skip a commit already built successfully. Final-version candidates require an explicit stable version such as `0.1.27`; they remain GitHub prereleases and are never automatically published to npm.
+Run **release candidate** on `main` after its CI succeeds. Choose `nightly` for the current testing cycle; the daily nightly run skips a commit whose source is already published on the nightly channel, so a stable candidate cut from the same commit no longer suppresses that day's nightly. Leave version empty for an automatically unique next-patch prerelease, or give an exact version such as `0.1.27-nightly.1`. Final-version candidates require an explicit stable version such as `0.1.27`; they remain GitHub prereleases and are never automatically published to npm.
 
 Every successful candidate attaches a signed ARM64 APK/AAB, npm tarball, compiled Android manifest, signer fingerprint and SHA256 release manifest to `v<VERSION>`. The source commit is shared by both products. GitHub Actions keeps the build artifacts for 90 days; the release assets remain available. Failed runs keep their logs and leave existing releases/channel pointers alone. GitHub runs builds and normal checks; emulator testing stays local.
 
-- **Dev APK:** compiled `app.muxr.local.dev`, label `muxr Dev`, scheme `muxr-dev`, separate Android data. It cannot receive `muxr://` or production HTTPS pairing links. Default `dev.invalid` deliberately requires manual self-host pairing; no imaginary sandbox service is assumed. Build with `APP_ENV=development` and `-PmuxrDevelopmentApp=true`. This is a native Gradle configuration using the existing Release task, not an Expo-only identifier change.
-- **Beta/final APK:** compiled `com.trymuxr.app`, updates the existing directly installed app and shares its data. It is not a second beta app. The production upload key signs these downloads. Store signing may differ: compare fingerprints before assuming a direct APK can update a Play install.
-- **npm:** the verified publisher uses explicit `dev`, `beta`, or `latest` tags. Install with `npm install -g @trymuxr/cli@beta`; the exact attached tarball also works as a direct install. `muxr update` retains the installed channel. `muxr update --channel beta --yes` explicitly switches the current installation and managed services; it does not create an isolated second host. Registry downgrades require `--allow-downgrade`.
+- **Nightly APK:** compiled `app.muxr.local.dev`, labelled `muxr Nightly` on signed distributions and `muxr Dev` on a local debug build, scheme `muxr-dev`, separate Android data, so it installs beside a stable app instead of replacing it. It cannot receive `muxr://` or production HTTPS pairing links. Default `dev.invalid` deliberately requires manual self-host pairing; no imaginary sandbox service is assumed. Build with `APP_ENV=development` and `-PmuxrDevelopmentApp=true`. This is a native Gradle configuration using the existing Release task, not an Expo-only identifier change.
+- **Stable APK:** compiled `com.trymuxr.app`, updates the existing directly installed app and shares its data. It is not a second app. The production upload key signs these downloads. Store signing may differ: compare fingerprints before assuming a direct APK can update a Play install.
+- **npm:** the verified publisher uses explicit `nightly` or `latest` tags. Install with `npm install -g --ignore-scripts @trymuxr/cli@nightly`; the exact attached tarball also works as a direct install. `muxr update` retains the installed channel. Switching channels explicitly replaces the current installation and its managed services; it does not create an isolated second host. Registry downgrades require `--allow-downgrade`.
+
+Beta and dev are retired. Their npm dist-tags are frozen at their last releases and no longer move, and their GitHub releases stay exactly as published. Moving an existing beta or dev installation over is a one-time `npm install -g --ignore-scripts @trymuxr/cli@nightly`: an older binary's updater may refuse a `-nightly` version, so it will not carry itself across.
 
 Build numbers are reserved through the `release-build-numbers` Git branch. Fast-forward-only updates serialize concurrent reservations; failed builds and retries consume numbers permanently. Never reset/delete this ledger or use git commit count as versionCode. The legacy manual Android builder accepts an explicit number for maintenance only: reserve through the same ledger first. The candidate workflow does that automatically.
 
@@ -39,19 +40,19 @@ https://raw.githubusercontent.com/umeranjum17/muxr/release-channels/channels.jso
 ```
 
 ```json
-{ "schema": 1, "channels": { "beta": { "version": "0.1.27-beta.4.1", "appVersion": "0.1.27", "tag": "v0.1.27-beta.4.1",
-  "releaseUrl": "…/releases/tag/v0.1.27-beta.4.1", "npmDistTag": "beta", "publishedAt": "…", "manifestUrl": "…/release-manifest.json",
-  "android": { "url": "…/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk", "sha256": "…", "bytes": 176639520, "versionCode": 360, "applicationId": "com.trymuxr.app" } } } }
+{ "schema": 1, "channels": { "nightly": { "version": "0.1.28-nightly.5.1", "appVersion": "0.1.28", "tag": "v0.1.28-nightly.5.1",
+  "releaseUrl": "…/releases/tag/v0.1.28-nightly.5.1", "npmDistTag": "nightly", "publishedAt": "…", "manifestUrl": "…/release-manifest.json",
+  "android": { "url": "…/releases/download/v0.1.28-nightly.5.1/muxr-0.1.28-370.apk", "sha256": "…", "bytes": 175400000, "versionCode": 370, "applicationId": "app.muxr.local.dev" } } } }
 ```
 
-Every field is derived from that release's own combined `release-manifest.json` — the npm-only candidate manifest carries no Android identity and is never used for this. Artifact URLs are always canonical `github.com/umeranjum17/muxr/releases/download/<tag>/<name>` with the manifest's exact digests. `npmDistTag` is `latest` for stable, `beta` and `dev` for the others. `manifestUrl` may be null only for the legacy stable `0.1.25` seed, which predates sealed manifests.
+Every field is derived from that release's own combined `release-manifest.json` — the npm-only candidate manifest carries no Android identity and is never used for this. Artifact URLs are always canonical `github.com/umeranjum17/muxr/releases/download/<tag>/<name>` with the manifest's exact digests. `npmDistTag` is `latest` for stable and `nightly` for nightly. The retired `beta` and `dev` records stay readable in the catalog so links already published keep resolving; nothing writes to them again. Until the first nightly is published the site serves those historical records; from then on `/downloads/beta`, `/downloads/dev` and `/api/releases/{beta,dev}` answer HTTP 302 to their nightly equivalents, so an old link lands on the channel that continues that work. `manifestUrl` may be null only for the legacy stable `0.1.25` seed, which predates sealed manifests.
 
-`publish npm` performs this automatically after a verified publication, in steps that can also be run by hand:
+**publish release** performs this automatically after a verified publication, reporting a success summary once every public surface agrees. The same steps can be run by hand:
 
 ```
 node scripts/release/presentation/promoteReleaseVisibility.mjs --tag v0.1.27   # stable only
-node scripts/release/presentation/updateChannelCatalog.mjs --tag v0.1.27-beta.4.1
-node scripts/release/presentation/verifyPublicRelease.mjs --tag v0.1.27-beta.4.1 --channel beta
+node scripts/release/presentation/updateChannelCatalog.mjs --tag v0.1.28-nightly.5.1
+node scripts/release/presentation/verifyPublicRelease.mjs --tag v0.1.28-nightly.5.1 --channel nightly
 ```
 
 The catalog update is idempotent and backfills any retained release without rebuilding. Before it writes anything it checks identity rather than names: the tag must point at the commit its manifest was sealed from, the APK asset GitHub serves must match the manifest's name, size and sha256 digest, the retained tarball must match its manifest digest and hash to the sha512 integrity npm published, and the npm dist-tag must already name that exact version. It then updates only its own channel, serializing concurrent writers through fast-forward-only ref updates — never a force push, never a backwards move, never the same version pointing at different bytes.
@@ -66,20 +67,20 @@ Publications serialize through the `npm-publication` concurrency group with `can
 
 Durable website paths, served from that catalog: `/downloads/<channel>` for the human page, `/downloads/<channel>/android` redirecting to the canonical APK, `/downloads/<channel>/release` for the release page and `/downloads/<channel>/checksums` for digests, with `/api/releases/<channel>` returning the entry itself. Verification tolerates their short cache by retrying, never by weakening the comparison: it fails unless the served version and APK digest match the catalog and the redirect target is exactly the canonical artifact URL.
 
-Release titles are `muxr <version>`. PR and build provenance belongs in the notes, not the title. Every candidate is created with `--prerelease --latest=false`, so a preview never becomes GitHub's Latest. Stable promotion clears the prerelease flag on that same release and makes it Latest, after the explicit approval and the npm integrity checks — without creating a release or rebuilding a binary — so `releases/latest/download/<asset>` follows the accepted stable instead of going stale. Beta and dev stay prereleases permanently.
+Release titles are `muxr <version>`. PR and build provenance belongs in the notes, not the title. Every candidate is created with `--prerelease --latest=false`, so a preview never becomes GitHub's Latest. Stable promotion clears the prerelease flag on that same release and makes it Latest, after the explicit approval and the npm integrity checks — without creating a release or rebuilding a binary — so `releases/latest/download/<asset>` follows the accepted stable instead of going stale. Nightly stays a prerelease permanently.
 
 ## Stable promotion — only after the user accepts the candidate
 
-1. Select the accepted source. Build a **stable** candidate with its final version. A beta npm tarball cannot be renamed into a stable version: this is a new package, and its exact installed artifact must pass checks before promotion. Preserve the beta evidence and compare source/native bytes. Repeat local emulator/phone checks when relevant bytes change.
-2. Run **publish npm** with that successful candidate run ID and `confirmation=promote-VERSION`. The protected `production` environment requires maintainer approval. It downloads and verifies the retained tarball; it does not rebuild. An already published version must have exactly the same registry integrity. Automatic completion of a stable candidate never enters this promotion path.
+1. Select the accepted source. Build a **stable** candidate with its final version. A nightly npm tarball cannot be renamed into a stable version: this is a new package, and its exact installed artifact must pass checks before promotion. Preserve the nightly evidence and compare source/native bytes. Repeat local emulator/phone checks when relevant bytes change.
+2. Run **publish release** with that successful candidate run ID and `confirmation=promote-VERSION`. The protected `production` environment requires maintainer approval. It downloads and verifies the retained tarball; it does not rebuild. An already published version must have exactly the same registry integrity. Automatic completion of a stable candidate never enters this promotion path.
 3. For Android, run **mobile Android internal** with `candidate_run_id`, the matching app version/build number, `submit_to_play=true`, and `confirmation=release-VERSION-BUILD`. It verifies and uploads the candidate's AAB unchanged. Keep the resulting Internal run ID.
-4. Run **mobile closed testing**, then **mobile Android production promotion**, with that Internal run ID, exact source commit, version and build number. Main may have advanced; the selected artifact's source and digest remain binding. Production remains protected and rollout is explicit. No Play upload/promotion is implied by a GitHub beta download.
+4. Run **mobile closed testing**, then **mobile Android production promotion**, with that Internal run ID, exact source commit, version and build number. Main may have advanced; the selected artifact's source and digest remain binding. Production remains protected and rollout is explicit. No Play upload/promotion is implied by a GitHub nightly download.
 5. Mark the GitHub candidate release stable only after the chosen platform promotions succeed. Record each platform separately. Keep previous releases and evidence; halt rollout/advance to a higher mobile build for regressions. Do not rebuild under an existing version/tag or overwrite release assets.
 
 The `npm` environment is the npm OIDC identity. It allows the main workflow; the separate `production` environment gates stable publication. npm trusted publishing must name this repository, `publish.yml`, and environment `npm`. No npm token is stored in the repository. A trusted-publisher failure leaves the downloadable tarball/APK intact and does not claim registry success.
 
 ## Evidence before calling a feature stable
 
-Link the exact local gate report and phone observations in the PR/release. A successful build is not proof of microphone audio, live browser paint or a historical crash fix. Record known limitations explicitly. Current terminal polish includes tested deliberate keyboard behavior and route continuity; transient blank frames around explicit IME resize remain a beta limitation.
+Link the exact local gate report and phone observations in the PR/release. A successful build is not proof of microphone audio, live browser paint or a historical crash fix. Record known limitations explicitly. Current terminal polish includes tested deliberate keyboard behavior and route continuity; transient blank frames around explicit IME resize remain a known limitation.
 
 Use a unique watched evidence directory for every local run. Keep failed runs alongside successful reruns. iOS delivery and OTA remain disabled pending their own native/signing/runtime validation. A separate iOS development app and fully isolated parallel CLI hosts are future work, not claims made by this first Android/npm channel rollout.

--- a/scripts/cli.mjs
+++ b/scripts/cli.mjs
@@ -67,7 +67,7 @@ Run and maintain
   muxr status                    check this setup (same as muxr doctor)
   muxr restart                   restart the supervised relay and host
   muxr update [--check|--yes]    update within the installed release channel
-              [--channel dev|beta|stable] [--to VERSION] [--allow-downgrade]
+              [--channel stable|nightly] [--to VERSION] [--allow-downgrade]
   muxr uninstall [--yes]         fully remove muxr; keep Herdr and repositories
   muxr self-host [options]       run the relay, host, and pairing flow
   muxr daemon <command>          install, start, stop, restart, or inspect muxr services
@@ -336,7 +336,7 @@ async function applyUpdate(args = []) {
     }
     const channelIndex = args.indexOf('--channel');
     if (channelIndex !== -1 && !args[channelIndex + 1]) {
-        process.stderr.write('--channel requires dev, beta or stable\n');
+        process.stderr.write('--channel requires stable or nightly\n');
         return 1;
     }
     return updateCli({

--- a/scripts/diagnostics/application/checkPackageSmoke.mjs
+++ b/scripts/diagnostics/application/checkPackageSmoke.mjs
@@ -836,10 +836,22 @@ try {
     assert.match(run(cli, ['update', '--yes'], { cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '0.0.1' } }).stdout, /newer than stable/);
     assert.ok(!existsSync(updateLog), 'updater installed a registry downgrade');
     assert.match(run(cli, ['update', '--check'], { cwd: installDir, env: updateEnv }).stdout, /9\.9\.9 is available/);
-    const betaCheck = run(cli, ['update', '--channel', 'beta', '--check'], {
-        cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '9.9.9-beta.2' },
+    const nightlyCheck = run(cli, ['update', '--channel', 'nightly', '--check'], {
+        cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '9.9.9-nightly.2' },
     });
-    assert.match(betaCheck.stdout, /available on beta/);
+    assert.match(nightlyCheck.stdout, /available on nightly/);
+    assert.ok(!existsSync(updateLog), 'channel check changed the installation');
+    // A retired channel name resolves to nightly, and a retired version cannot
+    // arrive as the current nightly.
+    const retiredAlias = run(cli, ['update', '--channel', 'beta', '--check'], {
+        cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '9.9.9-nightly.2' },
+    });
+    assert.match(retiredAlias.stdout, /beta channel is retired/);
+    assert.match(retiredAlias.stdout, /available on nightly/);
+    const retiredOffer = run(cli, ['update', '--channel', 'nightly', '--check'], {
+        cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '9.9.9-beta.2' }, allowFailure: true,
+    });
+    assert.notEqual(retiredOffer.status, 0, 'a retired version was accepted as the current nightly');
     assert.ok(!existsSync(updateLog), 'channel check changed the installation');
     const exactCheck = run(cli, ['update', '--to', '9.9.8', '--check'], {
         cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_LATEST: '9.9.8' },
@@ -853,10 +865,10 @@ try {
     assert.match(exactDowngrade.stdout, /0\.0\.1 is available/);
     assert.ok(!existsSync(updateLog), 'exact-version checks changed the installation');
 
-    const wrongChannel = run(cli, ['update', '--channel', 'beta', '--yes'], {
+    const wrongChannel = run(cli, ['update', '--channel', 'nightly', '--yes'], {
         cwd: installDir, env: updateEnv, allowFailure: true,
     });
-    assert.notEqual(wrongChannel.status, 0, 'beta tag accepted a stable version');
+    assert.notEqual(wrongChannel.status, 0, 'nightly tag accepted a stable version');
     assert.ok(!existsSync(updateLog), 'wrong channel reached installation');
     const prefixMismatch = run(cli, ['update', '--yes'], {
         cwd: installDir, env: { ...updateEnv, MUXR_UPDATE_NPM_ROOT: join(scratch, 'different-node', 'node_modules') }, allowFailure: true,

--- a/scripts/diagnostics/application/checkReleaseCatalog.mjs
+++ b/scripts/diagnostics/application/checkReleaseCatalog.mjs
@@ -3,84 +3,91 @@ import {
     channelEntry, checksumLineMismatch, emptyCatalog, mergeCatalog, parseCatalog, publicRecordMismatch, serializeCatalog,
 } from '../../release/index.mjs';
 
-// The real sealed manifest of v0.1.27-beta.4.1, trimmed to the fields the
-// catalog derives from. Deriving from the combined GitHub release manifest is
-// the contract: the npm-only candidate manifest carries no Android identity.
-const betaManifest = {
+// A nightly manifest in the shape the candidate workflow seals: a -nightly
+// version, the development application identity so it installs beside the
+// production app, and the APK digests the release actually carries.
+const nightlyManifest = {
     schema: 1,
-    release: { version: '0.1.27-beta.4.1', appVersion: '0.1.27', channel: 'beta', distTag: 'beta', id: '0.1.27-beta.4.1-2ba5483803d9' },
+    release: { version: '0.1.28-nightly.1.1', appVersion: '0.1.28', channel: 'nightly', distTag: 'nightly', id: '0.1.28-nightly.1.1-2ba5483803d9' },
     source: { commit: '2ba5483803d9cf0d4421ef813491d1f28de3770c', tree: '2ab276b3a0188144071203274fce950d474dc167', dirty: false },
     build: { runId: '34034219166', runAttempt: '1' },
     artifacts: [
-        { name: 'muxr-0.1.27-360.aab', bytes: 138332936, sha256: '56c9f635081c760219ad17de60851e88bd1646f711c2d6a22cb900f9283edc3b' },
-        { name: 'muxr-0.1.27-360.apk', bytes: 176639520, sha256: 'e1a50185292c6fefcf6ccf069674957353116c0aae298114cee71131d25b8b76' },
-        { name: 'trymuxr-cli-0.1.27-beta.4.1.tgz', bytes: 11615642, sha256: '14959d2298f80ddac5633ff8e2478edc5d411dffffffffffffffffffffffffff' },
+        { name: 'muxr-0.1.28-361.aab', bytes: 138332936, sha256: '56c9f635081c760219ad17de60851e88bd1646f711c2d6a22cb900f9283edc3b' },
+        { name: 'muxr-0.1.28-361.apk', bytes: 176639520, sha256: 'e1a50185292c6fefcf6ccf069674957353116c0aae298114cee71131d25b8b76' },
     ],
-    android: { applicationId: 'com.trymuxr.app', versionCode: 360, signerSha256: '9c33841142483611257fcdf772f5e8fc30d6fac803f6da28e7eacfcaec12b08d' },
+    android: { applicationId: 'app.muxr.local.dev', versionCode: 361, signerSha256: '9c33841142483611257fcdf772f5e8fc30d6fac803f6da28e7eacfcaec12b08d' },
 };
-// The one legacy stable entry, seeded before sealed manifests existed.
-const legacyStable = {
-    version: '0.1.25', appVersion: '0.1.25', tag: 'v0.1.25',
-    releaseUrl: 'https://github.com/umeranjum17/muxr/releases/tag/v0.1.25',
-    npmDistTag: 'latest', publishedAt: '2026-08-31T01:07:31.000Z', manifestUrl: null,
+const record = (version, applicationId, npmDistTag) => ({
+    version, appVersion: version.split('-')[0], tag: `v${version}`,
+    releaseUrl: `https://github.com/umeranjum17/muxr/releases/tag/v${version}`,
+    npmDistTag, publishedAt: '2026-09-06T13:17:22.000Z',
+    manifestUrl: version === '0.1.25' ? null : `https://github.com/umeranjum17/muxr/releases/download/v${version}/release-manifest.json`,
     android: {
-        url: 'https://github.com/umeranjum17/muxr/releases/download/v0.1.25/muxr-android.apk',
+        url: `https://github.com/umeranjum17/muxr/releases/download/v${version}/muxr-android.apk`,
         sha256: 'c4dd3bd905658b79a58f1b28d919d89da0d3fb6c0b2fed6c7eb1a211f5c59305',
-        bytes: 174880788, versionCode: 53, applicationId: 'com.trymuxr.app',
+        bytes: 174880788, versionCode: 53, applicationId,
+    },
+});
+// What the published catalog holds today: the legacy stable seed plus the two
+// retired channels, which stay readable exactly as they were written.
+const published = {
+    schema: 1,
+    channels: {
+        stable: record('0.1.25', 'com.trymuxr.app', 'latest'),
+        beta: record('0.1.27-beta.4.1', 'com.trymuxr.app', 'beta'),
+        dev: record('0.1.27-dev.2.1', 'app.muxr.local.dev', 'dev'),
     },
 };
 
-const { channel, entry } = channelEntry({ tag: 'v0.1.27-beta.4.1', manifest: betaManifest, publishedAt: '2026-09-06T13:17:22Z' });
-assert.equal(channel, 'beta');
-assert.equal(entry.npmDistTag, 'beta');
-assert.equal(entry.appVersion, '0.1.27');
-assert.equal(entry.releaseUrl, 'https://github.com/umeranjum17/muxr/releases/tag/v0.1.27-beta.4.1');
-assert.equal(entry.manifestUrl, 'https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/release-manifest.json');
-assert.deepEqual(entry.android, {
-    url: 'https://github.com/umeranjum17/muxr/releases/download/v0.1.27-beta.4.1/muxr-0.1.27-360.apk',
-    sha256: 'e1a50185292c6fefcf6ccf069674957353116c0aae298114cee71131d25b8b76',
-    bytes: 176639520, versionCode: 360, applicationId: 'com.trymuxr.app',
-});
+const { channel, entry } = channelEntry({ tag: 'v0.1.28-nightly.1.1', manifest: nightlyManifest, publishedAt: '2026-09-06T13:17:22Z' });
+assert.equal(channel, 'nightly');
+assert.equal(entry.npmDistTag, 'nightly');
+assert.equal(entry.appVersion, '0.1.28');
+assert.equal(entry.android.applicationId, 'app.muxr.local.dev', 'nightly must keep the side-by-side application identity');
+assert.equal(entry.android.url, 'https://github.com/umeranjum17/muxr/releases/download/v0.1.28-nightly.1.1/muxr-0.1.28-361.apk');
+assert.equal(entry.manifestUrl, 'https://github.com/umeranjum17/muxr/releases/download/v0.1.28-nightly.1.1/release-manifest.json');
 
-// Publishing one channel preserves the others and survives a round trip.
-const seeded = mergeCatalog(emptyCatalog(), 'stable', legacyStable);
-const published = mergeCatalog(seeded, channel, entry);
-assert.deepEqual(published.channels.stable, legacyStable, 'publishing beta disturbed the stable entry');
-assert.equal(published.channels.beta.version, '0.1.27-beta.4.1');
-const serialized = serializeCatalog(published);
-assert.deepEqual(parseCatalog(serialized), published);
-assert.equal(serializeCatalog(mergeCatalog(published, channel, entry)), serialized, 'republishing the same release was not idempotent');
+// Publishing nightly preserves every historical record untouched.
+const parsed = parseCatalog(JSON.stringify(published));
+assert.deepEqual(Object.keys(parsed.channels), ['stable', 'beta', 'dev']);
+const next = mergeCatalog(parsed, channel, entry);
+assert.deepEqual(next.channels.beta, published.channels.beta, 'publishing nightly disturbed the retired beta record');
+assert.deepEqual(next.channels.dev, published.channels.dev, 'publishing nightly disturbed the retired dev record');
+assert.deepEqual(next.channels.stable, published.channels.stable);
+assert.equal(Object.keys(JSON.parse(serializeCatalog(next)).channels).join(','), 'stable,nightly,beta,dev');
+const serialized = serializeCatalog(next);
+assert.deepEqual(parseCatalog(serialized), next);
+assert.equal(serializeCatalog(mergeCatalog(next, channel, entry)), serialized, 'republishing the same release was not idempotent');
+
+// Retired channels are readable, never written; a retired name cannot be published.
+assert.throws(() => mergeCatalog(next, 'beta', record('0.1.27-beta.5', 'com.trymuxr.app', 'beta')), /Only stable and nightly/);
+assert.throws(() => mergeCatalog(next, 'nightly', { ...entry, version: '0.1.28-beta.1', tag: 'v0.1.28-beta.1' }), /invalid channel entry/i);
+// A historical record that predates the dev/nightly split still classifies as beta.
+assert.doesNotThrow(() => parseCatalog(JSON.stringify({ schema: 1, channels: { beta: record('0.1.26-rc.1', 'com.trymuxr.app', 'beta') } })));
 
 // A channel never moves backwards, and a published version never changes bytes.
-assert.throws(() => mergeCatalog(published, 'beta', channelEntry({
-    tag: 'v0.1.27-beta.3.1',
-    manifest: { ...betaManifest, release: { ...betaManifest.release, version: '0.1.27-beta.3.1' } },
+assert.throws(() => mergeCatalog(next, 'nightly', channelEntry({
+    tag: 'v0.1.28-nightly.0.1',
+    manifest: { ...nightlyManifest, release: { ...nightlyManifest.release, version: '0.1.28-nightly.0.1' } },
     publishedAt: '2026-09-06T10:00:00Z',
 }).entry), /backwards/);
-const tampered = { ...entry, android: { ...entry.android, sha256: 'f'.repeat(64) } };
-assert.throws(() => mergeCatalog(published, 'beta', tampered), /different bytes/);
-
-// Only the legacy stable seed may omit a manifest; anything else is rejected.
-assert.throws(() => mergeCatalog(published, 'beta', { ...entry, manifestUrl: null }), /invalid channel entry/i);
+assert.throws(() => mergeCatalog(next, 'nightly', { ...entry, android: { ...entry.android, sha256: 'f'.repeat(64) } }), /different bytes/);
+assert.throws(() => mergeCatalog(next, 'nightly', { ...entry, manifestUrl: null }), /invalid channel entry/i);
 assert.throws(() => parseCatalog(JSON.stringify({ schema: 2, channels: {} })), /schema/);
 assert.deepEqual(parseCatalog(''), emptyCatalog());
 
 // Public routes must agree with the same record the catalog publishes.
 const served = JSON.parse(JSON.stringify(entry));
-assert.equal(publicRecordMismatch(entry, served, 'beta'), undefined, 'an exact copy of the entry was rejected');
-assert.equal(publicRecordMismatch(entry, { ...served, channel: 'beta' }, 'beta'), undefined);
-assert.match(publicRecordMismatch(entry, { ...served, channel: 'dev' }, 'beta'), /channel dev/);
-assert.match(publicRecordMismatch(entry, { ...served, publishedAt: '2026-01-01T00:00:00.000Z' }, 'beta'), /publishedAt/);
-assert.match(publicRecordMismatch(entry, { ...served, android: { ...served.android, bytes: 1 } }, 'beta'), /android.bytes/);
-assert.match(publicRecordMismatch(entry, undefined, 'beta'), /no record/);
+assert.equal(publicRecordMismatch(entry, served, 'nightly'), undefined, 'an exact copy of the entry was rejected');
+assert.equal(publicRecordMismatch(entry, { ...served, channel: 'nightly' }, 'nightly'), undefined);
+assert.match(publicRecordMismatch(entry, { ...served, channel: 'stable' }, 'nightly'), /channel stable/);
+assert.match(publicRecordMismatch(entry, { ...served, publishedAt: '2026-01-01T00:00:00.000Z' }, 'nightly'), /publishedAt/);
+assert.match(publicRecordMismatch(entry, { ...served, android: { ...served.android, bytes: 1 } }, 'nightly'), /android.bytes/);
+assert.match(publicRecordMismatch(entry, undefined, 'nightly'), /no record/);
 const apkName = entry.android.url.split('/').pop();
 assert.equal(checksumLineMismatch(entry, `${entry.android.sha256}  ${apkName}\n`), undefined);
 assert.equal(checksumLineMismatch(entry, `# digests\n${entry.android.sha256} *${apkName}\n`), undefined);
 assert.match(checksumLineMismatch(entry, `${'0'.repeat(64)}  ${apkName}\n`), /no line pairing/);
-assert.match(checksumLineMismatch(entry, `${entry.android.sha256}  muxr-other.apk\n`), /no line pairing/);
 assert.match(checksumLineMismatch(entry, ''), /no checksums/);
-
-// The dev channel carries the separate development application identity.
-assert.throws(() => mergeCatalog(published, 'dev', { ...entry, version: '0.1.27-dev.9.1', tag: 'v0.1.27-dev.9.1' }), /invalid channel entry/i);
 
 process.stdout.write('release catalog flow passed\n');

--- a/scripts/release/application/publishCandidate.mjs
+++ b/scripts/release/application/publishCandidate.mjs
@@ -11,7 +11,9 @@ export async function publishCandidate() {
     await verifyRelease({ directory, version: VERSION, channel: CHANNEL, commit: GITHUB_SHA, runId: GITHUB_RUN_ID });
     const androidDirectory = join(RUNNER_TEMP, 'android');
     const android = JSON.parse(readFileSync(join(androidDirectory, 'result.json')));
-    const expectedId = CHANNEL === 'dev' ? 'app.muxr.local.dev' : 'com.trymuxr.app';
+    // Nightly carries the development application identity so it installs
+    // beside the production app; stable is the production identity.
+    const expectedId = CHANNEL === 'nightly' ? 'app.muxr.local.dev' : 'com.trymuxr.app';
     if (android.gitCommitHash !== GITHUB_SHA || android.bundleIdentifier !== expectedId || android.appBuildVersion !== BUILD_CODE) throw new Error('Android source or identity mismatch');
     const apk = readdirSync(androidDirectory).filter((name) => name.endsWith('.apk'));
     const aab = readdirSync(androidDirectory).filter((name) => name.endsWith('.aab'));
@@ -24,7 +26,7 @@ export async function publishCandidate() {
     await sealRelease({ directory, version: VERSION, channel: CHANNEL, files: readdirSync(directory), runId: GITHUB_RUN_ID, runAttempt: GITHUB_RUN_ATTEMPT,
         android: { applicationId: expectedId, versionCode: Number(BUILD_CODE), signerSha256: signer } });
     const notes = join(RUNNER_TEMP, 'candidate-notes.md');
-    writeFileSync(notes, `Development candidate; **not production**.\n\nChannel: ${CHANNEL}. Source: ${GITHUB_SHA}. Android build: ${BUILD_CODE}.\n\nDownload the APK below. ${CHANNEL === 'dev' ? 'The dev app installs separately and uses manual self-host pairing.' : 'This beta updates the existing direct-install muxr app; it shares its data.'}\n\nThe npm tarball can be installed directly with npm. Registry publication uses the separate verified publisher. Production promotion is manual.\n\n[Build and checks](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Local emulator and phone acceptance are recorded separately; a build is not device acceptance.\n`);
+    writeFileSync(notes, `Release candidate; **not production**.\n\nChannel: ${CHANNEL}. Source: ${GITHUB_SHA}. Android build: ${BUILD_CODE}.\n\nDownload the APK below. ${CHANNEL === 'nightly' ? 'The nightly app installs separately, keeps its own data and uses manual self-host pairing.' : 'This updates the existing direct-install muxr app; it shares its data.'}\n\nThe npm tarball can be installed directly with npm. Registry publication uses the separate verified publisher. Production promotion is manual.\n\n[Build and checks](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). Local emulator and phone acceptance are recorded separately; a build is not device acceptance.\n`);
     execFileSync('gh', ['release', 'create', `v${VERSION}`, ...readdirSync(directory).map((name) => join(directory, name)), '--repo', GITHUB_REPOSITORY,
         '--target', GITHUB_SHA, '--title', `muxr ${VERSION}`, '--prerelease', '--latest=false', '--notes-file', notes], { stdio: 'inherit' });
 }

--- a/scripts/release/application/updateChannelCatalog.mjs
+++ b/scripts/release/application/updateChannelCatalog.mjs
@@ -18,7 +18,7 @@ const PACKAGE = '@trymuxr/cli';
  */
 export async function updateChannelCatalog({ repository = CANONICAL_REPOSITORY, tag, branch = CATALOG_BRANCH, verifyCatalog = true } = {}) {
     if (repository !== CANONICAL_REPOSITORY) throw new Error('The public catalog belongs to the canonical repository');
-    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag ?? '')) throw new Error('An exact release tag is required, such as v0.1.27-beta.4.1');
+    if (!/^v[0-9A-Za-z.-]{1,120}$/.test(tag ?? '')) throw new Error('An exact release tag is required, such as v0.1.28-nightly.1.1');
     const release = readReleaseMetadata({ repository, tag });
     const assets = new Map(release.assets.map((asset) => [asset.name, asset]));
     if (!assets.has(MANIFEST_ASSET)) throw new Error(`${tag} has no retained ${MANIFEST_ASSET} to derive from`);

--- a/scripts/release/application/updateCli.mjs
+++ b/scripts/release/application/updateCli.mjs
@@ -4,7 +4,7 @@ import { existsSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { runBootstrap, daemonIsRunning, daemonMode, runDaemon, restartSelfhostRelayIfRunning, stopSelfhostRelayIfRunning } from '../../setup/index.mjs';
-import { compareVersions, channelTags, releaseChannel, releaseVersion } from '../domain/channel.mjs';
+import { compareVersions, channelTags, releaseVersion, resolveChannel } from '../domain/channel.mjs';
 
 const PACKAGE = '@trymuxr/cli';
 
@@ -63,9 +63,18 @@ export async function updateCli(command = {}) {
     let channel;
     let installedChannel;
     let targetVersion;
+    let retired;
     try {
-        installedChannel = releaseVersion(current).channel;
-        channel = command.channel === undefined ? installedChannel : releaseChannel(command.channel);
+        const installed = releaseVersion(current);
+        installedChannel = installed.channel;
+        // A beta or dev install is a nightly install now; the name changed, the
+        // work continues there. Nothing is downgraded to make that true.
+        retired = installed.legacy === true;
+        const requestedChannel = command.channel === undefined ? { channel: installedChannel } : resolveChannel(command.channel);
+        channel = requestedChannel.channel;
+        if (requestedChannel.from !== undefined) {
+            process.stdout.write(`The ${requestedChannel.from} channel is retired; its work continues on nightly.\n`);
+        }
         if (command.targetVersion !== undefined) {
             const requested = releaseVersion(command.targetVersion);
             if (requested.channel !== channel) throw new Error('Exact version belongs to a different channel; pass --channel explicitly to switch.');
@@ -89,7 +98,11 @@ export async function updateCli(command = {}) {
     catch { latest = lookup.stdout.trim(); }
     try {
         if (targetVersion !== undefined && latest !== targetVersion) throw new Error('exact version mismatch');
-        if (releaseVersion(latest).channel !== channel) throw new Error('channel mismatch');
+        const offered = releaseVersion(latest);
+        if (offered.channel !== channel) throw new Error('channel mismatch');
+        // A retired name must not arrive as the current nightly. Installing one
+        // stays possible, but only when the user pins it with --to.
+        if (targetVersion === undefined && offered.legacy === true) throw new Error('retired version on an active channel');
     } catch {
         process.stderr.write('npm returned an invalid version for the requested muxr channel or exact target\n');
         return 1;
@@ -107,6 +120,7 @@ export async function updateCli(command = {}) {
     }
 
     process.stdout.write(`muxr ${latest} is available on ${channel} (installed: ${current}, ${installedChannel}).\n`);
+    if (retired) process.stdout.write(`${current} came from a retired channel; nightly continues it, and its published packages stay available.\n`);
     if (channel !== installedChannel) process.stdout.write('This explicitly switches the current installation and its managed services; it does not create a second isolated host.\n');
     if (command.checkOnly) return 0;
     const installedMode = daemonMode();

--- a/scripts/release/domain/channel.mjs
+++ b/scripts/release/domain/channel.mjs
@@ -1,5 +1,12 @@
 /** Distribution channel is independent of server environment and app identity. */
-export const channelTags = Object.freeze({ dev: 'dev', beta: 'beta', stable: 'latest' });
+export const channelTags = Object.freeze({ stable: 'latest', nightly: 'nightly' });
+/**
+ * Beta and dev are historical. Their published versions, tags and releases stay
+ * exactly as they are: readable, installable, never written to again. An input
+ * naming one resolves to nightly, which is where that work continues.
+ */
+export const legacyChannelTags = Object.freeze({ beta: 'beta', dev: 'dev' });
+const NIGHTLY_PRERELEASE = /^nightly(\.|-|$)/;
 
 export function releaseVersion(version) {
     if (typeof version !== 'string' || version.length > 120) throw new Error('Invalid release version');
@@ -7,19 +14,29 @@ export function releaseVersion(version) {
     if (!match || match.slice(1, 4).some((value) => !Number.isSafeInteger(Number(value)))) throw new Error('Invalid release version');
     const prerelease = match[4];
     if (prerelease?.split('.').some((part) => /^\d+$/.test(part) && part.length > 1 && part.startsWith('0'))) throw new Error('Invalid prerelease number');
-    let channel = 'stable';
-    if (prerelease !== undefined) channel = /^(dev|nightly)(\.|-|$)/.test(prerelease) ? 'dev' : 'beta';
-    return { version, appVersion: match.slice(1, 4).join('.'), channel };
+    // Every prerelease belongs to nightly now. One named for a historical
+    // channel is marked legacy: still recognised, no longer publishable.
+    const legacy = prerelease !== undefined && !NIGHTLY_PRERELEASE.test(prerelease);
+    const channel = prerelease === undefined ? 'stable' : 'nightly';
+    return { version, appVersion: match.slice(1, 4).join('.'), channel, legacy };
 }
 
 export function releaseChannel(channel) {
-    if (typeof channel !== 'string' || !Object.hasOwn(channelTags, channel)) throw new Error('Channel must be dev, beta or stable');
+    if (typeof channel !== 'string' || !Object.hasOwn(channelTags, channel)) throw new Error('Channel must be stable or nightly');
     return channel;
+}
+
+/** Accepts a historical channel name and answers where that work lives now. */
+export function resolveChannel(channel) {
+    if (typeof channel === 'string' && Object.hasOwn(legacyChannelTags, channel)) return { channel: 'nightly', from: channel };
+    return { channel: releaseChannel(channel), from: undefined };
 }
 
 export function distribution(version, channel = releaseVersion(version).channel) {
     const result = releaseVersion(version);
     if (result.channel !== releaseChannel(channel)) throw new Error('Version does not belong to the requested release channel');
+    // A historical name cannot be published again under any channel.
+    if (result.legacy) throw new Error(`${version} names a retired channel; publish a -nightly version instead`);
     return { ...result, distTag: channelTags[channel] };
 }
 

--- a/scripts/release/domain/channelCatalog.mjs
+++ b/scripts/release/domain/channelCatalog.mjs
@@ -1,4 +1,4 @@
-import { channelTags, compareVersions, distribution } from './channel.mjs';
+import { channelTags, compareVersions, distribution, legacyChannelTags, releaseVersion } from './channel.mjs';
 
 /**
  * The public channel catalog: one small record per channel, pointing at the
@@ -11,15 +11,38 @@ export const CANONICAL_REPOSITORY = 'umeranjum17/muxr';
 // The one legacy entry predating sealed manifests; every later release carries one.
 const LEGACY_MANIFEST_EXEMPTION = Object.freeze({ channel: 'stable', version: '0.1.25' });
 export const MANIFEST_ASSET = 'release-manifest.json';
-// A dev build carries the separate development identity; nothing else may.
-const CHANNEL_APPLICATION_ID = Object.freeze({ stable: 'com.trymuxr.app', beta: 'com.trymuxr.app', dev: 'app.muxr.local.dev' });
+// A nightly build carries the separate development identity so it installs
+// beside the production app; beta and dev keep the identity they shipped with.
+const CHANNEL_APPLICATION_ID = Object.freeze({
+    stable: 'com.trymuxr.app', nightly: 'app.muxr.local.dev', beta: 'com.trymuxr.app', dev: 'app.muxr.local.dev',
+});
+const RECORDED_TAGS = Object.freeze({ ...channelTags, ...legacyChannelTags });
+const HISTORICAL_DEV = /^dev(\.|-|$)/;
+
+/** The classification those records were written under: dev, else beta. */
+function historicalChannelOf(prerelease) {
+    return HISTORICAL_DEV.test(prerelease) ? 'dev' : 'beta';
+}
+
+/** Historical records stay readable; only stable and nightly are ever written. */
+function recordedChannel(channel) {
+    return Object.hasOwn(RECORDED_TAGS, channel);
+}
+
+function belongsToChannel(version, channel) {
+    const parsed = releaseVersion(version);
+    if (Object.hasOwn(channelTags, channel)) return parsed.channel === channel && parsed.legacy === false;
+    const prerelease = version.split('-').slice(1).join('-');
+    return parsed.legacy === true && historicalChannelOf(prerelease) === channel;
+}
 
 export function catalogUrl(repository = CANONICAL_REPOSITORY, branch = CATALOG_BRANCH) {
     return `https://raw.githubusercontent.com/${repository}/${branch}/${CATALOG_PATH}`;
 }
 
+/** The tag of any recorded release, historical ones included. */
 export function releaseTag(version) {
-    return `v${distribution(version).version}`;
+    return `v${releaseVersion(version).version}`;
 }
 
 export function assetUrl(repository, tag, name) {
@@ -39,8 +62,9 @@ function canonicalTimestamp(value) {
 }
 
 function validEntry(entry, channel) {
-    if (!entry || typeof entry !== 'object') return false;
-    const release = distribution(entry.version, channel);
+    if (!entry || typeof entry !== 'object' || typeof entry.version !== 'string') return false;
+    if (!recordedChannel(channel) || !belongsToChannel(entry.version, channel)) return false;
+    const release = releaseVersion(entry.version);
     const android = entry.android;
     if (android === null || typeof android !== 'object' || entry.tag !== releaseTag(entry.version)) return false;
     const legacy = channel === LEGACY_MANIFEST_EXEMPTION.channel && entry.version === LEGACY_MANIFEST_EXEMPTION.version;
@@ -48,7 +72,7 @@ function validEntry(entry, channel) {
     const manifestAllowed = manifestExact || (entry.manifestUrl === null && legacy);
     const apkName = typeof android.url === 'string' ? android.url.split('/').pop() : '';
     return release.appVersion === entry.appVersion
-        && entry.npmDistTag === channelTags[channel]
+        && entry.npmDistTag === RECORDED_TAGS[channel]
         && entry.releaseUrl === `https://github.com/${CANONICAL_REPOSITORY}/releases/tag/${entry.tag}`
         && manifestAllowed
         && entry.publishedAt === canonicalTimestamp(entry.publishedAt)
@@ -98,14 +122,15 @@ export function parseCatalog(text) {
     const catalog = JSON.parse(text);
     if (catalog?.schema !== 1 || !catalog.channels || typeof catalog.channels !== 'object') throw new Error('Unsupported channel catalog schema');
     for (const [channel, entry] of Object.entries(catalog.channels)) {
-        if (!Object.hasOwn(channelTags, channel) || !validEntry(entry, channel)) throw new Error(`Invalid catalog entry: ${channel}`);
+        if (!recordedChannel(channel) || !validEntry(entry, channel)) throw new Error(`Invalid catalog entry: ${channel}`);
     }
     return { schema: 1, channels: { ...catalog.channels } };
 }
 
 /** Replaces one channel and preserves every other; never moves a channel backwards. */
 export function mergeCatalog(catalog, channel, entry) {
-    if (!Object.hasOwn(channelTags, channel)) throw new Error('Channel must be dev, beta or stable');
+    // Historical channels are preserved by the spread below, never rewritten.
+    if (!Object.hasOwn(channelTags, channel)) throw new Error('Only stable and nightly are published');
     if (!validEntry(entry, channel)) throw new Error('Refusing to publish an invalid channel entry');
     const current = catalog.channels[channel];
     if (current !== undefined) {
@@ -119,7 +144,7 @@ export function mergeCatalog(catalog, channel, entry) {
 
 export function serializeCatalog(catalog) {
     const channels = {};
-    for (const channel of Object.keys(channelTags).sort()) {
+    for (const channel of [...Object.keys(channelTags), ...Object.keys(legacyChannelTags)]) {
         if (catalog.channels[channel] !== undefined) channels[channel] = catalog.channels[channel];
     }
     return `${JSON.stringify({ schema: 1, channels }, undefined, 2)}\n`;


### PR DESCRIPTION
Stable, beta, and dev split the testing stream into two public channels. New releases now use only stable and nightly: nightly builds from tested main on the existing daily schedule or manual dispatch, while stable retains explicit promotion of verified candidate bytes.

The CLI recognizes nightly and accepts beta/dev as compatibility inputs. Historical versions, npm tags, and catalog entries remain readable but are no longer publication targets; moving an old CLI to nightly is documented as a one-time npm install. Nightly keeps the separate Android app identity, displays muxr Nightly in signed builds, and leaves local debug builds labelled muxr Dev. README and in-app download wording use the two active channels.

The publication workflow is named publish release and adds a channel/version/download summary only after npm, GitHub, catalog, and live website verification pass. Scheduled builds skip only a commit already published on nightly, so a stable candidate or unpublished build cannot suppress nightly publication.

Validation: product build, the real installed-package flow, and catalog migration flow passed. Android debug manifest generation passed and retains app.muxr.local.dev with muxr Dev label. Website counterpart https://github.com/umeranjum17/muxr-cloud/pull/25 passed its 17 tests and production container check. A fresh signed nightly will be built and verified after merged main CI succeeds; stable remains unchanged.
