### PR TITLE
Let a build-only run be the artifact an import uploads

### DIFF
--- a/.github/workflows/mobile-android-internal.yml
+++ b/.github/workflows/mobile-android-internal.yml
@@ -340,8 +340,10 @@ jobs:
           sha=$(jq -r .head_sha "$RUNNER_TEMP/candidate.json")
           # An artifact that already went to Internal is not a candidate for
           # being sent again: this rejects a re-import of an earlier import's
-          # own output as well as any run that published what it built.
-          jq -e --arg sha "$sha" --arg version "$APP_VERSION" --arg code "$ANDROID_VERSION_CODE" '.gitCommitHash == $sha and .appVersion == $version and .appBuildVersion == $code and .bundleIdentifier == "com.trymuxr.app" and (.submittedToInternal | not)' "$RUNNER_TEMP/android-internal/result.json"
+          # own output as well as any run that published what it built. The
+          # sealed result always carries the flag as a boolean, so an absent one
+          # is missing provenance rather than evidence of an unsubmitted build.
+          jq -e --arg sha "$sha" --arg version "$APP_VERSION" --arg code "$ANDROID_VERSION_CODE" '.gitCommitHash == $sha and .appVersion == $version and .appBuildVersion == $code and .bundleIdentifier == "com.trymuxr.app" and .submittedToInternal == false' "$RUNNER_TEMP/android-internal/result.json"
           mapfile -t bundles < <(find "$RUNNER_TEMP/android-internal" -type f -name '*.aab')
           test "${#bundles[@]}" -eq 1
           test "$(sha256sum "${bundles[0]}" | cut -d ' ' -f 1)" = "$(jq -r .artifactSha256 "$RUNNER_TEMP/android-internal/result.json")"

--- a/.github/workflows/mobile-android-internal.yml
+++ b/.github/workflows/mobile-android-internal.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       candidate_run_id:
-        description: Successful release candidate run to upload unchanged (empty builds manually)
+        description: Successful release-candidate run, or a build-only run of this workflow, to upload unchanged (empty builds manually)
         required: false
         type: string
       version:
@@ -327,10 +327,21 @@ jobs:
         run: |
           [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$CANDIDATE_RUN_ID" > "$RUNNER_TEMP/candidate.json"
-          jq -e '.path == ".github/workflows/release-candidate.yml" and .head_branch == "main" and .status == "completed" and .conclusion == "success"' "$RUNNER_TEMP/candidate.json"
+          # A candidate, or a build-only run of this workflow: both produce the
+          # same signed artifact, and a build-only run is the only way to get one
+          # without publishing it. A run of this workflow called by the candidate
+          # reports the caller's path, so the two sources stay distinct.
+          jq -e '
+            .head_branch == "main" and .status == "completed" and .conclusion == "success" and (
+              .path == ".github/workflows/release-candidate.yml"
+              or (.path == ".github/workflows/mobile-android-internal.yml" and .event == "workflow_dispatch")
+            )' "$RUNNER_TEMP/candidate.json"
           gh run download "$CANDIDATE_RUN_ID" --repo "$GITHUB_REPOSITORY" --name android-internal --dir "$RUNNER_TEMP/android-internal"
           sha=$(jq -r .head_sha "$RUNNER_TEMP/candidate.json")
-          jq -e --arg sha "$sha" --arg version "$APP_VERSION" --arg code "$ANDROID_VERSION_CODE" '.gitCommitHash == $sha and .appVersion == $version and .appBuildVersion == $code and .bundleIdentifier == "com.trymuxr.app"' "$RUNNER_TEMP/android-internal/result.json"
+          # An artifact that already went to Internal is not a candidate for
+          # being sent again: this rejects a re-import of an earlier import's
+          # own output as well as any run that published what it built.
+          jq -e --arg sha "$sha" --arg version "$APP_VERSION" --arg code "$ANDROID_VERSION_CODE" '.gitCommitHash == $sha and .appVersion == $version and .appBuildVersion == $code and .bundleIdentifier == "com.trymuxr.app" and (.submittedToInternal | not)' "$RUNNER_TEMP/android-internal/result.json"
           mapfile -t bundles < <(find "$RUNNER_TEMP/android-internal" -type f -name '*.aab')
           test "${#bundles[@]}" -eq 1
           test "$(sha256sum "${bundles[0]}" | cut -d ' ' -f 1)" = "$(jq -r .artifactSha256 "$RUNNER_TEMP/android-internal/result.json")"


### PR DESCRIPTION
Tooling only, off `cee53e98`. The release freeze does not move.

A build-only run — `submit_to_play: false` — is the only way to produce a signed store artifact without publishing it. But `import-candidate` required its source run to be a release candidate, so the exact tested build could never reach Internal later without being rebuilt. Run `34086251961` at `cee53e98` is producing build 365 right now and would have been unusable as an import source.

## What changes

Import accepts either source: a release-candidate run, or a `workflow_dispatch` run of this workflow. Everything else is retained — completed, successful, on `main`, and the artifact still proved against the run's own `head_sha`, version, build number, identifier and AAB digest.

A run of this workflow *called by* the candidate reports the caller's path, so the two sources stay distinct rather than overlapping.

One assertion is added: the artifact must carry `submittedToInternal == false`. That rejects a re-import of an earlier import's own output — which is written back with the flag set — and any run that published what it built. Without it, widening the accepted source would have opened a way to launder an upload through a second run.

It is an equality check rather than a falsiness one on purpose. The sealed result always writes the flag as a boolean, so an artifact without one has lost its provenance rather than proved it was never published, and treating absence as unsubmitted would let provenance be established by omission.

The `candidate_run_id` description now says so.

## Verified against real metadata, not fixtures invented for the purpose

Run-source guard, driven by the actual `34086251961` run JSON and variants of it:

```
buildonly     ACCEPT     (dispatch of this workflow, completed+success)
candidate     ACCEPT     (release-candidate path)
push          reject     (this workflow, but not a dispatch)
other         reject     (a different workflow)
run-live      reject     (the real run as it stands: still in_progress)
```

Artifact guard, driven by the retained `result.json` from the 0.1.28 store candidate:

```
submittedToInternal: false   ACCEPT   (a build-only artifact)
submittedToInternal: true    reject   (an earlier import's own output)
submittedToInternal: null    reject
field missing                reject
wrong version code           reject
```

One workflow file, +14/−3, no native changes and no new tests. The in-flight build was not touched.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCASatKCB1og812nz5x83V
