### PR TITLE
fix(graphics): halve a large frame's density before compressing it

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { deflateSync } from 'node:zlib';
+import { deflateSync, inflateSync } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HerdrGraphicsBridge, MAX_IMAGE_BYTES, decodeServerMessage, encodeKitty, mapGraphicsPointer, routeGraphicsPane } from './herdrGraphicsBridge.js';
 
@@ -515,6 +515,77 @@ describe('Herdr graphics flow', () => {
         // for as long as the producer keeps painting: a scrolling browser only
         // moves once the gesture stops.
         expect(deliveredDuringBurst).toBeGreaterThan(0);
+    });
+
+    it('halves a large frame before compressing it and still reports the producer\'s pixels', async () => {
+        const socket = Object.assign(new EventEmitter(), { writable: true, write: () => true, destroy: () => {} });
+        const bridge = Reflect.construct(HerdrGraphicsBridge, [socket, 'herdr']) as HerdrGraphicsBridge;
+        const internals = bridge as unknown as {
+            sourcePane: (leading: Buffer) => Promise<string | undefined>;
+            visibleRect: (paneId: string) => Promise<{ x: number; y: number; width: number; height: number } | undefined>;
+            queueInline: (data: Buffer) => void;
+            drainInline: () => Promise<void>;
+            inlineQueue: unknown[];
+            inlineDraining: boolean;
+        };
+        internals.sourcePane = async () => 'pane';
+        internals.visibleRect = async () => ({ x: 0, y: 0, width: 20, height: 10 });
+
+        const frames: string[] = [];
+        bridge.register({
+            channel: 'phone', paneId: 'pane', cols: 20, rows: 10, cellWidthPx: 10, cellHeightPx: 20,
+            write: (frame) => frames.push(frame),
+        });
+        const drain = vi.spyOn(internals, 'drainInline');
+        const settle = async (): Promise<void> => {
+            await drain.mock.results.at(-1)?.value;
+            expect(internals.inlineQueue).toHaveLength(0);
+            expect(internals.inlineDraining).toBe(false);
+        };
+
+        // A pane-filling frame at the producer's own density: 600x400 is past
+        // the size where compression is worth hardening, which is the same
+        // point past which the density is worth halving.
+        const width = 600;
+        const height = 400;
+        const rgba = Buffer.alloc(width * height * 4);
+        for (let i = 0; i < rgba.length; i += 4) {
+            const value = (i / 4) % 255;
+            rgba[i] = value; rgba[i + 1] = 255 - value; rgba[i + 2] = value; rgba[i + 3] = 255;
+        }
+        internals.queueInline(Buffer.from(
+            '\u001b[1;1H'
+            + `\u001b_Ga=t,f=32,s=${width},v=${height},i=9,o=z,m=0;${deflateSync(rgba).toString('base64')}\u001b\\`
+            + '\u001b_Ga=p,i=9,c=20,r=10;\u001b\\',
+        ));
+        await settle();
+        expect(frames).toHaveLength(1);
+        const ansi = frameAnsi(frames[0]!);
+
+        // Halved, and the control it writes matches the pixels it sends.
+        expect(ansi).toContain('a=T,f=32,s=300,v=200,i=9,');
+        // The payload is chunked; the image is every chunk's body joined.
+        const encoded = [...ansi.matchAll(/\u001b_G[^;]*;([^\u001b]*)\u001b\\/g)]
+            .map((match) => match[1] ?? '').join('');
+        const halved = inflateSync(Buffer.from(encoded, 'base64'));
+        expect(halved).toHaveLength(300 * 200 * 4);
+        // Cell counts are independent of pixel density, so the placement the
+        // phone is given is the one it would have had at full density.
+        expect(ansi).toContain('c=20,r=7');
+
+        // Averaged, not sampled. The first output pixel covers source pixels
+        // 0, 1, 600 and 601, whose red channels are 0, 1, 90 and 91: the mean
+        // is 46, where nearest-neighbour would have kept 0.
+        expect(halved[0]).toBe(46);
+
+        // A gesture is still reported in the producer's pixel space, never the
+        // transmitted one, or every touch would land at half its position.
+        const mapped = mapGraphicsPointer(
+            { compressed: Buffer.alloc(1), width: 300, height: 200, imageId: 9, transferId: 0n, sourceWidth: 600, sourceHeight: 400 },
+            { channel: 'phone', paneId: 'pane', cols: 20, rows: 10, cellWidthPx: 10, cellHeightPx: 20, write: () => {} },
+            { x: 100, y: 100, width: 200, height: 200, phase: 'move' },
+        );
+        expect(mapped).toEqual({ x: 300, y: 229 });
     });
 
     it('keeps one resident full image per pane while an inline neighbour survives', async () => {

--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -78,6 +78,13 @@ export type PreparedImage = {
     height: number;
     imageId: number;
     transferId: bigint;
+    /**
+     * The producer's own pixel dimensions, when the transmitted image was
+     * downscaled. Pointer reports are injected in the producer's pixel space,
+     * never the transmitted one, so they are mapped against these.
+     */
+    sourceWidth?: number;
+    sourceHeight?: number;
 };
 
 type ImageOwner = { paneId: string; imageId: number; sourceImageId: number };
@@ -1402,9 +1409,13 @@ export function mapGraphicsPointer(
     if (x < left || x > left + width || y < top || y > top + height) return undefined;
     // Injected reports bypass Herdr's desktop encoder and must match the
     // producer's SGR-pixel mode: 1-based source-image pixels.
+    // Against the producer's own pixels: a transmitted image that was halved
+    // would otherwise report every gesture at half the position it happened.
+    const sourceWidth = image.sourceWidth ?? image.width;
+    const sourceHeight = image.sourceHeight ?? image.height;
     return {
-        x: Math.max(1, Math.min(image.width, Math.round((x - left) / width * image.width))),
-        y: Math.max(1, Math.min(image.height, Math.round((y - top) / height * image.height))),
+        x: Math.max(1, Math.min(sourceWidth, Math.round((x - left) / width * sourceWidth))),
+        y: Math.max(1, Math.min(sourceHeight, Math.round((y - top) / height * sourceHeight))),
     };
 }
 
@@ -1574,10 +1585,56 @@ async function prepareKitty(rgba: Buffer, control: string, imageId: number, tran
         || width * height * 4 !== rgba.length) {
         throw new Error('invalid Herdr graphics control');
     }
+    // The producer renders at the desktop's device pixel ratio -- 411 CSS px
+    // arrive as 2055 -- which no phone panel resolves. Halving before the
+    // deflate is the whole saving: a quarter of the bytes to compress, to
+    // encrypt, and to hold. Kitty c/r are cell counts and graphicsPlacement
+    // refits by aspect ratio, so the placement is unchanged; only the density
+    // is. Small images are left exact: an icon beside a plot has no density to
+    // spare, and halving it would only blur it.
+    const scaled = rgba.length > COMPRESS_HARDER_BYTES ? halveRgba(rgba, width, height) : undefined;
+    const pixels = scaled?.rgba ?? rgba;
     // Every byte of this frame is decrypted in JavaScript on the phone, so a
     // large image is worth real compression; a small one is not worth the wait.
-    const level = rgba.length > COMPRESS_HARDER_BYTES ? 6 : 1;
-    return { compressed: await compress(rgba, { level }), width, height, imageId, transferId };
+    const level = pixels.length > COMPRESS_HARDER_BYTES ? 6 : 1;
+    return {
+        compressed: await compress(pixels, { level }),
+        width: scaled?.width ?? width,
+        height: scaled?.height ?? height,
+        imageId,
+        transferId,
+        ...(scaled === undefined ? {} : { sourceWidth: width, sourceHeight: height }),
+    };
+}
+
+/**
+ * Box-filtered halving: each output pixel is the average of the 2x2 block it
+ * covers. Nearest-neighbour would be cheaper, but this is a page of text and
+ * dropping every other row of a glyph stem is exactly the aliasing a reader
+ * sees. An odd final column or row has only one source pixel to average, so it
+ * is carried through as itself rather than read past the end of the buffer.
+ */
+function halveRgba(rgba: Buffer, width: number, height: number): { rgba: Buffer; width: number; height: number } {
+    const outWidth = Math.ceil(width / 2);
+    const outHeight = Math.ceil(height / 2);
+    const out = Buffer.allocUnsafe(outWidth * outHeight * 4);
+    for (let y = 0; y < outHeight; y += 1) {
+        const y0 = y * 2;
+        const y1 = y0 + 1 < height ? y0 + 1 : y0;
+        for (let x = 0; x < outWidth; x += 1) {
+            const x0 = x * 2;
+            const x1 = x0 + 1 < width ? x0 + 1 : x0;
+            const a = (y0 * width + x0) * 4;
+            const b = (y0 * width + x1) * 4;
+            const c = (y1 * width + x0) * 4;
+            const d = (y1 * width + x1) * 4;
+            const at = (y * outWidth + x) * 4;
+            for (let channel = 0; channel < 4; channel += 1) {
+                out[at + channel] = (rgba[a + channel]! + rgba[b + channel]! + rgba[c + channel]! + rgba[d + channel]! + 2) >> 2;
+            }
+        }
+    }
+    return { rgba: out, width: outWidth, height: outHeight };
 }
 
 /** Bounded sample window: an account of the recent past, never a history. */


### PR DESCRIPTION
Follows #247, which merged while this was in flight, so it is rebased onto main and the diff is only this change.

## Change

The producer renders at the desktop's device pixel ratio — 411 CSS px arrive as 2055 — a density no phone panel resolves. `prepareKitty` now box-filters a large frame 2:1 before the deflate: **9,772,688 bytes of RGBA become 2,443,172**.

- **Placement is unchanged.** Kitty `c`/`r` are cell counts and `graphicsPlacement` refits by aspect ratio, which a 2x halving preserves. Only the density changes.
- **The control matches the pixels.** `s`/`v` come from the transmitted dimensions; `prepareKitty`'s `width * height * 4 === rgba.length` check still runs against the producer's own control, before any scaling.
- **Odd dimensions are explicit.** Output is `ceil(w/2) x ceil(h/2)`; a final odd column or row has one source pixel to average and is carried through as itself rather than read past the end of the buffer.
- **Box filter, not nearest.** Each output pixel is the mean of its 2x2 block, `(a+b+c+d+2) >> 2`. This is a page of text; dropping every other row of a glyph stem is exactly the aliasing a reader notices.
- **Pointer reports do not follow the transmission.** They are injected in the producer's pixel space, so `PreparedImage` gained `sourceWidth`/`sourceHeight` and `mapGraphicsPointer` maps against those. Without this every touch would land at half the position it happened — the one real hazard in this change.
- **Small images are left exact.** An icon or legend beside a plot has no density to spare. The same `COMPRESS_HARDER_BYTES` threshold that already means "large enough to compress hard" decides this. Say the word if you would rather it were unconditional.

## Bytes and time, over 40 real captured frames

```
rgba per frame       9,772,688 -> 2,443,172
compressed p50         195,830 ->    72,530
compressed p95         289,969 ->    82,197
compressed max         304,047 ->    83,820
compressed mean        177,576 ->    65,448   (36.9% of before)

deflate ms/frame          24.9 ->       7.3   (29.3% of before)
halving ms/frame                         7.0
preparation ms/frame      24.9 ->      14.3   (57.5% of before)
```

Deflate does get cheaper, by the 4x you would expect from a 4x smaller input. The halving itself is not free — 7.0 ms of JS per frame — so the honest figure for the whole preparation step is **24.9 ms to 14.3 ms**, not 24.9 to 7.3.

## Replayed through the pinned terminal

Real bridge, real captured frames, replayed through libghostty-vt built from pinned ghostty `b0947378349e` under `DebugAllocator(.{ .safety = true })`, at the **10 MB `.lib` cap**:

```
pane-filling repaint at changing extents (#247's case, the real one)
    with this change: images=1  placements=1  total_bytes=2,443,172  tracked_pins=3

pane placing 20 distinct images (inline surfaces, which #247 deliberately does not supersede)
    before:           images=1  placements=1  total_bytes=9,772,688  tracked_pins=201
    with this change: images=4  placements=4  total_bytes=9,772,688  tracked_pins=202
```

The realistic case now sits at **24% of the cap with four frames' headroom**, so eviction is off the hot path and #247 is belt-and-braces exactly as you said.

Stated plainly: in the twenty-surface case the pin count is unchanged (201 vs 202). Four frames fit instead of one, but a pane that genuinely places up to `MAX_LIVE_PLACEMENTS` = 16 images still needs ~39 MB and still evicts. Downscaling buys headroom; it does not make eviction impossible for a pane that legitimately holds many images.

Wire bytes for the same 384-frame emission: **29,143,580 -> 10,213,787**.

## Sharpness

`~/.muxr/attachments/pane/w1FE:p2B/downscale-sharpness.png` — a real crop of the rendered page, left at full density, right halved and then nearest-doubled so both are the same size on screen. The right is slightly softer with visible stair-stepping on the underline. It is a fair worst case in two ways: the crop is the smallest text on the page, and the phone would scale the halved image smoothly rather than by pixel doubling, so the real result is better than the right half shows.

## Red / green

```
× halves a large frame before compressing it and still reports the producer's pixels
  → expected the frame to contain 'a=T,f=32,s=300,v=200,i=9,'
Tests  1 failed | 7 passed (8)
```

```
herdrGraphicsBridge.test.ts                        8 passed
apps/host/src/agent/infrastructure/                8 files, 51 tests passed
tsc --build apps/host                              exit 0
checkArchitecture                                  135 files clean
```

The flow sends a 600x400 frame, and asserts the control says `s=300,v=200`, that the joined chunk payload inflates to exactly `300 * 200 * 4`, that the placement is still `c=20,r=7`, that the first output pixel is the mean of its 2x2 block (46, where nearest-neighbour would keep 0), and that a pointer maps into the producer's 600x400 space rather than the transmitted 300x200.
