### PR TITLE
fix(graphics): delete the image a pane displaces at its placement limit

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
@@ -517,6 +517,71 @@ describe('Herdr graphics flow', () => {
         expect(deliveredDuringBurst).toBeGreaterThan(0);
     });
 
+    it('deletes the image it displaces when a pane exceeds its placement limit', async () => {
+        const socket = Object.assign(new EventEmitter(), { writable: true, write: () => true, destroy: () => {} });
+        const bridge = Reflect.construct(HerdrGraphicsBridge, [socket, 'herdr']) as HerdrGraphicsBridge;
+        const internals = bridge as unknown as {
+            sourcePane: (leading: Buffer) => Promise<string | undefined>;
+            visibleRect: (paneId: string) => Promise<{ x: number; y: number; width: number; height: number } | undefined>;
+            queueInline: (data: Buffer) => void;
+            drainInline: () => Promise<void>;
+            inlineQueue: unknown[];
+            inlineDraining: boolean;
+        };
+        internals.sourcePane = async () => 'pane';
+        internals.visibleRect = async () => ({ x: 0, y: 0, width: 20, height: 10 });
+
+        const frames: string[] = [];
+        bridge.register({
+            channel: 'phone', paneId: 'pane', cols: 20, rows: 10, cellWidthPx: 10, cellHeightPx: 20,
+            write: (frame) => frames.push(frame),
+        });
+
+        const pixels = Buffer.alloc(2 * 2 * 4, 3).toString('base64');
+        // Distinct cells, so each is its own surface rather than a repaint.
+        const small = (id: number): Buffer => Buffer.from(
+            `\u001b[${id};1H`
+            + `\u001b_Ga=t,f=32,s=2,v=2,i=${id},m=0;${pixels}\u001b\\`
+            + `\u001b_Ga=p,i=${id},c=2,r=1;\u001b\\`,
+        );
+        const drain = vi.spyOn(internals, 'drainInline');
+        const settle = async (): Promise<void> => {
+            await drain.mock.results.at(-1)?.value;
+            expect(internals.inlineQueue).toHaveLength(0);
+            expect(internals.inlineDraining).toBe(false);
+        };
+
+        // Sixteen fit. The seventeenth displaces the first, and the phone is
+        // owed a delete for it: a placement dropped silently leaves resident
+        // pixels this host no longer tracks, and the terminal has to reclaim
+        // them itself on the next transmission.
+        for (let id = 1; id <= 16; id += 1) {
+            internals.queueInline(small(id));
+            await settle();
+        }
+        expect(frames).toHaveLength(16);
+        expect(frames.every((frame) => !frameAnsi(frame).includes('a=d,'))).toBe(true);
+
+        internals.queueInline(small(17));
+        await settle();
+        expect(frames).toHaveLength(18);
+        const evicted = frameAnsi(frames[16]!);
+        expect(evicted).toContain('a=d,d=I,i=1,');
+        expect(evicted).not.toContain('a=d,d=A');
+        // The delete lands before the frame that displaced it, and names only
+        // that image.
+        expect(frameAnsi(frames[17]!)).toContain('a=T,f=32,s=2,v=2,i=17');
+        expect(frameAnsi(frames[17]!)).not.toContain('a=d,d=I,i=1,');
+
+        // The displaced surface is forgotten, not merely dropped: an identical
+        // placement of it later is a real frame again, never suppressed as
+        // already placed.
+        internals.queueInline(small(1));
+        await settle();
+        expect(frames).toHaveLength(20);
+        expect(frameAnsi(frames.at(-1)!)).toContain('a=T,f=32,s=2,v=2,i=1');
+    });
+
     it('keeps two program images, coalesces repaints, and paces a gesture', async () => {
         const socket = Object.assign(new EventEmitter(), {
             writable: true,

--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -702,10 +702,7 @@ export class HerdrGraphicsBridge {
         const live = this.placementsFor(paneId);
         const previous = live.get(key);
         live.set(key, { image, block, surface, ...(rect === undefined ? {} : { rect }) });
-        if (live.size > MAX_LIVE_PLACEMENTS) {
-            const oldest = live.keys().next().value;
-            if (oldest !== undefined && oldest !== key) live.delete(oldest);
-        }
+        const displaced = this.displaceOldestPlacement(paneId, live, key);
         this.inlinePlaced.set(`${paneId}:${key}`, identity);
         if (surface === 'full') this.latestByPane.set(paneId, image);
         // The same split the delete path already makes: this block's own
@@ -715,8 +712,16 @@ export class HerdrGraphicsBridge {
         // one rather than a replacement -- and reporting that one frame's
         // surface ended the phone's takeover while a full image was still live.
         const paneSurface = this.survivingSurface(paneId);
+        const displacedDelete = displaced === undefined
+            ? undefined
+            : Buffer.from(`\u001b_Ga=d,d=I,i=${displaced.imageId},q=2;\u001b\\`);
         for (const registration of this.registrations.values()) {
             if (registration.paneId !== paneId) continue;
+            // The displaced image leaves before its successor arrives, so the
+            // phone never holds pixels this pane has stopped tracking.
+            if (displacedDelete !== undefined) {
+                registration.write(terminalFrame(wrapAtOrigin(displacedDelete), registration, true, undefined, paneSurface));
+            }
             const bytes = encodeKitty(image, registration, replaced(previous, image), block, rect, surface);
             const frame = terminalFrame(bytes, registration, true, undefined, paneSurface);
             registration.write(frame);
@@ -726,6 +731,37 @@ export class HerdrGraphicsBridge {
         // A frame is the honest acknowledgement that this pane kept up, so the
         // next notch of the gesture goes out now and no faster.
         this.drainNotch(paneId);
+    }
+
+    /**
+     * A pane may keep only so many images on the phone at once, and displacing
+     * the oldest is a real delete rather than a bookkeeping drop. Forgetting it
+     * silently left the phone showing pixels this host no longer tracked, and
+     * left the embedded terminal to reclaim them itself on the next
+     * transmission -- its image storage is 10MB there against a full-size frame
+     * of nearly that, so the eviction was neither rare nor free. Forget it the
+     * way an executed delete does: the placement, its placed identity, and the
+     * pane's presented image if this was it.
+     *
+     * Returns the image the caller owes the phone a delete for, or nothing when
+     * the pane is under its limit or the id is still carried by a surviving
+     * placement -- deleting that would erase the frame being sent.
+     */
+    private displaceOldestPlacement(
+        paneId: string,
+        live: Map<string, LivePlacement>,
+        keep: string,
+    ): PreparedImage | undefined {
+        if (live.size <= MAX_LIVE_PLACEMENTS) return undefined;
+        const oldest = live.keys().next().value;
+        if (oldest === undefined || oldest === keep) return undefined;
+        const placement = live.get(oldest);
+        live.delete(oldest);
+        this.inlinePlaced.delete(`${paneId}:${oldest}`);
+        if (placement === undefined) return undefined;
+        if (this.latestByPane.get(paneId) === placement.image) this.latestByPane.delete(paneId);
+        const stillPlaced = [...live.values()].some((item) => item.image.imageId === placement.image.imageId);
+        return stillPlaced ? undefined : placement.image;
     }
 
     private placementsFor(paneId: string): Map<string, LivePlacement> {


### PR DESCRIPTION
## Problem

Past `MAX_LIVE_PLACEMENTS` the oldest placement was dropped with a bare `live.delete(oldest)`. Three consequences in three lines:

- **no Kitty delete reached the phone**, so it kept showing pixels this host no longer tracked — and the embedded terminal had to reclaim them itself on the next transmission, which is the eviction path measured to leak a tracked pin per eviction at the pinned ghostty `b0947378`;
- **`inlinePlaced` kept a stale entry**, so a later identical placement of that surface was suppressed as already-placed although it was gone;
- **`latestByPane` could still name the dropped image**.

`forgetPlacements` already does all three correctly for an explicit delete.

## After

`displaceOldestPlacement` forgets it the way an executed delete does — the placement, its placed identity, and the pane's presented image if this was it — and returns the image the phone is owed a delete for. That delete is written inside the existing registrations loop, **before** the frame that displaced it, with the byte shape the delete path already uses, uppercase `d=I` so the resident bytes are reclaimed rather than hidden.

Two ordering details are load-bearing: the drop happens **before** `survivingSurface` is computed, so the reported pane surface already reflects it; and an id still carried by a surviving placement is never deleted, since `d=I` would erase the frame being sent.

## Evidence

**Red** — reverting the source, keeping the test:

```
× deletes the image it displaces when a pane exceeds its placement limit
  → expected [ …(17) ] to have a length of 18 but got 17
Tests  1 failed | 5 passed (6)
```

The other five flows pass unchanged on main, so nothing existing was re-specified.

**Green**:

```
herdrGraphicsBridge.test.ts                        6 passed
apps/host/src/agent/infrastructure/                8 files, 49 tests passed
tsc --build apps/host                              exit 0
checkArchitecture                                  135 files clean
```

**Device-side, measured rather than assumed.** Driving the real bridge with 20 distinct surfaces carrying real captured frames (2074×1178, 9.77 MB RGBA each), then replaying exactly what it emitted through libghostty-vt built from the pinned ghostty `b0947378349eff70f7030dda0e6d022fae1e6fbd` under `DebugAllocator(.{ .safety = true })`:

```
emission            main: 200 frames,   0 deletes      this: 384 frames, 184 deletes
replay @ 320MB      main: images=32 placements=32 total_bytes=312,726,016 tracked_pins=202
                    this: images=16 placements=16 total_bytes=156,363,008 tracked_pins=18
replay @ 10MB       main: tracked_pins=202            this: tracked_pins=201
```

At a limit that can hold more than one frame the fix halves resident storage — keeping the terminal in step with the host's own 16-placement bound instead of letting it drift to double that and sit at 98% of the cap — and cuts leaked tracked pins from 202 to 18.

## What it does not do

**At the 10 MB limit libghostty-vt actually ships it changes nothing** (202 → 201). `Terminal.Options.kitty_image_storage_limit` is `320 * 1000 * 1000` for `.ghostty` but `10 * 1000 * 1000` for `.lib`, and a single full-size frame is 9.77 MB, so every transmission evicts its predecessor before our delete for a 16-frames-old image can matter. There the limit dominates and the answer is fewer bytes per frame, not better deletes. No `ENOMEM` occurred in either arm of this stream, so no claim is made about stopping it.

This is not offered as a fix for the vc259 SIGSEGV, which remains unexplained. What it fixes is one of the mechanisms that forces eviction — the only path we have to the leak in the pinned terminal.