### PR TITLE
fix(graphics): let a pane trade bytes back for a sharp frame

### DIFF
--- a/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
+++ b/apps/host/src/agent/infrastructure/herdrGraphicsBridge.ts
@@ -40,6 +40,13 @@ const NOTCH_FALLBACK_MS = 100;
 const MAX_LIVE_PLACEMENTS = 16;
 /** Deflate harder once a frame is large: the phone decrypts every byte in JS. */
 const COMPRESS_HARDER_BYTES = 512 * 1024;
+/**
+ * A halved frame no longer lands one-for-one on the pane it was rendered for,
+ * so the phone scales it back up and text softens. Off costs four times the
+ * bytes and buys that sharpness back; which one reads better is a judgement
+ * about a particular screen, so it is a knob rather than a constant.
+ */
+const HALVE_LARGE_FRAMES = process.env.MUXR_GRAPHICS_HALVE !== '0';
 const compress = promisify(deflate);
 const run = promisify(execFile);
 
@@ -1592,7 +1599,8 @@ async function prepareKitty(rgba: Buffer, control: string, imageId: number, tran
     // refits by aspect ratio, so the placement is unchanged; only the density
     // is. Small images are left exact: an icon beside a plot has no density to
     // spare, and halving it would only blur it.
-    const scaled = rgba.length > COMPRESS_HARDER_BYTES ? halveRgba(rgba, width, height) : undefined;
+    const scaled = HALVE_LARGE_FRAMES && rgba.length > COMPRESS_HARDER_BYTES
+        ? halveRgba(rgba, width, height) : undefined;
     const pixels = scaled?.rgba ?? rgba;
     // Every byte of this frame is decrypted in JavaScript on the phone, so a
     // large image is worth real compression; a small one is not worth the wait.


### PR DESCRIPTION
## Problem

#248 halves a large frame before compressing it. That broke a **1:1 blit**: the producer renders at the pane's own device size (2055x1190 against a 2057x1190 pane), so before #248 each frame landed pixel-for-pixel. Now the host halves and the phone scales it back up, which is what the owner reported as **"text feels blurry"** after using it.

The static side-by-side in #248 did not show this, because it compared full against halved — not against halved-then-upscaled-by-the-phone, which is what the device actually does.

## Change

`MUXR_GRAPHICS_HALVE=0` keeps the producer's pixels. Default is unchanged, so this is opt-in.

Two arms the owner can flip between in one sitting:

| | frame | text |
|---|---|---|
| default | 2.44 MB | soft |
| `MUXR_GRAPHICS_HALVE=0` | 9.77 MB | sharp, 1:1 |

Not a revert: #248's saving is real and stays the default until the owner's phone says otherwise. #247 keeps residency at one image, so the sharp arm still fits under the 10MB `.lib` cap.

## Correctness in both states

`mapGraphicsPointer` reads `sourceWidth ?? width`, and `sourceWidth` is only set when a frame was actually scaled. With halving off it is absent and the fallback is the transmitted size, so pointer positions stay correct in both arms — that mapping was the hazard opus-verification caught in #248 and it is untouched here.

## Tests

None added. One env-gated boolean on an existing branch; the 8 existing `herdrGraphicsBridge` flow tests pass, and they cover the emission path either way.

```
Test Files  1 passed (1)
     Tests  8 passed (8)
```

tsc reports the same 18 pre-existing errors with and without this diff (stale workspace package build, unrelated file).