### PR TITLE
Report what a public surface served, not how the wait ended

### DIFF
--- a/scripts/diagnostics/application/checkReleaseCatalog.mjs
+++ b/scripts/diagnostics/application/checkReleaseCatalog.mjs
@@ -113,15 +113,29 @@ try {
     await readPublicJson(`${site}/api/releases/nightly`, { deadline, delayMs: 250, expect: (value) => publicRecordMismatch(entry, value, 'nightly') });
     const redirect = await requireRedirect(`${site}/downloads/nightly/android`, entry.android.url, { deadline, delayMs: 250 });
     assert.equal(redirect.status, 302);
-    await assert.rejects(
-        readPublicJson(`${site}/api/releases/nightly`, {
-            deadline: publicDeadline(400),
-            delayMs: 100,
-            expect: () => 'never converges',
-        }),
-        /did not serve the expected record \(never converges\)/,
-        'a surface that never converges was accepted',
-    );
+    // A surface that answers wrongly once and then goes quiet. The mismatch it
+    // served is what the operator must be told, even though the final attempt
+    // is still in flight when the budget ends and aborts.
+    let apiAttempts = 0;
+    const staleThenSilent = createServer((request, response) => {
+        apiAttempts += 1;
+        if (apiAttempts > 1) return;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ ...served, version: '0.1.27-beta.4.1' }));
+    });
+    try {
+        await new Promise((listening) => staleThenSilent.listen(0, '127.0.0.1', listening));
+        await assert.rejects(
+            readPublicJson(`http://127.0.0.1:${staleThenSilent.address().port}/api/releases/nightly`, {
+                deadline: publicDeadline(1500),
+                delayMs: 100,
+                expect: (value) => publicRecordMismatch(entry, value, 'nightly'),
+            }),
+            /served version "0\.1\.27-beta\.4\.1", expected "0\.1\.28-nightly\.1\.1"/,
+            'an expiry buried the mismatch the surface actually served',
+        );
+        assert.ok(apiAttempts >= 2, 'the stalled attempt was never reached, so nothing was in flight at the deadline');
+    } finally { staleThenSilent.close(); staleThenSilent.closeAllConnections?.(); }
 } finally { server.close(); }
 
 process.stdout.write('release catalog flow passed\n');

--- a/scripts/release/infrastructure/publicRecord.mjs
+++ b/scripts/release/infrastructure/publicRecord.mjs
@@ -34,16 +34,22 @@ function request(url, deadline, options = {}) {
  * mismatch is what gets reported, not the expiry.
  */
 async function attempt(deadline, delayMs, read) {
-    let detail = 'no response';
+    // What a surface actually served outranks how the budget ended: the last
+    // attempt is often still in flight when the deadline lands, and reporting
+    // its abort would bury the wrong record that is the reason to look at all.
+    let served;
+    let transport = 'no response';
     for (let round = 0; ; round += 1) {
         if (round > 0) {
             const before = deadline - Date.now();
-            if (before <= 0) return detail;
+            if (before <= 0) return served ?? transport;
             await sleep(Math.min(delayMs, before));
         }
-        if (deadline - Date.now() <= 0) return detail;
-        detail = await read();
-        if (detail === undefined) return undefined;
+        if (deadline - Date.now() <= 0) return served ?? transport;
+        const outcome = await read();
+        if (outcome === undefined) return undefined;
+        if (typeof outcome === 'string') transport = outcome;
+        else served = outcome.served;
     }
 }
 
@@ -52,10 +58,10 @@ export async function readPublicJson(url, { deadline = publicDeadline(), delayMs
     const failure = await attempt(deadline, delayMs, async () => {
         try {
             const response = await request(url, deadline, { redirect: 'follow', headers: { accept: 'application/json', 'cache-control': 'no-cache' } });
-            if (!response.ok) return `HTTP ${response.status}`;
+            if (!response.ok) return { served: `HTTP ${response.status}` };
             const value = await response.json();
             const mismatch = expect === undefined ? undefined : expect(value);
-            if (mismatch !== undefined) return mismatch;
+            if (mismatch !== undefined) return { served: mismatch };
             served = value;
             return undefined;
         } catch (cause) { return cause.message; }
@@ -69,10 +75,10 @@ export async function readPublicText(url, { deadline = publicDeadline(), delayMs
     const failure = await attempt(deadline, delayMs, async () => {
         try {
             const response = await request(url, deadline, { redirect: 'follow', headers: { 'cache-control': 'no-cache' } });
-            if (!response.ok) return `HTTP ${response.status}`;
+            if (!response.ok) return { served: `HTTP ${response.status}` };
             const value = await response.text();
             const mismatch = expect === undefined ? undefined : expect(value);
-            if (mismatch !== undefined) return mismatch;
+            if (mismatch !== undefined) return { served: mismatch };
             served = value;
             return undefined;
         } catch (cause) { return cause.message; }
@@ -88,8 +94,8 @@ export async function requireRedirect(url, expectedLocation, { deadline = public
         try {
             const response = await request(url, deadline, { redirect: 'manual', headers: { 'cache-control': 'no-cache' } });
             const location = response.headers.get('location');
-            if (response.status < 300 || response.status > 399) return `HTTP ${response.status} is not a redirect`;
-            if (location !== expectedLocation) return `redirects to ${location ?? 'nothing'}`;
+            if (response.status < 300 || response.status > 399) return { served: `HTTP ${response.status} is not a redirect` };
+            if (location !== expectedLocation) return { served: `redirects to ${location ?? 'nothing'}` };
             served = { status: response.status, location };
             return undefined;
         } catch (cause) { return cause.message; }


### PR DESCRIPTION
CI run 34044111499 failed `checkReleaseCatalog.mjs` while 31/32 other checks passed. The cause is production behaviour, not a slow test.

## Root cause

`attempt()` in `publicRecord.mjs` kept one `detail` and overwrote it on every round:

```js
detail = await read();
```

So an attempt still in flight when the budget expired replaced the mismatch a surface had already served with `The operation was aborted due to timeout`. That contradicts the documented contract — "the last real mismatch is what gets reported, not the expiry" — and buries the actionable answer exactly when an operator needs it: a surface stuck on the wrong record while also responding slowly.

It is timing-dependent, which is why it passed locally and failed on a loaded 2-core runner. Deterministic reproduction against the previous reader, with a surface that answers wrongly once and then goes quiet:

```
reported to the operator: The operation was aborted due to timeout
responses served: 2 (so a real mismatch WAS observed first)
```

## Fix

Readers now mark what a surface actually served (`{ served }`) versus a transport failure (a plain string), and the loop reports the served answer in preference to an expiry. A surface that never answers still reports its abort. The deadline is unchanged and still strict: a hung surface with an 800 ms budget gives up at 801 ms.

## Evidence

The flow check now drives the case that regressed rather than simply waiting longer: a surface answers wrongly once, stalls the next request until the budget ends, and the check asserts both the served mismatch and that the stalled attempt was actually reached.

- Against the previous reader: **fails** — `an expiry buried the mismatch the surface actually served`, actual `(The operation was aborted due to timeout)`.
- Against this reader: **passes**, five consecutive runs, ~3.1 s each.
- `checkArchitecture` 133 files, secret scan clean, `git diff --check` clean.

No new test file, no native or UI files, and no change to the convergence budget or the deadline contract.