### PR TITLE
fix(graphics): keep one resident full image per pane

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
@@ -517,6 +517,66 @@ describe('Herdr graphics flow', () => {
         expect(deliveredDuringBurst).toBeGreaterThan(0);
     });
 
+    it('keeps one resident full image per pane while an inline neighbour survives', async () => {
+        const socket = Object.assign(new EventEmitter(), { writable: true, write: () => true, destroy: () => {} });
+        const bridge = Reflect.construct(HerdrGraphicsBridge, [socket, 'herdr']) as HerdrGraphicsBridge;
+        const internals = bridge as unknown as {
+            sourcePane: (leading: Buffer) => Promise<string | undefined>;
+            visibleRect: (paneId: string) => Promise<{ x: number; y: number; width: number; height: number } | undefined>;
+            queueInline: (data: Buffer) => void;
+            drainInline: () => Promise<void>;
+            inlineQueue: unknown[];
+            inlineDraining: boolean;
+            livePlacements: Map<string, Map<string, { image: { imageId: number } }>>;
+        };
+        internals.sourcePane = async () => 'pane';
+        internals.visibleRect = async () => ({ x: 0, y: 0, width: 20, height: 10 });
+
+        const frames: string[] = [];
+        bridge.register({
+            channel: 'phone', paneId: 'pane', cols: 20, rows: 10, cellWidthPx: 10, cellHeightPx: 20,
+            write: (frame) => frames.push(frame),
+        });
+
+        const pixels = Buffer.alloc(2 * 2 * 4, 5).toString('base64');
+        const image = (id: number, row: number, col: number, cols: number, rows: number): Buffer => Buffer.from(
+            `\u001b[${row};${col}H`
+            + `\u001b_Ga=t,f=32,s=2,v=2,i=${id},m=0;${pixels}\u001b\\`
+            + `\u001b_Ga=p,i=${id},c=${cols},r=${rows};\u001b\\`,
+        );
+        const drain = vi.spyOn(internals, 'drainInline');
+        const settle = async (): Promise<void> => {
+            await drain.mock.results.at(-1)?.value;
+            expect(internals.inlineQueue).toHaveLength(0);
+            expect(internals.inlineDraining).toBe(false);
+        };
+
+        // A pane-filling image, then a small one beside it.
+        internals.queueInline(image(1, 1, 1, 20, 10));
+        await settle();
+        internals.queueInline(image(2, 8, 3, 4, 2));
+        await settle();
+        expect(frames).toHaveLength(2);
+        expect(frames.every((frame) => !frameAnsi(frame).includes('a=d,'))).toBe(true);
+
+        // A repaint clipped to a different extent is a different placement key,
+        // so `replaced` sees no predecessor and would leave the first image
+        // resident forever. The pane may hold exactly one full image, so this
+        // frame clears it -- ahead of its own pixels, in the same frame.
+        internals.queueInline(image(3, 1, 1, 19, 9));
+        await settle();
+        expect(frames).toHaveLength(3);
+        const repaint = frameAnsi(frames[2]!);
+        expect(repaint).toContain('a=d,d=I,i=1,');
+        expect(repaint).toContain('a=T,f=32,s=2,v=2,i=3');
+        expect(repaint.indexOf('a=d,d=I,i=1,')).toBeLessThan(repaint.indexOf('a=T,f=32,s=2,v=2,i=3'));
+        // The inline neighbour is a separate, legitimate placement.
+        expect(repaint).not.toContain('a=d,d=I,i=2,');
+        expect(repaint).not.toContain('a=d,d=A');
+        const live = internals.livePlacements.get('pane')!;
+        expect([...live.values()].map((placement) => placement.image.imageId).sort()).toEqual([2, 3]);
+    });
+
     it('deletes the image it displaces when a pane exceeds its placement limit', async () => {
         const socket = Object.assign(new EventEmitter(), { writable: true, write: () => true, destroy: () => {} });
         const bridge = Reflect.construct(HerdrGraphicsBridge, [socket, 'herdr']) as HerdrGraphicsBridge;

--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -704,6 +704,7 @@ export class HerdrGraphicsBridge {
         live.set(key, { image, block, surface, ...(rect === undefined ? {} : { rect }) });
         const displaced = this.displaceOldestPlacement(paneId, live, key);
         this.inlinePlaced.set(`${paneId}:${key}`, identity);
+        const supersededFull = surface === 'full' ? this.supersedeFullImage(paneId, image) : undefined;
         if (surface === 'full') this.latestByPane.set(paneId, image);
         // The same split the delete path already makes: this block's own
         // surface decides how it is drawn, the pane's surviving surface is
@@ -712,17 +713,28 @@ export class HerdrGraphicsBridge {
         // one rather than a replacement -- and reporting that one frame's
         // surface ended the phone's takeover while a full image was still live.
         const paneSurface = this.survivingSurface(paneId);
-        const displacedDelete = displaced === undefined
-            ? undefined
-            : Buffer.from(`\u001b_Ga=d,d=I,i=${displaced.imageId},q=2;\u001b\\`);
+        // encodeKitty writes its clear ahead of the pixels, so naming the
+        // superseded full image there costs nothing. Only when this frame
+        // already clears a different id does the second delete need a frame of
+        // its own; that is the rare case, not the repaint.
+        const atomicClear = replaced(previous, image);
+        const separate: number[] = [];
+        if (displaced !== undefined) separate.push(displaced.imageId);
+        const clear = atomicClear === 'none' && supersededFull !== undefined
+            ? { imageId: supersededFull.imageId }
+            : atomicClear;
+        if (supersededFull !== undefined && clear !== 'none' && clear.imageId !== supersededFull.imageId) {
+            separate.push(supersededFull.imageId);
+        }
+        const deletes = separate.map((imageId) => wrapAtOrigin(Buffer.from(`\u001b_Ga=d,d=I,i=${imageId},q=2;\u001b\\`)));
         for (const registration of this.registrations.values()) {
             if (registration.paneId !== paneId) continue;
-            // The displaced image leaves before its successor arrives, so the
-            // phone never holds pixels this pane has stopped tracking.
-            if (displacedDelete !== undefined) {
-                registration.write(terminalFrame(wrapAtOrigin(displacedDelete), registration, true, undefined, paneSurface));
+            // Anything this frame retires leaves before its successor arrives,
+            // so the phone never holds pixels this pane has stopped tracking.
+            for (const bytes of deletes) {
+                registration.write(terminalFrame(bytes, registration, true, undefined, paneSurface));
             }
-            const bytes = encodeKitty(image, registration, replaced(previous, image), block, rect, surface);
+            const bytes = encodeKitty(image, registration, clear, block, rect, surface);
             const frame = terminalFrame(bytes, registration, true, undefined, paneSurface);
             registration.write(frame);
             this.recordFrame(at, frame.length, image.width * image.height);
@@ -762,6 +774,35 @@ export class HerdrGraphicsBridge {
         if (this.latestByPane.get(paneId) === placement.image) this.latestByPane.delete(paneId);
         const stillPlaced = [...live.values()].some((item) => item.image.imageId === placement.image.imageId);
         return stillPlaced ? undefined : placement.image;
+    }
+
+    /**
+     * One resident full image per pane.
+     *
+     * Nothing else deletes the predecessor. `replaced` only clears when the
+     * same placement key changes image id, and a placement key carries the
+     * covered extent, so a clipped image that scrolls arrives under a new key
+     * every frame and its predecessor is left resident forever. Two full frames
+     * of a phone-sized pane are ~19MB against the embedded terminal's 10MB
+     * image budget, so every transmission had to evict -- and eviction is the
+     * path that leaks a tracked pin in the pinned terminal.
+     *
+     * Scope is deliberate: full surfaces only. An inline image beside a full
+     * one is a separate, legitimate placement and keeps its pixels, and an id
+     * an inline placement still carries is never deleted -- an uppercase delete
+     * would take that placement with it.
+     */
+    private supersedeFullImage(paneId: string, image: PreparedImage): PreparedImage | undefined {
+        const prior = this.latestByPane.get(paneId);
+        if (prior === undefined || prior.imageId === image.imageId) return undefined;
+        const live = this.livePlacements.get(paneId);
+        const sharedWithInline = live !== undefined && [...live.values()]
+            .some((item) => item.image.imageId === prior.imageId && item.surface !== 'full');
+        if (sharedWithInline) return undefined;
+        for (const key of this.retireInlinePlacements(paneId, prior.imageId)) {
+            this.settleDeferredAfterFrame(paneId, key, image);
+        }
+        return prior;
     }
 
     private placementsFor(paneId: string): Map<string, LivePlacement> {


### PR DESCRIPTION
Base is `main`; #246 merged while this was in flight, so this is the follow-up it was stacked on.
## Problem — and it is exactly the diagnosis, confirmed

Nothing ever deleted a pane's previous **full** image. `replaced(previous, image)` only clears when the *same* placement key changes image id, and `placementKey` is `row:col:c:r` — the covered extent is part of the key. A clipped, scrolling pane-filling image changes extent every frame, so it arrives under a new key, `previous` is `undefined`, and the frame goes out with `clear: 'none'`.

Two full frames of a phone-sized pane are ~19 MB against libghostty-vt's **10 MB** `kitty_image_storage_limit` (`.lib` default; `.ghostty` gets 320 MB). So the embedded terminal had to evict on **every** transmission — and eviction is the path measured to leak a tracked pin at the pinned ghostty `b0947378`. That is also why #246's delete arrived sixteen placements too late to move the 10 MB number.

## Change

A full transmit supersedes the pane's previous full image: `supersedeFullImage` retires its placements the way an executed delete does, settles their deferred deletes, and returns the image. The delete rides in `encodeKitty`'s own `clear`, ahead of the pixels, so **the common case costs no extra frame**. Only when the frame already clears a different id does the second delete need a frame of its own.

Scope is the #244 invariant, deliberately: **full surfaces only**. An inline image beside a full one is a separate, legitimate placement and keeps its pixels, and an id an inline placement still carries is never deleted -- `d=I` would take that placement with it.

## Red / green

Reverting the source to #246's head, keeping the test:

```
x keeps one resident full image per pane while an inline neighbour survives
  -> expected the repaint frame to contain 'a=d,d=I,i=1,'
Tests  1 failed | 6 passed (7)
```

Green:

```
herdrGraphicsBridge.test.ts                        7 passed
apps/host/src/agent/infrastructure/                8 files, 50 tests passed
tsc --build apps/host                              exit 0
checkArchitecture                                  135 files clean
```

The flow places a full image, an inline neighbour, then a full repaint at a different extent, and asserts the repaint carries `a=d,d=I,i=1,` **before** its own `a=T`, is not a clear-all, does not delete the inline neighbour, and leaves exactly `[2, 3]` live.

## The number that decides it

Real bridge driven with real captured frames as a pane-filling image repainting at changing extents; exactly what it emitted replayed through libghostty-vt built from pinned ghostty `b0947378349e` under `DebugAllocator(.{ .safety = true })`:

```
emission            base: 200 frames, 188 deletes, 12 live placements
                    this: 200 frames, 199 deletes,  1 live placement

replay @  10MB      base: images=1  placements=1  total_bytes=9,772,688    tracked_pins=202
(shipped .lib)      this: images=1  placements=1  total_bytes=9,772,688    tracked_pins=3

replay @ 320MB      base: images=12 placements=12 total_bytes=117,272,256  tracked_pins=14
                    this: images=1  placements=1  total_bytes=9,772,688    tracked_pins=3
```

**At the 10 MB limit that actually ships, tracked pins go flat: 202 to 3, and images settle at 1.** The base holds one image there too, but only because it evicted ~200 times to get there, leaking a pin each time; this branch never makes the terminal evict at all.

The base arm is *conservative*: the harness cycles twelve extents, so keys repeat and `replaced` still fires 188 times. A genuinely scrolling image whose extent does not repeat would emit fewer deletes and hold more.

## Not claimed

- **No `ENOMEM` occurred in any of the four arms**, so nothing is claimed about stopping them.
- Eviction counts are not directly observable: `evicting image` is `log.info` and the harness runs at `.warn`. `tracked_pins` is the proxy, and it is the leak itself rather than a count of the events causing it.
- This is not offered as a fix for the vc259 SIGSEGV, which remains unexplained. It removes the mechanism that forces eviction, which is the only path we have to the leak in the pinned terminal.
