### PR TITLE
Sign the app target alone, and prove what the archive actually ships

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,5 @@
 opt_out_usage
+require "digest"
 require "shellwords"
 
 
@@ -14,20 +15,51 @@ end
 platform :ios do
   desc "Build a signed App Store archive"
   lane :build_internal do
-    build_app(
-      workspace: "apps/mobile/ios/muxr.xcworkspace",
-      scheme: "muxr",
-      configuration: "Release",
-      export_method: "app-store",
-      output_directory: File.dirname(ENV.fetch("IOS_IPA_OUTPUT")),
-      output_name: File.basename(ENV.fetch("IOS_IPA_OUTPUT")),
-      export_options: {
-        signingStyle: "manual",
-        teamID: ENV.fetch("APPLE_TEAM_ID"),
-        provisioningProfiles: { "com.trymuxr.app" => ENV.fetch("IOS_PROFILE_NAME") }
-      },
-      xcargs: "MARKETING_VERSION=#{Shellwords.escape(ENV.fetch('APP_VERSION'))} CURRENT_PROJECT_VERSION=#{Shellwords.escape(ENV.fetch('IOS_BUILD_NUMBER'))} DEVELOPMENT_TEAM=#{Shellwords.escape(ENV.fetch('APPLE_TEAM_ID'))} CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(ENV.fetch('IOS_PROFILE_NAME'))}"
-    )
+    # Signing belongs to the app target alone. Passing it through xcargs hands
+    # the distribution profile to every Pods target as well; those are static
+    # libraries that must not be signed, and they fail before the app is built.
+    # The project file is a generated input, so it is restored afterwards.
+    # fastlane runs a lane's own code inside the fastlane folder and each action
+    # one level up at the repository root, so paths an action resolves on its
+    # own have to be anchored before plain Ruby can read the same file.
+    project = "apps/mobile/ios/muxr.xcodeproj"
+    pbxproj = File.expand_path(File.join("..", project, "project.pbxproj"), FastlaneCore::FastlaneFolder.path)
+    generated = File.read(pbxproj)
+    begin
+      # Expo generates the project with CODE_SIGN_IDENTITY[sdk=iphoneos*] set to
+      # a development identity, so the overrides are written in the same
+      # conditional form to be sure they win rather than sit beside it.
+      update_code_signing_settings(
+        path: project,
+        use_automatic_signing: false,
+        targets: ["muxr"],
+        build_configurations: ["Release"],
+        sdk: "iphoneos*",
+        team_id: ENV.fetch("APPLE_TEAM_ID"),
+        code_sign_identity: ENV.fetch("IOS_CODE_SIGN_IDENTITY", "Apple Distribution"),
+        profile_name: ENV.fetch("IOS_PROFILE_NAME")
+      )
+      # The project file is restored below, so the only place the archive's real
+      # input can be recorded is here, before it is handed to xcodebuild.
+      UI.message("pbxproj_generated_sha256: #{Digest::SHA256.hexdigest(generated)}")
+      UI.message("pbxproj_signed_sha256: #{Digest::SHA256.hexdigest(File.read(pbxproj))}")
+      build_app(
+        workspace: "apps/mobile/ios/muxr.xcworkspace",
+        scheme: "muxr",
+        configuration: "Release",
+        export_method: "app-store",
+        output_directory: File.dirname(ENV.fetch("IOS_IPA_OUTPUT")),
+        output_name: File.basename(ENV.fetch("IOS_IPA_OUTPUT")),
+        export_options: {
+          signingStyle: "manual",
+          teamID: ENV.fetch("APPLE_TEAM_ID"),
+          provisioningProfiles: { "com.trymuxr.app" => ENV.fetch("IOS_PROFILE_NAME") }
+        },
+        xcargs: "MARKETING_VERSION=#{Shellwords.escape(ENV.fetch('APP_VERSION'))} CURRENT_PROJECT_VERSION=#{Shellwords.escape(ENV.fetch('IOS_BUILD_NUMBER'))}"
+      )
+    ensure
+      File.write(pbxproj, generated)
+    end
   end
 
   desc "Upload an internal build directly to TestFlight"

--- a/scripts/buildIosLocal.sh
+++ b/scripts/buildIosLocal.sh
@@ -14,6 +14,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 : "${IOS_PROVISIONING_PROFILE_PATH:?IOS_PROVISIONING_PROFILE_PATH is required}"
 : "${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}"
 : "${IOS_IPA_OUTPUT:?IOS_IPA_OUTPUT is required}"
+# The store build's Expo project id decides whether push registration can even
+# ask for a token: app.config only publishes extra.eas when this is set, and
+# the app reports no native push without it. The value the App Store build
+# expects is the one committed in apps/mobile/eas.json under
+# build.production.env; it is supplied explicitly so a local archive can never
+# quietly fall back to a different project or to none.
+: "${MUXR_EAS_PROJECT_ID:?MUXR_EAS_PROJECT_ID is required}"
 
 [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "APP_VERSION must be semantic" >&2; exit 1; }
 [[ "$IOS_BUILD_NUMBER" =~ ^[1-9][0-9]*(\.[0-9]+)*$ ]] || { echo "IOS_BUILD_NUMBER must be positive numeric components" >&2; exit 1; }
@@ -21,7 +28,8 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 [[ "$IOS_IPA_OUTPUT" = *.ipa ]] || { echo "IOS_IPA_OUTPUT must end in .ipa" >&2; exit 1; }
 [ -f "$IOS_CERTIFICATE_PATH" ] || { echo "IOS_CERTIFICATE_PATH does not exist" >&2; exit 1; }
 [ -f "$IOS_PROVISIONING_PROFILE_PATH" ] || { echo "IOS_PROVISIONING_PROFILE_PATH does not exist" >&2; exit 1; }
-for command in xcodebuild security node yarn ruby bundle pod openssl unzip plutil shasum git awk; do
+[[ "$MUXR_EAS_PROJECT_ID" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || { echo "MUXR_EAS_PROJECT_ID must be a lowercase UUID" >&2; exit 1; }
+for command in xcodebuild codesign security node yarn ruby bundle pod openssl unzip plutil shasum git awk; do
   command -v "$command" >/dev/null || { echo "$command is required" >&2; exit 1; }
 done
 [ -z "$(git -C "$ROOT" status --porcelain)" ] || { echo "The repository must be clean before iOS validation" >&2; exit 1; }
@@ -37,7 +45,20 @@ fi
 export APP_ENV=production
 export MUXR_PUBLIC_BASE_URL=https://trymuxr.com
 export MUXR_DISTRIBUTION=store
-unset EXPO_PUBLIC_MUXR_MODE EXPO_PUBLIC_MUXR_RELAY_URL EXPO_PUBLIC_MUXR_TOKEN EXPO_PUBLIC_MUXR_MACHINE_ID
+export MUXR_EAS_PROJECT_ID
+# Metro inlines these at bundle time and they are not part of app.config, so
+# they cannot be checked in the archive afterwards. Dropping them does not
+# fall back to the hosted relay: the mode does default to hosted, but the
+# relay URL defaults to a loopback address, which is not what a store build
+# declares. Take the declared values from the committed production profile
+# rather than restating them here. Credentials are never baked in.
+store_profile="$ROOT/apps/mobile/eas.json"
+for store_key in EXPO_PUBLIC_MUXR_MODE EXPO_PUBLIC_MUXR_RELAY_URL; do
+  store_value="$(node -e 'const {env}=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).build.production;process.stdout.write(env[process.argv[2]] ?? "")' "$store_profile" "$store_key")"
+  [ -n "$store_value" ] || { echo "$store_key is missing from the production build profile" >&2; exit 1; }
+  export "$store_key=$store_value"
+done
+unset EXPO_PUBLIC_MUXR_TOKEN EXPO_PUBLIC_MUXR_MACHINE_ID
 
 (cd "$ROOT" && yarn install --frozen-lockfile --non-interactive)
 (cd "$ROOT" && (bundle check || bundle install))
@@ -68,6 +89,26 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# PlistBuddy renders a boolean and the string "false" the same way, and a
+# profile may authorise domains with a scalar wildcard rather than a list, so
+# the checks that turn on type read the plist as JSON. A conversion that fails
+# aborts rather than reading as an absent key.
+entitlements_json() { plutil -convert json -o "$2" "$1"; }
+debuggable_entitlement() {
+  ENTITLEMENTS_JSON="$1" node -e 'const entitlements = JSON.parse(require("fs").readFileSync(process.env.ENTITLEMENTS_JSON, "utf8"));
+const value = entitlements["get-task-allow"];
+process.stdout.write(value === undefined || value === false ? "no" : `yes (${JSON.stringify(value)})`);'
+}
+associated_domain_allowed() {
+  ENTITLEMENTS_JSON="$1" node -e 'const entitlements = JSON.parse(require("fs").readFileSync(process.env.ENTITLEMENTS_JSON, "utf8"));
+const declared = entitlements["com.apple.developer.associated-domains"];
+const [required, mode] = process.argv.slice(1);
+const entries = Array.isArray(declared) ? declared : [declared];
+// A profile may carry the wildcard that authorises every domain; a signed app
+// and the project always name the concrete domain.
+process.stdout.write(entries.some((entry) => entry === required || (mode === "authorises" && entry === "*")) ? "yes" : "no");' "$2" "$3"
+}
+
 security cms -D -i "$IOS_PROVISIONING_PROFILE_PATH" > "$profile_plist"
 profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
 profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")"
@@ -77,6 +118,17 @@ get_task_allow="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow
 [ "$profile_team" = "$APPLE_TEAM_ID" ] || { echo "Provisioning profile team does not match APPLE_TEAM_ID" >&2; exit 1; }
 [ "$application_id" = "$APPLE_TEAM_ID.com.trymuxr.app" ] || { echo "Provisioning profile application identifier is invalid" >&2; exit 1; }
 [ "$get_task_allow" = false ] || { echo "A non-debug provisioning profile is required" >&2; exit 1; }
+# The signed archive can only carry what both the profile and the project
+# declare, so disagreement is caught here rather than after the build.
+profile_aps="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:aps-environment' "$profile_plist" 2>/dev/null || true)"
+[ "$profile_aps" = production ] || { echo "The provisioning profile does not authorise production push" >&2; exit 1; }
+profile_entitlements="$workdir/profile-entitlements.json"
+plutil -extract Entitlements json -o "$profile_entitlements" "$profile_plist"
+[ "$(associated_domain_allowed "$profile_entitlements" applinks:trymuxr.com authorises)" = yes ] || { echo "The provisioning profile does not authorise the trymuxr.com associated domain" >&2; exit 1; }
+project_entitlements="$workdir/project-entitlements.json"
+entitlements_json "$ROOT/apps/mobile/ios/muxr/muxr.entitlements" "$project_entitlements"
+[ "$(/usr/libexec/PlistBuddy -c 'Print :aps-environment' "$ROOT/apps/mobile/ios/muxr/muxr.entitlements")" = production ] || { echo "The project does not declare production push" >&2; exit 1; }
+[ "$(associated_domain_allowed "$project_entitlements" applinks:trymuxr.com exact)" = yes ] || { echo "The project does not declare the trymuxr.com associated domain" >&2; exit 1; }
 
 profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
 mkdir -p "$profiles_dir"
@@ -117,13 +169,68 @@ unzip -p "$IOS_IPA_OUTPUT" "$mapfile_entry" > "$mapfile_path"
 [ "$(plutil -extract CFBundleShortVersionString raw "$mapfile_path")" = "$APP_VERSION" ]
 [ "$(plutil -extract CFBundleVersion raw "$mapfile_path")" = "$IOS_BUILD_NUMBER" ]
 
+commit_sha="$(git -C "$ROOT" rev-parse HEAD)"
+payload="$workdir/payload"
+unzip -q "$IOS_IPA_OUTPUT" -d "$payload"
+app="$payload/${mapfile_entry%/Info.plist}"
+[ -d "$app" ] || { echo "The IPA does not contain the expected app bundle" >&2; exit 1; }
+
+# An unsigned or development-signed export drops the capabilities the app
+# declares without failing, so the signature the IPA actually ships is what
+# gets checked, not the settings that were asked for.
+codesign --verify --deep --strict "$app" || { echo "The exported app is not validly signed" >&2; exit 1; }
+signature="$workdir/signature.txt"
+codesign -dvvv "$app" > "$signature" 2>&1
+[ "$(awk -F= '/^TeamIdentifier=/{print $2}' "$signature")" = "$APPLE_TEAM_ID" ] || { echo "The signed app is not from the expected team" >&2; exit 1; }
+signing_identity="$(awk -F= '/^Authority=/{print $2; exit}' "$signature")"
+case "$signing_identity" in
+  "Apple Distribution: "*|"iPhone Distribution: "*) ;;
+  *) echo "The app is not signed with a distribution identity: $signing_identity" >&2; exit 1 ;;
+esac
+
+entitlements="$workdir/entitlements.plist"
+codesign -d --entitlements :- --xml "$app" > "$entitlements"
+plutil -lint "$entitlements" >/dev/null
+signed_entitlement() { /usr/libexec/PlistBuddy -c "Print :$1" "$entitlements" 2>/dev/null || true; }
+[ "$(signed_entitlement aps-environment)" = production ] || { echo "The signed app does not carry production push" >&2; exit 1; }
+[ "$(signed_entitlement application-identifier)" = "$APPLE_TEAM_ID.com.trymuxr.app" ] || { echo "The signed application identifier is wrong" >&2; exit 1; }
+[ "$(signed_entitlement com.apple.developer.team-identifier)" = "$APPLE_TEAM_ID" ] || { echo "The signed team identifier is wrong" >&2; exit 1; }
+signed_entitlements="$workdir/entitlements.json"
+entitlements_json "$entitlements" "$signed_entitlements"
+# A store signature normally omits get-task-allow entirely; boolean false is
+# equally non-debug. Any other value, of any type, is not shippable.
+debuggable="$(debuggable_entitlement "$signed_entitlements")"
+[ "$debuggable" = no ] || { echo "The signed app is debuggable: get-task-allow is $debuggable" >&2; exit 1; }
+[ "$(associated_domain_allowed "$signed_entitlements" applinks:trymuxr.com exact)" = yes ] || { echo "The signed app is missing the trymuxr.com associated domain" >&2; exit 1; }
+
+embedded_plist="$workdir/embedded.plist"
+security cms -D -i "$app/embedded.mobileprovision" > "$embedded_plist"
+[ "$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$embedded_plist")" = "$profile_uuid" ] || { echo "The IPA embeds a different provisioning profile" >&2; exit 1; }
+
+# Push registration reads the project id out of this file at runtime, so an
+# archive built without it reports no native push however well it is signed.
+app_config="$app/EXConstants.bundle/app.config"
+[ -f "$app_config" ] || { echo "The app bundle does not contain EXConstants.bundle/app.config" >&2; exit 1; }
+config_value() {
+  APP_CONFIG="$app_config" node -e 'const config = JSON.parse(require("fs").readFileSync(process.env.APP_CONFIG, "utf8"));
+const value = process.argv.slice(1).reduce((node, key) => (node === undefined ? undefined : node[key]), config);
+process.stdout.write(value === undefined ? "" : String(value));' "$@"
+}
+[ "$(config_value extra eas projectId)" = "$MUXR_EAS_PROJECT_ID" ] || { echo "The archive does not embed the required Expo project id" >&2; exit 1; }
+[ "$(config_value extra app publicBaseUrl)" = "$MUXR_PUBLIC_BASE_URL" ] || { echo "The archive embeds a different public base URL" >&2; exit 1; }
+[ "$(config_value extra app directDistribution)" = false ] || { echo "The archive is not configured for store distribution" >&2; exit 1; }
+[ "$(config_value extra app consoleLoggingDefault)" = false ] || { echo "The archive would log to the console by default" >&2; exit 1; }
+[ "$(config_value extra app releaseVersion)" = "$APP_VERSION" ] || { echo "The archive embeds a different release version" >&2; exit 1; }
+[ "$(config_value extra app buildCommitSha)" = "$commit_sha" ] || { echo "The archive embeds a different source commit" >&2; exit 1; }
+
 ipa_sha256="$(shasum -a 256 "$IOS_IPA_OUTPUT" | awk '{print $1}')"
+entitlements_sha256="$(shasum -a 256 "$entitlements" | awk '{print $1}')"
+app_config_sha256="$(shasum -a 256 "$app_config" | awk '{print $1}')"
 podfile_lock="$ROOT/apps/mobile/ios/Podfile.lock"
 [ -f "$podfile_lock" ] || { echo "pod install did not produce Podfile.lock" >&2; exit 1; }
 podfile_lock_sha256="$(shasum -a 256 "$podfile_lock" | awk '{print $1}')"
 ghostty_libraries="$(cd "$ROOT/node_modules/expo-libghostty/ios/vendor/Frameworks/GhosttyKit.xcframework" \
   && shasum -a 256 ios-arm64/libghostty.a ios-arm64_x86_64-simulator/libghostty.a | awk '{printf "%s=%s ", $2, $1}')"
-commit_sha="$(git -C "$ROOT" rev-parse HEAD)"
 printf '%s\n' \
   "iOS archive validation passed" \
   "commit: $commit_sha" \
@@ -133,4 +240,10 @@ printf '%s\n' \
   "ipa_sha256: $ipa_sha256" \
   "podfile_lock_sha256: $podfile_lock_sha256" \
   "ghostty_libraries: $ghostty_libraries" \
+  "entitlements_sha256: $entitlements_sha256" \
+  "app_config_sha256: $app_config_sha256" \
+  "signing_identity: $signing_identity" \
+  "profile_uuid: $profile_uuid" \
+  "eas_project_id: $MUXR_EAS_PROJECT_ID" \
+  "build_env: EXPO_PUBLIC_MUXR_MODE=$EXPO_PUBLIC_MUXR_MODE EXPO_PUBLIC_MUXR_RELAY_URL=$EXPO_PUBLIC_MUXR_RELAY_URL (Metro inputs, not app.config keys)" \
   "ipa: $IOS_IPA_OUTPUT"

--- a/scripts/buildIosLocal.sh
+++ b/scripts/buildIosLocal.sh
@@ -123,7 +123,12 @@ get_task_allow="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:get-task-allow
 profile_aps="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:aps-environment' "$profile_plist" 2>/dev/null || true)"
 [ "$profile_aps" = production ] || { echo "The provisioning profile does not authorise production push" >&2; exit 1; }
 profile_entitlements="$workdir/profile-entitlements.json"
-plutil -extract Entitlements json -o "$profile_entitlements" "$profile_plist"
+# A decoded profile carries objects JSON cannot represent, and plutil rejects
+# the whole document rather than just the subtree being asked for, so the
+# entitlements are lifted out as a plist first and converted on their own.
+profile_entitlements_plist="$workdir/profile-entitlements.plist"
+plutil -extract Entitlements xml1 -o "$profile_entitlements_plist" "$profile_plist"
+entitlements_json "$profile_entitlements_plist" "$profile_entitlements"
 [ "$(associated_domain_allowed "$profile_entitlements" applinks:trymuxr.com authorises)" = yes ] || { echo "The provisioning profile does not authorise the trymuxr.com associated domain" >&2; exit 1; }
 project_entitlements="$workdir/project-entitlements.json"
 entitlements_json "$ROOT/apps/mobile/ios/muxr/muxr.entitlements" "$project_entitlements"


### PR DESCRIPTION
For future builds only. The frozen 0.1.28 artifacts and the archive being uploaded now are untouched by this.

## Signing

The lane set `CODE_SIGN_STYLE`, `DEVELOPMENT_TEAM` and `PROVISIONING_PROFILE_SPECIFIER` through `xcargs`, which applies them to every target in the build — including the Pods targets, which are static libraries that must not be signed. Reaching for global `CODE_SIGNING_ALLOWED` overrides to get past that breaks them a different way.

`update_code_signing_settings` writes into the app project only, and that project contains exactly one target, so the Pods project is out of reach by construction. It is scoped further to `targets: ["muxr"]`, `build_configurations: ["Release"]`. The overrides are written in the `[sdk=iphoneos*]` conditional form because Expo generates the project with `CODE_SIGN_IDENTITY[sdk=iphoneos*]` set to a development identity at the project level; matching that form removes any question of which one wins. The identity defaults to `Apple Distribution` and can be overridden with `IOS_CODE_SIGN_IDENTITY` for an older certificate.

The action rewrites and reformats the whole `project.pbxproj`, which is a generated file, so the lane restores it in an `ensure` — on failure too. That is also why the hashes of both the generated input and the signing-configured input are printed inside the lane, before `build_app`: afterwards the file on disk is the restored one and no longer describes what was archived.

## What the export is checked for

An export can quietly drop the capabilities the app declares, which is exactly what happened. The IPA is now unpacked and checked before anything can upload it: `codesign --verify --deep --strict`, a distribution authority from the expected team, `aps-environment` production, the correct `application-identifier` and team identifier, the `applinks:trymuxr.com` associated domain, no debuggable entitlement, and the embedded profile UUID matching the one validated at the start.

Both the profile and the project are checked to agree before the build starts, so a mismatch costs seconds rather than an archive. The profile is allowed to authorise domains with the scalar `*` wildcard as well as a list; a signed app and the project must name the concrete domain.

Where a value's type decides the answer, the plist is read as JSON rather than through PlistBuddy, which renders boolean `false` and the string `"false"` identically. `get-task-allow` passes only when absent or actually boolean false; a failed conversion aborts instead of being read as an absent key.

## The Expo project id

`app.config` publishes `extra.eas` only when `MUXR_EAS_PROJECT_ID` is set, and push registration returns false without it. The local script never required it, so a locally built store archive was correctly signed for production push and still reported no native push at runtime.

It is now required from the operator — validated as a UUID, never defaulted; the value the store build expects is the one committed in `apps/mobile/eas.json` under `build.production.env`. The packaged `EXConstants.bundle/app.config` is then checked to carry it, along with the public base URL, store distribution, release version and source commit.

The same profile declares `EXPO_PUBLIC_MUXR_MODE` and `EXPO_PUBLIC_MUXR_RELAY_URL`. The script dropped both; the mode default happens to match, but the relay URL falls back to a loopback address, so a local store archive shipped pointing at localhost. Those two are now taken from the committed profile rather than restated here. They are Metro inputs inlined at bundle time, not `app.config` keys, so they are recorded as evidence and never presented as something the archive was checked for. Credentials are still never baked in.

## Validation

No Xcode here, so nothing was archived or signed. What was exercised:

- The real `update_code_signing_settings` from fastlane 2.238.0, called with the lane's parameters verbatim, against a copy of the current generated project: `Skipping Debug not selected`, only `muxr/Release` modified, exactly `CODE_SIGN_STYLE=Manual`, `CODE_SIGN_IDENTITY[sdk=iphoneos*]`, `DEVELOPMENT_TEAM[sdk=iphoneos*]`, `PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]`; `CODE_SIGN_ENTITLEMENTS` and `PRODUCT_BUNDLE_IDENTIFIER` preserved; project-level settings untouched.
- The full lane body, minus `build_app`, on that copy: `pbxproj_generated_sha256` matched the committed file, `pbxproj_signed_sha256` differed, and the project was restored byte-identical — on the success path and on a simulated archive failure.
- This caught a real defect: fastlane runs a lane's own code inside `fastlane/` and each action one level up, so the plain `File.read` failed with ENOENT. The path is now anchored explicitly. It would have failed on the first Mac run.
- The typed entitlement checks against fixtures: absent and boolean false accepted; boolean true, `"false"`, `""` and `0` rejected. Domains: scalar `*`, `["*"]` and the exact entry authorised for a profile; a near-miss suffix and a bare `*` rejected for a signed app; the real `muxr.entitlements` accepted.
- `ruby -c`, `bash -n`, and the committed production profile read back through the exact expression the script uses.

A first macOS preflight then found a real failure that none of the above could reach: `plutil -extract Entitlements json` exited 1 against an actual provisioning profile, because plutil validates the whole document against the destination format and a decoded profile carries a creation date and certificate blobs JSON cannot represent. The entitlements are now lifted out as a plist and converted on their own.

## Verified on macOS

- Corrected extraction against the actual provisioning profile: exit 0, scalar wildcard `associated-domains` and production `aps-environment` preserved, decoded input unchanged.
- The post-export helpers and gate run against the retained final IPA `4b80053e`: PASS.
- An IPA missing production push (`1368`) is rejected, and fails at the expected guard rather than incidentally.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCASatKCB1og812nz5x83V

