### PR TITLE
fix(graphics): report the pane's surface, not one frame's, to the phone

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
@@ -574,9 +574,31 @@ describe('Herdr graphics flow', () => {
         await settle();
         expect(frames).toHaveLength(2);
         expect(frames[0]).toMatchObject({ graphics: true, graphicsSurface: 'full' });
-        expect(frames[1]).toMatchObject({ graphics: true, graphicsSurface: 'inline' });
+        // The small image is drawn at its own size, but the pane still owns the
+        // full surface, so that is what the phone is told. Reporting this one
+        // frame's surface ended the phone's graphics scroll ownership while a
+        // pane-filling image was still resident -- the same question the delete
+        // path below already answers with survivingSurface.
+        expect(frames[1]).toMatchObject({ graphics: true, graphicsSurface: 'full' });
         // Neither frame may clear the whole pane, or the other image is erased.
         expect(frames.every((frame) => !Buffer.from(frame.bytes, 'base64').toString('utf8').includes('a=d,d=A'))).toBe(true);
+
+        // A phone joining while both are live is replayed both placements, and
+        // every replayed frame must report the pane's surface, not the size of
+        // whichever placement happens to be replayed last.
+        const rejoined: { graphicsSurface?: string }[] = [];
+        bridge.register({
+            channel: 'rejoined',
+            paneId: 'pane',
+            cols: 20,
+            rows: 10,
+            cellWidthPx: 10,
+            cellHeightPx: 20,
+            write: (frame) => rejoined.push(JSON.parse(frame) as { graphicsSurface?: string }),
+        });
+        expect(rejoined).toHaveLength(2);
+        expect(rejoined.every((frame) => frame.graphicsSurface === 'full')).toBe(true);
+        bridge.unregister('rejoined');
 
         // A repaint of the full surface arrives twice before either is prepared:
         // the older one is dropped, and the small image is untouched.
@@ -715,7 +737,9 @@ console.log(JSON.stringify({ result: replies[command] }));
             send(image(1));
             expect(JSON.parse(await nextFrame())).toMatchObject({ graphics: true, graphicsSurface: 'full' });
             send(image(2, 8, 3, 4, 2));
-            expect(JSON.parse(await nextFrame())).toMatchObject({ graphics: true, graphicsSurface: 'inline' });
+            // Placed beside a live pane-filling image: the pane's surface, not
+            // this block's.
+            expect(JSON.parse(await nextFrame())).toMatchObject({ graphics: true, graphicsSurface: 'full' });
 
             // Direct graphics replaces the full image without stealing the
             // neighboring image's id. A channel handoff must replay both.

--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -257,13 +257,20 @@ export class HerdrGraphicsBridge {
         const live = this.livePlacements.get(registration.paneId);
         const latest = this.latestByPane.get(registration.paneId);
         if (live !== undefined && live.size > 0) {
+            // Geometry is per placement; takeover metadata is the pane's. Each
+            // replayed frame is drawn at its own placement's size, but every
+            // one of them reports what the pane as a whole owns -- otherwise a
+            // small placement replayed last tells the phone the surface is
+            // inline while a full one is still resident, and the phone hands
+            // back scroll ownership on arrival.
+            const paneSurface = this.survivingSurface(registration.paneId);
             for (const placement of live.values()) {
                 registration.write(terminalFrame(
                     encodeKitty(placement.image, registration, 'none', placement.block, placement.rect, placement.surface),
                     registration,
                     true,
                     undefined,
-                    placement.surface,
+                    paneSurface,
                 ));
             }
             // A direct successor owns the pane's presented surface without
@@ -701,10 +708,17 @@ export class HerdrGraphicsBridge {
         }
         this.inlinePlaced.set(`${paneId}:${key}`, identity);
         if (surface === 'full') this.latestByPane.set(paneId, image);
+        // The same split the delete path already makes: this block's own
+        // surface decides how it is drawn, the pane's surviving surface is
+        // what the phone is told. A placement key carries the covered extent,
+        // so a repaint at a different size is a new placement beside the old
+        // one rather than a replacement -- and reporting that one frame's
+        // surface ended the phone's takeover while a full image was still live.
+        const paneSurface = this.survivingSurface(paneId);
         for (const registration of this.registrations.values()) {
             if (registration.paneId !== paneId) continue;
             const bytes = encodeKitty(image, registration, replaced(previous, image), block, rect, surface);
-            const frame = terminalFrame(bytes, registration, true, undefined, surface);
+            const frame = terminalFrame(bytes, registration, true, undefined, paneSurface);
             registration.write(frame);
             this.recordFrame(at, frame.length, image.width * image.height);
         }


### PR DESCRIPTION
## Problem

`forwardInlineBlock`'s **placement** path and `register()`'s **replay** derived a frame's `graphicsSurface` from a single block's geometry, while the **delete** path in the same function already derived it from `survivingSurface(paneId)`.

`placementKey` is `row:col:c:r`, so the covered extent is part of the key: a repaint at a different size becomes a **new placement beside the old one**, not a replacement. The small one then reported `inline` while a pane-filling image was still resident.

The client treats an explicit `inline` as authoritative — `OpenTerminal.ts:153` takes `surface ?? graphicsSurface` (a frame that omits the field keeps the sticky value; one that sets it replaces it) and `TerminalView.tsx:313` computes `active && surface !== 'inline'`. So one small frame handed graphics scroll ownership back while the pane still owned a full surface, and it stayed back until a later frame said `full`.

## After

Both sites report the pane's surviving surface. Per-placement geometry is untouched: `encodeKitty` still receives the block's own surface, which is what selects a bounded placement over a pane-filling one — single-frame geometry and aggregate pane state stay distinct.

Every other surface-bearing emission was audited and was already pane-level equivalent: the direct `a=p` re-placement, the direct `forward()` frame, and `register()`'s two latest-only writes all run with `latestByPane` set, where `survivingSurface` is `'full'`; the clear paths (`emitPaneClear`, the reason-carrying clear) pass no surface at all.

## Evidence

Red — reverting the **placement** hunk alone, keeping the tests:

```
× keeps two program images, coalesces repaints, and paces a gesture
× delivers a queued repaint atomically and honors the final image delete
  → expected { type: 'terminal.frame', …(8) } to match object { graphics: true, …(1) }
Tests  2 failed | 3 passed (5)
```

Red — reverting the **replay** hunk alone:

```
× keeps two program images, coalesces repaints, and paces a gesture
  → expected false to be true
Tests  1 failed | 4 passed (5)
```

Green:

```
apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts   5 passed
apps/host/src/agent/infrastructure/                              8 files, 48 tests passed
tsc --build apps/host                                            exit 0
checkArchitecture                                                135 files clean
```

No new test file. The existing flow gained a rejoin check that a phone registering while a full and an inline placement are both live is replayed both, with every replayed frame reporting `full`; two assertions that encoded the old frame-level answer were flipped, and the surrounding delete assertions (`full` while the pane-filling image survives, `inline` once only the small one remains) are unchanged and still pass.

## Not claimed

A source invariant only. No device measurement is attributed to it — in particular the 420-gestures/60 s net-displacement figure is not offered as causal proof, since the viewport changed during that run. No deployment; the live host was not restarted.