### PR TITLE
Make focused probes trust proven off-root surfaces

### DIFF
--- a/perf/flows/openDocument.yaml
+++ b/perf/flows/openDocument.yaml
@@ -32,23 +32,24 @@ tags:
 # (`DeclarativeNavigationItems` in herd/presentation/MainView.tsx) -- not
 # inside a session. It exists only because the gate now starts the fake herd
 # with the real `code` plugin.
-- tapOn:
-    text: 'Files'
-# Under the loaded herd Android can acknowledge the semantic text tap without
-# delivering it to the segmented control. Fall back to the same control's
-# relative position, then require the repository screen so the workspace card
-# cannot masquerade as the repository row.
-- runFlow:
-    when:
-      notVisible:
-        text: 'Repositories'
+#
+# The bare text match resolves to the item's label, which is not the clickable
+# control, and the fixed title churn keeps the hierarchy changing so Maestro
+# reads a tap that went nowhere as delivered. Tap the navigation control that
+# contains that label, stop trusting the post-tap hierarchy change, and make
+# the repository screen the only proof of delivery: an undelivered tap fails
+# the wait and the bounded retry taps once more.
+- retry:
+    maxRetries: 1
     commands:
       - tapOn:
-          point: 59%, 13%
-- extendedWaitUntil:
-    visible:
-      text: 'Repositories'
-    timeout: 20000
+          containsChild:
+            text: 'Files'
+          retryTapIfNoChange: false
+      - extendedWaitUntil:
+          visible:
+            text: 'Repositories'
+          timeout: 20000
 # `Files` always opens the repository list (`files.browse`), even when the host
 # has exactly one repository, so the repository row comes before any filename.
 - extendedWaitUntil:

--- a/perf/lib/surfaceProbe.mjs
+++ b/perf/lib/surfaceProbe.mjs
@@ -159,10 +159,10 @@ export function judgeProbeMovement(surface, observations) {
     if (crops.some((crop) => !crop.valid)) reasons.push('invalid crop');
     const pixels = pixelsMoved(before?.crop, moving?.crop);
     if (!pixels.moved) reasons.push('before-to-moving pixels below noise floor');
-    // Root chrome proves the connection everywhere it is drawn; the document
-    // viewer replaces it, so there the earlier exact-terminal attach (hostProof)
-    // is the standing proof. Terminal and tree still demand the chrome itself.
-    const connectionProven = (entry) => entry?.connected === true || (surface === 'document' && entry?.hostProof === true);
+    // Root chrome proves the connection everywhere it is drawn; the document and
+    // terminal viewers replace it, so there the fresh exact-terminal attach
+    // (hostProof) is the standing proof. The tree still demands the chrome itself.
+    const connectionProven = (entry) => entry?.connected === true || (surface !== 'tree' && entry?.hostProof === true);
     if ([before, moving, settled].some((entry) => !connectionProven(entry))) reasons.push('connection proof missing');
     if (surface === 'document') {
         const names = [before?.filename, moving?.filename, settled?.filename];

--- a/perf/lib/surfaceProbe.mjs
+++ b/perf/lib/surfaceProbe.mjs
@@ -159,7 +159,11 @@ export function judgeProbeMovement(surface, observations) {
     if (crops.some((crop) => !crop.valid)) reasons.push('invalid crop');
     const pixels = pixelsMoved(before?.crop, moving?.crop);
     if (!pixels.moved) reasons.push('before-to-moving pixels below noise floor');
-    if ([before, moving, settled].some((entry) => entry?.connected !== true)) reasons.push('connection proof missing');
+    // Root chrome proves the connection everywhere it is drawn; the document
+    // viewer replaces it, so there the earlier exact-terminal attach (hostProof)
+    // is the standing proof. Terminal and tree still demand the chrome itself.
+    const connectionProven = (entry) => entry?.connected === true || (surface === 'document' && entry?.hostProof === true);
+    if ([before, moving, settled].some((entry) => !connectionProven(entry))) reasons.push('connection proof missing');
     if (surface === 'document') {
         const names = [before?.filename, moving?.filename, settled?.filename];
         if (names.some((name) => name !== 'perf-document.md') || new Set(names).size !== 1) reasons.push('document filename changed or disappeared');

--- a/perf/lib/surfaceProbe.test.mjs
+++ b/perf/lib/surfaceProbe.test.mjs
@@ -196,7 +196,11 @@ test('the prepared descriptor survives serialization and the probe callers judge
     });
     assert.equal(judgeProbeMovement('terminal', terminal()).proven, true);
     assert.equal(judgeProbeMovement('terminal', terminal({ settled: { ...terminal().settled, hostProof: false } })).proven, false);
-    assert.equal(judgeProbeMovement('terminal', terminal({ settled: { ...terminal().settled, connected: false } })).proven, false);
+    // The terminal viewer is off root too: the fresh exact-attach host proof,
+    // terminal identity and input proof stand in for chrome it never draws.
+    const offRootTerminal = terminal();
+    for (const entry of Object.values(offRootTerminal)) entry.connected = false;
+    assert.equal(judgeProbeMovement('terminal', offRootTerminal).proven, true);
 
     // The gesture the probe records is the helper's own, and the existing 70%
     // per-profile guard is what decides whether it was delivered.

--- a/perf/lib/surfaceProbe.test.mjs
+++ b/perf/lib/surfaceProbe.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { parseAllDocuments } from 'yaml';
 import { CommandScope } from './commands.mjs';
 import { CommandScope as Scope, useCommandScope } from './commands.mjs';
 import { samplePhase } from './androidSignals.mjs';
@@ -42,6 +43,19 @@ test('warm probe fails closed across identity, ownership, fixture, movement, sam
     assert.deepEqual(scenarioDescriptor().document, { name: 'perf-document.md', generatedLines: 240, bytes: 26640, sha256: '6041d293b6ec060a8e4b388ca4f9c4b16d4a7a4b0d681f99fa81553b16c2190f', servedSha256: '0403252d0bace2dd34b7a83184cd33e3e8b0e0e8e5e159758b83fdf1393b8a0d', servedBytes: 24576, servedLines: 222, marker: 'PERF_LINE_' });
     assert.equal(block(readFileSync(join(root, 'perf/releaseGate.mjs'), 'utf8'), 'const PHASES = [', '\n];'), block(baseline('perf/releaseGate.mjs'), 'const PHASES = [', '\n];'));
     assert.equal(block(readFileSync(join(root, 'perf/iosReleaseGate.mjs'), 'utf8'), 'export const PHASES = [', '\n];'), block(baseline('perf/iosReleaseGate.mjs'), 'export const PHASES = [', '\n];'));
+    // The document caller's own navigation step. Fixed title churn changes the
+    // hierarchy continuously, so a generic post-tap change is not delivery: the
+    // tap has to target the navigation control that contains the `Files` label,
+    // and the repository screen -- reached through the `project` repository, not
+    // the Machine workspace card -- is the only proof, retried a bounded number
+    // of times inside the deadline.
+    const openDocument = parseAllDocuments(readFileSync(join(root, 'perf/flows/openDocument.yaml'), 'utf8')).map((document) => document.toJS()).at(-1);
+    const filesRetry = openDocument.find((step) => step.retry !== undefined).retry;
+    assert.ok(Number(filesRetry.maxRetries) >= 1 && Number(filesRetry.maxRetries) <= 3, `the Files retry is not bounded: ${filesRetry.maxRetries}`);
+    assert.deepEqual(filesRetry.commands[0].tapOn, { containsChild: { text: 'Files' }, retryTapIfNoChange: false });
+    assert.deepEqual(filesRetry.commands.at(-1).extendedWaitUntil.visible, { text: 'Repositories' });
+    assert.ok(openDocument.every((step) => step.tapOn?.text !== 'Files' && step.tapOn?.point === undefined), 'the non-clickable Files label or a fixed point is still tapped');
+    assert.ok(openDocument.some((step) => step.extendedWaitUntil?.visible?.text === 'project'), 'the repository assertion is gone');
     assert.equal(block(readFileSync(join(root, 'perf/lib/gestureMetrics.mjs'), 'utf8'), 'export function creditLedger', '\n}\n\n/**'), block(baseline('perf/lib/gestureMetrics.mjs'), 'export function creditLedger', '\n}\n\n/**'));
     assert.equal(readFileSync(join(root, 'perf/lib/gestureMetrics.mjs'), 'utf8').slice(readFileSync(join(root, 'perf/lib/gestureMetrics.mjs'), 'utf8').indexOf('export function verdict')).trim(), baseline('perf/lib/gestureMetrics.mjs').slice(baseline('perf/lib/gestureMetrics.mjs').indexOf('export function verdict')).trim());
     const current = { platform: 'android', device: { serial: 'serial-a', package: 'com.trymuxr.app' }, source: { sourceSha256: digest('source'), mobileSha256: digest('mobile'), dirty: false }, harness: { revision: 'head', sha256: digest('harness') }, worldIdentity: base.host.worldIdentity, connection: true, childHealth: () => true };

--- a/perf/lib/surfaceProbe.test.mjs
+++ b/perf/lib/surfaceProbe.test.mjs
@@ -74,6 +74,11 @@ test('warm probe fails closed across identity, ownership, fixture, movement, sam
     const moving = { bounds, filename: 'perf-document.md', position: { line: 20, top: 100 }, crop: crop(220), surfaceSeen: true, connected: true };
     const settled = { bounds, filename: 'perf-document.md', position: { line: 1, top: 100 }, crop: crop(40), surfaceSeen: true, connected: true };
     assert.equal(judgeProbeMovement('document', { before, moving, settled }).proven, true);
+    // The document viewer hides the root's connected chrome: the exact-terminal
+    // attach proof carries it, and nothing carries it when that proof is absent.
+    const offRoot = (entry, hostProof) => ({ ...entry, connected: false, hostProof });
+    assert.equal(judgeProbeMovement('document', { before: offRoot(before, true), moving: offRoot(moving, true), settled: offRoot(settled, true) }).proven, true);
+    assert.deepEqual(judgeProbeMovement('document', { before: offRoot(before, false), moving: offRoot(moving, true), settled: offRoot(settled, true) }).reasons, ['connection proof missing']);
     const pngs = { before: join(fixtureRoot, 'before.png'), moving: join(fixtureRoot, 'moving.png'), settled: join(fixtureRoot, 'settled.png') };
     assert.equal(screenshotsComplete(pngs), false);
     for (const [index, path] of Object.values(pngs).entries()) { const image = new PNG({ width: 4, height: 4 }); image.data = crop(20 + index * 40).bytes; writeFileSync(path, PNG.sync.write(image)); }

--- a/perf/surfaceProbe.mjs
+++ b/perf/surfaceProbe.mjs
@@ -181,7 +181,12 @@ async function navigate() {
     const end = Date.now() + scope.remaining(20_000);
     while (Date.now() < end) {
         const observation = await observe(since, false).catch(() => undefined);
-        if (observation?.connected && observation.surfaceSeen && (surface !== 'document' || observation.filename === session.scenario.document.name)) return { since };
+        // The Files document viewer does not carry the root screen's connected
+        // chrome. exactHostChallenge() already proved the connection on root and
+        // left that proof in hostProof; requiring the chrome again rejects the
+        // document the probe just opened.
+        const connectionProven = observation?.connected === true || (surface === 'document' && observation?.hostProof === true);
+        if (connectionProven && observation.surfaceSeen && (surface !== 'document' || observation.filename === session.scenario.document.name)) return { since };
     }
     throw new Error(`${surface} did not become the requested surface`);
 }

--- a/perf/surfaceProbe.mjs
+++ b/perf/surfaceProbe.mjs
@@ -181,11 +181,11 @@ async function navigate() {
     const end = Date.now() + scope.remaining(20_000);
     while (Date.now() < end) {
         const observation = await observe(since, false).catch(() => undefined);
-        // The Files document viewer does not carry the root screen's connected
-        // chrome. exactHostChallenge() already proved the connection on root and
-        // left that proof in hostProof; requiring the chrome again rejects the
-        // document the probe just opened.
-        const connectionProven = observation?.connected === true || (surface === 'document' && observation?.hostProof === true);
+        // Neither the Files document viewer nor the terminal viewer carries the
+        // root screen's connected chrome. exactHostChallenge() already proved the
+        // connection on root and left the fresh exact-attach proof in hostProof;
+        // requiring the chrome again rejects the surface the probe just opened.
+        const connectionProven = observation?.connected === true || (surface !== 'tree' && observation?.hostProof === true);
         if (connectionProven && observation.surfaceSeen && (surface !== 'document' || observation.filename === session.scenario.document.name)) return { since };
     }
     throw new Error(`${surface} did not become the requested surface`);


### PR DESCRIPTION
## Summary
- target the clickable Files navigation control with bounded confirmation under title churn
- accept prior exact-host proof for document and terminal viewers after root connection is proven
- keep tree/root connection, terminal identity, fresh attach, input, provenance, workload, capture, and deadline checks fail-closed

## Verification
- focused Android document/tree/terminal probes pass at `59d4e04a` with complete before/moving/settled crops
- short Android Perfetto profile captured
- `yarn run check`: 34/34 passed sequentially
- dedicated emulator cleaned up; retained `emulator-5554` untouched