### PR TITLE
Carry a prepared frame to the phone instead of discarding it

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
@@ -462,6 +462,61 @@ describe('Herdr graphics flow', () => {
         expect(frames.some((frame) => frame.includes('p=700001'))).toBe(false);
     });
 
+    it('delivers a frame while a producer keeps repainting the same surface', async () => {
+        // Supersession is re-checked after the layout probe, after the decode
+        // and after the rect. While a producer repaints faster than one frame
+        // can be prepared, a newer block for the same surface is always queued
+        // by the time those checks run, so every prepared frame is discarded
+        // and the pane delivers nothing at all.
+        const socket = Object.assign(new EventEmitter(), { writable: true, write: () => true, destroy: () => {} });
+        const bridge = Reflect.construct(HerdrGraphicsBridge, [socket, 'herdr']) as HerdrGraphicsBridge;
+        const internals = bridge as unknown as {
+            sourcePane: (leading: Buffer) => Promise<string | undefined>;
+            visibleRect: (paneId: string) => Promise<{ x: number; y: number; width: number; height: number } | undefined>;
+            queueInline: (data: Buffer) => void;
+            drainInline: () => Promise<void>;
+            inlineQueue: unknown[];
+        };
+        internals.sourcePane = async () => 'pane';
+
+        const frames: string[] = [];
+        bridge.register({
+            channel: 'phone', paneId: 'pane', cols: 20, rows: 10, cellWidthPx: 10, cellHeightPx: 20,
+            write: (frame) => frames.push(frame),
+        });
+
+        const pixels = Buffer.alloc(2 * 2 * 4, 7).toString('base64');
+        const repaint = (id: number): Buffer => Buffer.from(
+            '\u001b[1;1H'
+            + `\u001b_Ga=t,f=32,s=2,v=2,i=${id},m=0;${pixels}\u001b\\`
+            + `\u001b_Ga=p,i=${id},c=20,r=10;\u001b\\`,
+        );
+        // The layout probe shells out to herdr, so it really is async. A
+        // repaint lands while it is open, which is what a scrolling browser
+        // does: the next frame is always already waiting.
+        let repaints = 1;
+        let deliveredDuringBurst = -1;
+        internals.visibleRect = async () => {
+            if (repaints < 6) { repaints += 1; internals.queueInline(repaint(repaints)); }
+            // What the phone has been shown while the producer is still going.
+            if (repaints === 5) deliveredDuringBurst = frames.length;
+            await new Promise((resolve) => setImmediate(resolve));
+            return { x: 0, y: 0, width: 20, height: 10 };
+        };
+
+        const drain = vi.spyOn(internals, 'drainInline');
+        internals.queueInline(repaint(1));
+        await drain.mock.results.at(-1)?.value;
+        expect(internals.inlineQueue).toHaveLength(0);
+        expect(repaints).toBe(6);
+
+        // The last repaint finds an empty queue and is delivered, so counting
+        // at the end hides this. What matters is the phone being shown nothing
+        // for as long as the producer keeps painting: a scrolling browser only
+        // moves once the gesture stops.
+        expect(deliveredDuringBurst).toBeGreaterThan(0);
+    });
+
     it('keeps two program images, coalesces repaints, and paces a gesture', async () => {
         const socket = Object.assign(new EventEmitter(), {
             writable: true,

--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -630,6 +630,13 @@ export class HerdrGraphicsBridge {
         // worthless, and it is dropped before it costs a layout probe, a base64
         // decode, or a compression -- but a second image elsewhere in the pane
         // is not a repaint of this one, and survives.
+        //
+        // Only here. Once a frame has been selected and paid for, it is carried
+        // to the phone: re-checking after the probe, the decode and the rect
+        // discarded every completed frame while a producer kept painting, so a
+        // scrolling browser delivered nothing until the gesture stopped. The
+        // drain is serial, so a delivered frame is never overtaken by an older
+        // one, and the repaints queued behind this one still coalesce here.
         if (this.superseded(key)) return;
         const paneId = await this.sourcePane(cursorAt(block));
         if (paneId === undefined) {
@@ -638,7 +645,7 @@ export class HerdrGraphicsBridge {
             await this.flushUnroutedDeferred(key);
             return;
         }
-        if (this.closed || this.superseded(key)) return;
+        if (this.closed) return;
         // A placement-only replay of an image an uppercase delete deleted --
         // byte-identical or not -- must never forward the deleted pixels: the
         // deferred entry and the id's stamp decide before any prepare or
@@ -681,9 +688,9 @@ export class HerdrGraphicsBridge {
             await this.flushDeferredFor(paneId, key);
             return;
         }
-        if (this.closed || this.superseded(key)) return;
+        if (this.closed) return;
         const rect = await this.visibleRect(paneId);
-        if (this.closed || this.superseded(key)) return;
+        if (this.closed) return;
         const surface = surfaceOf(block, rect);
         const live = this.placementsFor(paneId);
         const previous = live.get(key);


### PR DESCRIPTION
## Problem

`forwardInlineBlock` re-checked supersession three times after starting work — after the layout probe, after the decode, and after the rect. A producer repainting faster than one frame can be prepared always has a newer block queued by the time those checks run, so **every completed frame was discarded at the moment it became ready**. The pane prepares continuously and delivers nothing until the producer stops.

For a program that repaints while being scrolled, that means the image only moves once the gesture ends.

## After

The check before the work stays, and it is what coalesces: a repaint queued behind this one is still dropped before it costs a probe, a decode or a compression. What changes is that a frame already selected and paid for is carried through to the phone.

The drain is serial, so a delivered frame is never overtaken by an older one. The deferred-delete and replay guards are untouched — this only removes checks that discard finished work.

## Red / green

The existing flow test now reproduces the starvation deterministically: a repaint arrives while the layout probe is still open, which is what a repainting producer does. It measures what the phone was shown **while the producer was still painting** — counting at the end hides the defect, because the last repaint finds an empty queue and always ships.

Before, five frames prepared and none delivered:

```
× delivers a frame while a producer keeps repainting the same surface
  → expected 0 to be greater than 0
```

After: 5/5 in the file, **48 tests across `apps/host/src/agent/infrastructure/` pass**, `tsc --build apps/host` exit 0.

Each removed check is load-bearing — restoring only the post-rect one fails the test again:

```
× delivers a frame while a producer keeps repainting the same surface
  → expected 0 to be greater than 0
```

## Scope and what is not claimed

Two files: the bridge and its existing flow test. No new test file.

**This is not claimed to fix anything on a device.** The proof is a deterministic reproduction in the bridge's own flow; no build was installed and no device behaviour was observed. Host-side counters cannot establish a client freeze either.

Worth knowing for whoever tests it: the host currently running is `9fa34265`, not `main`. `superseded()` is byte-identical there and the same three sites are present at `:631, :639, :682, :684`, so the defect exists in the installed host — but `forwardInlineBlock` otherwise differs, because `main` carries the replay and delete fixes from `09c1f405` that the installed host does not.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCASatKCB1og812nz5x83V
