### PR TITLE
fix(code): count an untracked file's lines as the additions they are

### DIFF
--- a/plugins/code/changes.mjs
+++ b/plugins/code/changes.mjs
@@ -80,8 +80,28 @@ function files() {
         return { path: path.join('\t'), added, deleted, kind: scope };
     });
     const untracked = scope === 'working' ? git(['ls-files', '--others', '--exclude-standard', '-z'], root).split('\0').filter(Boolean)
-        .map((path) => ({ path, added: '', deleted: '', kind: 'untracked' })) : [];
+        .map((path) => ({ path, ...untrackedStat(join(root, path)), kind: 'untracked' })) : [];
     return [...tracked, ...untracked];
+}
+
+/**
+ * A new file is entirely added lines, so counting none of them reports a
+ * working tree of untracked files as no change at all. Git counts the same
+ * lines for an intent-to-add file, without us having to touch the index.
+ */
+function untrackedStat(absolute) {
+    try {
+        const stat = lstatSync(absolute);
+        if (!stat.isFile() || stat.size > 1024 * 1024) return { added: '-', deleted: '-' };
+        const content = readFileSync(absolute);
+        if (content.includes(0)) return { added: '-', deleted: '-' };
+        let added = 0;
+        for (let index = content.indexOf(10); index !== -1; index = content.indexOf(10, index + 1)) added++;
+        if (content.length > 0 && content[content.length - 1] !== 10) added++;
+        return { added: String(added), deleted: '0' };
+    } catch {
+        return { added: '-', deleted: '-' };
+    }
 }
 const params = (extra = {}) => ({ sessionId, root, scope, ...extra });
 function workingFileAction(file) {
@@ -131,16 +151,14 @@ if (method === 'worktrees') {
         if (/^\d+$/.test(file.deleted)) deletedLines += Number(file.deleted);
     }
     const summary = unavailable ? [] : [
-        { label: 'Tracked lines added', value: `+${addedLines.toLocaleString('en-US')}`, tone: 'positive' },
-        { label: 'Tracked lines removed', value: `−${deletedLines.toLocaleString('en-US')}`, tone: 'danger' },
+        { label: 'Lines added', value: `+${addedLines.toLocaleString('en-US')}`, tone: 'positive' },
+        { label: 'Lines removed', value: `−${deletedLines.toLocaleString('en-US')}`, tone: 'danger' },
     ];
     const pageCount = Math.max(1, Math.ceil(changed.length / 49));
     const requestedPage = typeof input.page === 'number' || (typeof input.page === 'string' && /^\d+$/.test(input.page)) ? Number(input.page) : 0;
     const page = method === 'browse' && Number.isSafeInteger(requestedPage) ? Math.max(0, Math.min(pageCount - 1, requestedPage)) : 0;
     const rows = changed.slice(page * 49, (page + 1) * 49).map((file) => {
-        let count = `+${file.added} / −${file.deleted}`;
-        if (file.kind === 'untracked') count = 'Untracked';
-        else if (file.added === '-') count = 'Binary';
+        const count = file.added === '-' ? 'Binary' : `+${file.added} / −${file.deleted}`;
         return { ...file, title: basename(file.path), subtitle: `${file.path} · ${count}`, sessionId, root, scope, head, base };
     });
     const scopeNotes = { branch: 'Committed branch changes only; working edits are separate.', staged: 'The index that will be committed; unstaged edits are separate.', working: 'Current files compared with HEAD, including untracked files. Committed branch changes are separate.' };


### PR DESCRIPTION
## Problem

The Changes card counts untracked files in its file badge, but the +/− totals came only from `git diff --numstat`, which never reports untracked content. A working tree of new files therefore rendered as **`97 files`** with **`+0 −0`** — the badge and the totals were describing different populations.

Reproduced on this repo: 97 untracked files, 0 tracked changes.

## After

Untracked files carry the line counts git itself reports for an intent-to-add file, without touching the index:

- text files count their lines as additions (`+N / −0`)
- binary files, files over 1 MB, and unreadable paths report as binary rather than as zero
- the per-file row shows the real count instead of the flat `Untracked` label; the `Untracked` group heading already carries that fact
- the summary labels drop "Tracked", since they are no longer tracked-only

## Evidence

Verified against git on this repo, both scopes.

Working tree — 97 untracked files, 0 tracked changes:

```
badge:   97 files
summary: Lines added +11,289 · Lines removed −0
.playwright-mcp/console-…-835Z.log · +14 / −0     git diff --no-index --numstat → 14
.playwright-mcp/console-…-767Z.log · +116 / −0    git → 116
.playwright-mcp/console-…-545Z.log · +8 / −0      git → 8
.playwright-mcp/ios-parity-spec-210px.png · Binary
```

Branch scope — tracked path unchanged:

```
badge:   18 files
summary: Lines added +322 · Lines removed −152
git diff --numstat <merge-base> HEAD → 18 files +322 -152
```

Counting all 97 files costs 48 ms, no subprocess per file.

## Tests

None added, per AGENTS.md. The counter is a line count verified against git's own numstat on 97 real files across both scopes.