### PR TITLE
Use iOS build settings for bundle release version

### DIFF
--- a/apps/mobile/ios/muxr/Info.plist
+++ b/apps/mobile/ios/muxr/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.12</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -39,7 +39,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>12</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
     <key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
The local iOS release lane passes version and build settings to Xcode, but Info.plist hardcodes 0.1.12 (12). The archive would retain those old values and fail the IPA identity checks.

Resolve the bundle version fields from MARKETING_VERSION and CURRENT_PROJECT_VERSION so the candidate can carry 0.1.27 (46). This changes only iOS release metadata.

Validation: plist lint and git diff --check passed. Simulator and archive metadata verification are pending.
